### PR TITLE
Camera reset bug fix

### DIFF
--- a/multi_camera/acquisition/cameras_reset.py
+++ b/multi_camera/acquisition/cameras_reset.py
@@ -36,6 +36,7 @@ def reset(all_cams=True, config="", verbose=False):
         print(f"Reset {c.DeviceSerialNumber}")
         c.DeviceReset()
 
+
 if __name__ == "__main__":
     import argparse
 
@@ -45,6 +46,4 @@ if __name__ == "__main__":
     parser.add_argument("-v", "--verbose", default=False, action="store_true", help="Control verbosity of code")
     args = parser.parse_args()
 
-    reset(all_cams=args.all_cams,
-          config=args.config,
-          verbose=args.verbose)
+    reset(all_cams=args.all_cams, config=args.config, verbose=args.verbose)


### PR DESCRIPTION
This pull request addresses a bug that did not allow the reset code to work correctly if no config file was passed. Also through this development, since the order in which the cameras are selected is random, the --num_cams flag was replaced with --all_cams. For our use case, there would never be a situation where we would need n random cameras reset. A verbosity flag was also added.