### PR TITLE
Push session FIN and patient photos to DataJoint (#15)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 # This is the build file for the docker. Note this should be run from the
 # parent directory for the necessary files to be available
 
-.PHONY: clean build run run-no-checks _docker-run run-mocap-test test test-matrix test-diagnostics validate-sync diag-recording diag-analyze health health-fix setup-env install-sudoers force-ip
+.PHONY: clean build run run-no-checks _docker-run run-mocap-test test test-matrix test-diagnostics validate-sync diag-recording diag-analyze health health-fix setup-env install-sudoers force-ip init-dj-test run-mocap-test-dj reset-dj-test
 
 DIR := ${CURDIR}
+TEST_DJ_EXTERNAL ?= /tmp/datajoint_external_test
 
 build-mocap:
 	docker compose build mocap
@@ -104,3 +105,26 @@ force-ip:
 # without prompting for a password.
 install-sudoers:
 	sudo ./scripts/acquisition/install_sudoers.sh
+
+# --- Test DataJoint targets ---
+
+# One-time setup: create external storage directory with sentinel file (TEST_DJ_EXTERNAL, default /mnt/datajoint_external_test).
+init-dj-test:
+	mkdir -p $(TEST_DJ_EXTERNAL)
+	touch $(TEST_DJ_EXTERNAL)/.multi_cam_mount_check
+
+# Run acquisition in test mode against local test DataJoint (starts datajoint-test automatically).
+# Cannot run simultaneously with 'make run' or 'make run-mocap-test' — all bind host ports 8000 and 3000.
+# Run 'make init-dj-test' once before first use.
+# --build rebuilds the image so Python source changes under multi_camera/ are picked up
+# (the Dockerfile bakes source in via COPY; there is no source bind mount on this service).
+run-mocap-test-dj:
+	docker compose run --rm --build mocap-test-dj
+
+# Drop and recreate the test DataJoint database (clean-slate testing).
+# Stops the container, removes the data volume, and restarts.
+reset-dj-test:
+	docker compose stop datajoint-test
+	docker compose rm -f datajoint-test
+	docker volume ls -q | grep datajoint_test_db | xargs -r docker volume rm
+	docker compose up -d datajoint-test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,3 +91,52 @@ services:
       - /etc/localtime:/etc/localtime:ro
       - ${DATAJOINT_EXTERNAL:-/mnt/datajoint_external}:/datajoint_external
     network_mode: host
+
+  # Local test DataJoint MySQL — safe upload target that mirrors production engine.
+  # Binds only to localhost:3307. Data persists in the datajoint_test_db named volume.
+  # Password defaults to 'djtest'; override with DJ_TEST_PASS (also update datajoint_config.test.json).
+  # Run via: make run-mocap-test-dj  (starts this container automatically)
+  datajoint-test:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DJ_TEST_PASS:-djtest}
+      MYSQL_ROOT_HOST: '%'
+    ports:
+      - "127.0.0.1:3307:3306"
+    volumes:
+      - datajoint_test_db:/var/lib/mysql
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -h localhost -u root -p$$MYSQL_ROOT_PASSWORD"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  # mocap-test variant that uploads to the local datajoint-test MySQL instead of production.
+  # Uses TEST_DATA_VOLUME for recording data and TEST_DJ_EXTERNAL for DataJoint external storage.
+  # Run via: make run-mocap-test-dj  (waits for datajoint-test to be healthy before starting)
+  mocap-test-dj:
+    build:
+      context: .
+      dockerfile: ./docker/Dockerfile
+    image: isr/mct_acquisition
+    tty: true
+    stdin_open: true
+    depends_on:
+      datajoint-test:
+        condition: service_healthy
+    environment:
+      REACT_APP_BASE_URL: ${REACT_APP_BASE_URL:-localhost}
+      REACT_APP_TEST_MODE: "true"
+      PYTHONUNBUFFERED: 1
+    volumes:
+      - ${TEST_DATA_VOLUME:-/data-test}:/data
+      - ${CAMERA_CONFIGS:-/camera_configs}:/configs
+      - /etc/localtime:/etc/localtime:ro
+      - ${TEST_DJ_EXTERNAL:-/tmp/datajoint_external_test}:/datajoint_external
+      - ./docker/datajoint_config.test.json:/root/.datajoint_config.json:ro
+    network_mode: host
+    command: /Mocap/entrypoints/start_acquisition_gui.sh
+
+volumes:
+  datajoint_test_db:

--- a/docker/datajoint_config.test.json
+++ b/docker/datajoint_config.test.json
@@ -1,0 +1,20 @@
+{
+    "database.host": "127.0.0.1",
+    "database.port": 3307,
+    "database.user": "root",
+    "database.password": "djtest",
+    "connection.charset": "",
+    "connection.init_function": null,
+    "database.reconnect": true,
+    "database.use_tls": false,
+    "enable_python_native_blobs": true,
+    "fetch_format": "array",
+    "loglevel": "INFO",
+    "safemode": false,
+    "stores": {
+        "localattach": {
+            "protocol": "file",
+            "location": "/datajoint_external"
+        }
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,3 +35,10 @@ Use the links below to navigate:
 1. [Processing Pipeline](analysis/processing_pipeline.md)
 2. [SMPL Model Setup](analysis/smpl_setup.md)
 
+## Operations
+1. [Container Reference](operations/container_reference.md)
+2. [DataJoint Test Environment](operations/datajoint_test_environment.md)
+
+## Development
+1. [Backend Architecture](development/backend_architecture.md)
+

--- a/docs/acquisition/docker_setup.md
+++ b/docs/acquisition/docker_setup.md
@@ -1,5 +1,7 @@
 # Docker Setup
 
+This page covers installing the Docker engine on Ubuntu. For the project's containers and how to operate them, see [Container Reference](../operations/container_reference.md).
+
 ## Install Docker according to the [Docker website](https://docs.docker.com/engine/install/ubuntu/)
 
 Copy and paste each of these blocks into the terminal and run them
@@ -55,3 +57,7 @@ newgrp docker
 ```
 docker run hello-world
 ```
+
+## Next steps
+
+Once the Docker engine is installed and your user can run `docker` without sudo, see [Container Reference](../operations/container_reference.md) for the project's containers and the Makefile targets that drive them.

--- a/docs/development/backend_architecture.md
+++ b/docs/development/backend_architecture.md
@@ -1,0 +1,147 @@
+# Backend Architecture
+
+A developer-facing overview of the MultiCameraTracking codebase: the services that run, how data flows, and where to look for what. For container/lifecycle details see [Container Reference](../operations/container_reference.md). For the camera-side processing pipeline, see [Processing Pipeline](../analysis/processing_pipeline.md).
+
+## System overview
+
+MultiCameraTracking is the backend half of the capture system. It runs on a Linux host with attached FLIR cameras and is responsible for:
+
+1. **Acquisition** — recording synchronized video from multiple FLIR cameras (IEEE1588 PTP)
+2. **Local data management** — tracking participants, sessions, and recordings in a local SQLite database
+3. **Pipeline orchestration** — pushing recordings into DataJoint and running pose estimation, 3D reconstruction, and SMPL fitting
+4. **Annotation** — serving a web UI for reviewing and correcting pose estimates
+
+The companion client is the Flutter `capture-app/`, which talks to this backend over HTTP/WebSocket. See [`capture-app/documentation/MULTICAMERA_API.md`](https://github.com/IntelligentSensingAndRehabilitation/capture-app/blob/main/documentation/MULTICAMERA_API.md) for the API surface.
+
+## Two FastAPI applications
+
+The backend serves two independent HTTP APIs, each backed by its own React frontend:
+
+| App | Module | Port | Frontend | Purpose |
+|---|---|---|---|---|
+| Acquisition | `multi_camera.backend.fastapi` | 8000 | `frontend/acquisition` (port 3000) | Camera recording, session management, live preview via WebSocket (`/video_ws`), calibration, push to DataJoint |
+| Annotation | `multi_camera.backend.fastapi_annotation` | 8005 | `frontend/annotation` (port 3005) | Unannotated-recording discovery, SMPL mesh delivery, annotation posting |
+
+The acquisition API uses a `GlobalState` dataclass singleton that holds the `FlirRecorder`, current session, and a frame queue. Camera callbacks run on a background thread; the FastAPI event loop reads from the frame queue to stream previews.
+
+Both apps live behind their containers' entrypoint scripts — they're started by `start_acquisition_gui.sh` / `run_annotate.sh`, which also build and serve the React bundles.
+
+## Dual-database pattern
+
+Two databases are in use simultaneously:
+
+- **DataJoint** (MySQL) — pipeline orchestration, computed tables, analysis results. Configured via `datajoint_config.json` (copied to `/root/.datajoint_config.json` in the image). Requires `enable_python_native_blobs: true` for numpy storage.
+- **SQLite** — local acquisition database at `data/recordings.db`, defined in `multi_camera/backend/recording_db.py` (SQLAlchemy ORM). Tracks participants, sessions, recordings, photos, and a sync-status `Imported` table.
+
+`synchronize_to_datajoint()` reconciles the two databases at startup: any local recording marked as imported but missing from DataJoint is re-flagged so the next push can retry. This is the safety net that keeps the local and remote views consistent across crashes, network failures, and manual DataJoint edits.
+
+For test/dev work, swap the production DataJoint for a local MySQL container — see [DataJoint Test Environment](../operations/datajoint_test_environment.md).
+
+## Frontend apps
+
+Two React 18 (Create React App) apps live in `frontend/`:
+
+- `frontend/acquisition/` — main operator UI. Notable components: `CameraStatusTable`, `Config`, `Participant`, `RecordingControl`, `SmplBrowser`, `Video`. Uses Three.js + `@react-three/fiber` for 3D mesh visualization.
+- `frontend/annotation/` — the `Annotator` view plus `visualization_js/` helpers.
+
+Both use react-bootstrap (Bootswatch theme) and axios. npm scripts pass `--openssl-legacy-provider` because of an OpenSSL 3 / webpack 4 incompatibility — keep that flag when modifying the npm scripts.
+
+The acquisition image pre-builds the React bundle at image build time with default env vars and writes a fingerprint file. `start_acquisition_gui.sh` checks the runtime env-var fingerprint and rebuilds the bundle only if it differs — for example, `mocap-test` sets `REACT_APP_TEST_MODE=true`, which triggers a rebuild on first launch.
+
+## Module map
+
+```
+multi_camera/
+├── acquisition/      FLIR camera capture, IEEE1588 sync, diagnostics
+├── analysis/         3D math, calibration, reconstruction, biomechanics
+├── backend/          The two FastAPI apps + SQLite recording DB
+├── datajoint/        DataJoint schemas and populate logic
+├── utils/            Shared helpers, standard pipeline composition
+├── validation/       Input validation
+├── visualization/    Plotting and figure helpers
+├── wrappers/         Thin wrappers around external libs
+└── experimental/     WIP code (mvmhat.py, gaitrite_mtc.py) — not in main pipeline
+```
+
+| Module | What lives there | Key entry points |
+|---|---|---|
+| `acquisition` | FLIR capture + sync diagnostics | `flir_recording_api.py` (`FlirRecorder`), `diagnostics/json_parser.py`, `diagnostics/system_monitor.py`, `cameras_reset.py`, `health.py` |
+| `analysis` | Camera math, calibration, reconstruction | `camera.py` (JAX/jaxlie), `reconstruction.py` (aniposelib triangulation), `calibration.py` (ChArUco), `optimize_reconstruction.py` (Flax + Optax), `biomechanics/opensim_fitting.py` |
+| `backend` | Web layer + local DB | `fastapi.py`, `fastapi_annotation.py`, `recording_db.py` |
+| `datajoint` | All DJ tables and pipelines | `multi_camera_dj.py`, `sessions.py`, `annotation.py`, `easymocap.py`, `calibrate_cameras.py`, `smpl.py`, `quality_metrics.py`, `session_calibrations.py`, `utils/recording_delete.py` |
+| `utils` | Reusable helpers | `standard_pipelines.py` |
+
+## DataJoint schemas
+
+Three primary schemas:
+
+- **`multicamera_tracking`** — Recording and reconstruction tables. Key tables: `MultiCameraRecording`, `SingleCameraVideo`, `CalibratedRecording`, `Calibration`, `PersonKeypointReconstruction` (Computed), `PersonKeypointReconstructionMethodLookup` (13 methods), `SMPLReconstruction`/`SMPLXReconstruction`, `SynchronizationQuality` (Computed).
+- **`mocap_sessions`** — Session/subject organization. `Subject`, `Session`, `Recording`. Links to `MultiCameraRecording` via foreign key. `SessionCalibration` validates one calibration per recording.
+- **`multicamera_tracking_annotation`** — Activity labels. `VideoActivityLookup`/`VideoActivity` (walking, TUG, FMS, CUET, etc.), `RangeAnnotation`, `EventAnnotation`.
+
+Additional schemas: `multicamera_tracking_gaitrite` (GaitRite pressure-mat comparison), plus NimblePhysics biomechanics tables.
+
+Upstream dependencies (provided by `pose_pipeline`): `Video`, `VideoInfo`, `TopDownPerson`, `BottomUpPeople`.
+
+Notes:
+- `camera_config_hash` is part of primary keys so multiple camera setups can coexist.
+- `SkippedRecording` has **no foreign keys** intentionally — it logs failures even when FK tables lack matching entries.
+- Use `thorough_delete_recording()` / `thorough_delete_calibration()` in `datajoint/utils/recording_delete.py` for safe cascading deletes (handles inverted FK dependencies with PosePipeline).
+
+See [Processing Pipeline](../analysis/processing_pipeline.md) for the populate workflow.
+
+## Local development workflow
+
+There are two ways to run backend code:
+
+### In Docker (required for cameras)
+
+Anything that touches FLIR cameras must run in the `mocap` container (FLIR Spinnaker SDK is installed there; the host doesn't need it). See [Container Reference](../operations/container_reference.md).
+
+### Without Docker (analysis, DataJoint, unit tests)
+
+For DataJoint pipeline work, analysis-only changes, or unit tests, install the package locally with pip:
+
+```bash
+pip install -e .
+pip install -e ".[opencv]"          # with OpenCV GUI
+pip install -e ".[opencv-headless]" # headless variant for servers
+```
+
+This installs the `multi_camera` package without the acquisition system. You can then run pytest, develop DataJoint table changes, or debug analysis code interactively. The `tests/acquisition/` tests still require real cameras, but most other tests run cleanly without hardware.
+
+### Running tests
+
+```bash
+pytest tests/                            # all unit tests
+pytest tests/test_camera.py              # camera math tests
+pytest tests/test_camera.py::test_project # single test
+
+# In Docker (containerized test suite):
+make test                                # all (cameras required for matrix)
+make test-diagnostics                    # no cameras required
+make test-matrix                         # cameras required
+```
+
+`tests/test_data_integrity.py` requires live DataJoint + SQLite connections. `tests/acquisition/` requires attached FLIR cameras.
+
+## Camera-model conventions
+
+Camera parameters are dicts keyed by camera with arrays `mtx`, `dist`, `rvec`, `tvec`:
+
+- `mtx` — each row is `[fx, fy, cx, cy]` in **normalized** coordinates (pixel values divided by 1000). `get_intrinsic()` multiplies by 1000 to reconstruct the standard K matrix.
+- `tvec` — in **meters**. `get_extrinsic()` multiplies by 1000 to produce mm.
+- `rvec` — axis-angle (Rodrigues), used with jaxlie SO3.
+- `dist` — OpenCV-convention distortion coefficients.
+
+`robust_triangulate_points()` returns shape `(T, J, 4)` where the 4th channel is a confidence weight. Output is in meters.
+
+The EasyMocap bridge (`_build_camera()`) divides `tvec` by 1000 — that's converting from DataJoint's meter convention back to whatever EasyMocap expects internally.
+
+## See also
+
+- [Container Reference](../operations/container_reference.md) — containers and lifecycle
+- [DataJoint Test Environment](../operations/datajoint_test_environment.md) — local DJ for development
+- [Processing Pipeline](../analysis/processing_pipeline.md) — populate workflow and stage-by-stage detail
+- [SMPL Model Setup](../analysis/smpl_setup.md) — model files and paths
+- [`capture-app` API reference](https://github.com/IntelligentSensingAndRehabilitation/capture-app/blob/main/documentation/MULTICAMERA_API.md) — endpoints the Flutter client calls

--- a/docs/operations/container_reference.md
+++ b/docs/operations/container_reference.md
@@ -1,0 +1,194 @@
+# Container Reference
+
+This page describes every Docker container defined by MultiCameraTracking — what each one does and how to start, stop, and reset it. For installing the Docker engine itself, see [Docker Setup](../acquisition/docker_setup.md).
+
+## Overview
+
+MultiCameraTracking builds two Docker images and pulls one stock image:
+
+| Image | Source | Used by |
+|---|---|---|
+| `isr/mct_acquisition` | `docker/Dockerfile` | `mocap`, `mocap-test`, `mocap-test-dj`, `test`, `reset` |
+| `isr/mct_annotation` | `docker/Dockerfile.annotation` | `annotate` |
+| `mysql:8.0` | Docker Hub | `datajoint-test` |
+
+All services run with `network_mode: host` except `datajoint-test`, which binds only to `127.0.0.1:3307`. Most operations are driven through the `Makefile`; the underlying compose file is `docker-compose.yml`.
+
+## Quick reference
+
+| Service | Image | Purpose | Host ports | Primary Make target |
+|---|---|---|---|---|
+| `mocap` | `mct_acquisition` | Production acquisition GUI + FastAPI | 8000, 3000 | `make run` |
+| `mocap-test` | `mct_acquisition` | Acquisition against isolated `/data-test` | 8000, 3000 | `make run-mocap-test` |
+| `mocap-test-dj` | `mct_acquisition` | Acquisition against local test DataJoint | 8000, 3000 | `make run-mocap-test-dj` |
+| `test` | `mct_acquisition` | Pytest + diagnostics runner | — | `make test`, `make health`, etc. |
+| `reset` | `mct_acquisition` | One-shot FLIR camera reset | — | `make reset` |
+| `annotate` | `mct_annotation` | Annotation web tool | 3005 | `make annotate` |
+| `datajoint-test` | `mysql:8.0` | Local DataJoint MySQL for testing | 127.0.0.1:3307 | `make run-mocap-test-dj` (auto-starts) |
+
+**Port-conflict rule:** `mocap`, `mocap-test`, and `mocap-test-dj` all bind host ports 8000 (FastAPI) and 3000 (React). Only one can run at a time.
+
+## Building images
+
+```bash
+make build-mocap       # builds isr/mct_acquisition from docker/Dockerfile
+make build-annotate    # builds isr/mct_annotation from docker/Dockerfile.annotation
+```
+
+Rebuild after changes to `Dockerfile`, `Dockerfile.annotation`, `multi_camera/`, `frontend/`, `pyproject.toml`, or `docker/entrypoints/`. The first build is slow because the acquisition image installs the FLIR Spinnaker SDK; subsequent rebuilds are cached.
+
+## Per-container detail
+
+### `mocap` — production acquisition
+
+The primary acquisition container. Runs the Python FastAPI backend and the React acquisition UI against attached FLIR cameras.
+
+| | |
+|---|---|
+| **Entrypoint** | `/Mocap/entrypoints/start_acquisition_gui.sh` |
+| **Processes** | FastAPI (`python3 -m multi_camera.backend.fastapi`, port 8000) and React serve (port 3000) |
+| **Volumes** | `${DATA_VOLUME:-/data}` → `/data`, `${CAMERA_CONFIGS:-/camera_configs}` → `/configs`, `${DATAJOINT_EXTERNAL:-/mnt/datajoint_external}` → `/datajoint_external` |
+| **Network** | `host` |
+| **Lifecycle** | Foreground; runs until stopped |
+
+**Start:**
+```bash
+make run             # with system validation (DHCP, disk, env) — recommended
+make run-no-checks   # skip validation
+```
+
+`make run` invokes `scripts/acquisition/start_acquisition.sh`, which validates the host before calling `docker compose run --rm mocap`.
+
+**Stop:** Ctrl-C in the foreground terminal. The `--rm` flag removes the container on exit. If launched detached, use `docker compose stop mocap`.
+
+**Reset:** No persistent state in the container itself; recording data lives on the host under `${DATA_VOLUME}`. To reset FLIR cameras after a hang, see [`reset`](#reset--flir-camera-reset).
+
+### `mocap-test` — acquisition with isolated data
+
+Same image and behavior as `mocap`, but recordings land in `${TEST_DATA_VOLUME:-/data-test}` so production data is untouched. Also sets `REACT_APP_TEST_MODE=true` so the UI rebuilds with a test banner.
+
+| | |
+|---|---|
+| **Start** | `make run-mocap-test` |
+| **Stop** | Ctrl-C |
+| **Volumes** | `${TEST_DATA_VOLUME:-/data-test}` → `/data` (all others same as `mocap`) |
+
+Cannot run simultaneously with `mocap` or `mocap-test-dj` (port conflict).
+
+### `mocap-test-dj` — acquisition against local DataJoint
+
+Same image as `mocap`, configured to upload to a local MySQL container (`datajoint-test`) instead of production DataJoint. Use this when developing or testing DataJoint inserts without touching shared infrastructure.
+
+| | |
+|---|---|
+| **Start** | `make run-mocap-test-dj` (auto-starts `datajoint-test` and waits for its health check) |
+| **Stop** | Ctrl-C (stops mocap-test-dj; `datajoint-test` keeps running) |
+| **DataJoint config** | `docker/datajoint_config.test.json` mounted read-only at `/root/.datajoint_config.json` |
+| **DataJoint external storage** | `${TEST_DJ_EXTERNAL:-/tmp/datajoint_external_test}` → `/datajoint_external` |
+
+Requires one-time setup with `make init-dj-test`. See [DataJoint Test Environment](datajoint_test_environment.md) for the full workflow.
+
+### `test` — pytest + diagnostics
+
+A non-interactive container used to run pytest and most diagnostic tools. Mounts `./tests` and `./tests/testdata` from the repo so test files don't need to be baked into the image.
+
+| | |
+|---|---|
+| **Entrypoint** | `/Mocap/entrypoints/run_tests.sh` (default) or overridden via `--entrypoint` |
+| **Lifecycle** | One-shot; auto-removes on exit |
+
+**Test targets:**
+```bash
+make test                # all acquisition tests (cameras required for matrix tests)
+make test-matrix         # camera test matrix only (cameras required, long)
+make test-diagnostics    # sync diagnostics unit tests (no cameras required)
+```
+
+**Diagnostics targets** (also use the `test` container via `--entrypoint` overrides):
+
+| Target | Cameras? | Purpose |
+|---|---|---|
+| `make validate-sync CONFIG=/configs/your_config.yaml` | yes | Pre-recording sync validation |
+| `make diag-recording CONFIG=/configs/your_config.yaml [FRAMES=N] [DATA=/path]` | yes | Short recording with full diagnostics |
+| `make diag-analyze [DATA=/data]` | no | Post-hoc analysis of recording JSON |
+| `make health` | no | Host network/DHCP/MTU/camera reachability check |
+| `make health-fix` | no | Same as `health` but auto-remediates (requires passwordless sudo for `ip link`, `sysctl`, `systemctl`) |
+
+### `reset` — FLIR camera reset
+
+One-shot container that hardware-resets all FLIR cameras (clears IEEE1588 state, releases stuck buffers). Useful after a sync failure or when cameras stop responding.
+
+| | |
+|---|---|
+| **Command** | `python3 -m multi_camera.acquisition.cameras_reset -av` |
+| **Lifecycle** | Runs once, exits, auto-removes |
+
+```bash
+make reset
+```
+
+### `annotate` — annotation web tool
+
+Web tool for reviewing and correcting pose estimates. Independent from `mocap` — different image, different port, no camera access needed.
+
+| | |
+|---|---|
+| **Entrypoint** | `/Mocap/entrypoints/run_annotate.sh` |
+| **Processes** | FastAPI annotation backend (`multi_camera.backend.fastapi_annotation`) and React annotation UI |
+| **Port** | 3005 |
+| **Volumes** | `${DATAJOINT_EXTERNAL:-/mnt/datajoint_external}` → `/datajoint_external` |
+
+```bash
+make build-annotate   # first time only (or after Dockerfile.annotation changes)
+make annotate
+```
+
+Stop with Ctrl-C.
+
+### `datajoint-test` — local DataJoint MySQL
+
+Stock MySQL 8.0 container providing a local DataJoint server for testing. Bound to `127.0.0.1:3307` only (not exposed externally). Data persists in the `datajoint_test_db` Docker volume.
+
+| | |
+|---|---|
+| **Image** | `mysql:8.0` |
+| **Port** | `127.0.0.1:3307` → `3306` |
+| **Volume** | `datajoint_test_db` (named, persistent across restarts) |
+| **Root password** | `djtest` by default (override with `DJ_TEST_PASS`) |
+| **Health check** | `mysqladmin ping` every 10 s, 5 retries, 30 s grace |
+
+Normally you do not start this container directly — `make run-mocap-test-dj` brings it up automatically. For full lifecycle (init, reset, stop, troubleshooting), see [DataJoint Test Environment](datajoint_test_environment.md).
+
+## Cross-cutting concerns
+
+### Host networking
+
+All acquisition containers (`mocap`, `mocap-test`, `mocap-test-dj`, `test`, `reset`) and the `annotate` container use Docker's `host` network mode. This is required for FLIR camera discovery (which relies on direct GigE access) and for IEEE1588 PTP synchronization, neither of which works through Docker's default bridge networking. Consequently, container processes share the host's port space — see the port-conflict rule above.
+
+### Environment variables
+
+The acquisition stack reads configuration from a `.env` file at the repo root. The template is at `.env.template`; run `make setup-env` to validate your `.env` against the template (prompts for any missing values). Key variables:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `DJ_USER`, `DJ_PASS`, `DJ_HOST`, `DJ_PORT` | — | DataJoint credentials |
+| `NETWORK_INTERFACE` | `enp5s0` | NIC bound to camera subnet |
+| `DEPLOYMENT_MODE` | `network` | `laptop` or `network` |
+| `DATA_VOLUME` | `/data` | Recording storage |
+| `TEST_DATA_VOLUME` | `/data-test` | Test-mode recording storage |
+| `CAMERA_CONFIGS` | `/camera_configs` | YAML camera configs |
+| `DATAJOINT_EXTERNAL` | `/mnt/datajoint_external` | DataJoint external blob storage |
+| `TEST_DJ_EXTERNAL` | `/tmp/datajoint_external_test` | DataJoint external storage for test |
+| `DJ_TEST_PASS` | `djtest` | Local DataJoint MySQL root password |
+| `DISK_SPACE_WARNING_THRESHOLD_GB` | `50` | Min free space at startup |
+
+### Data flow
+
+The acquisition containers write recordings to `/data` inside the container, which maps to the host's `${DATA_VOLUME}`. Each session produces per-camera `{serial}.mp4` files plus a `.json` metadata sidecar (consumed by `make diag-analyze`). Pushes to DataJoint copy large binary blobs into `${DATAJOINT_EXTERNAL}` and insert rows into MySQL.
+
+## See also
+
+- [Docker Setup](../acquisition/docker_setup.md) — installing the Docker engine
+- [DataJoint Test Environment](datajoint_test_environment.md) — full local DJ workflow
+- [Unified Startup Script](../acquisition/startup_script.md) — what `make run` validates before launching
+- [Backend Architecture](../development/backend_architecture.md) — what the code inside these containers actually does

--- a/docs/operations/datajoint_test_environment.md
+++ b/docs/operations/datajoint_test_environment.md
@@ -1,0 +1,132 @@
+# DataJoint Test Environment
+
+A local DataJoint MySQL server for development and testing. Lets you exercise the full acquisition → DataJoint upload path without touching the production database.
+
+## When to use it
+
+- Developing changes to DataJoint table definitions or `populate()` logic
+- Verifying that a session uploads cleanly before pointing at production DJ
+- Running CI-style smoke tests of the upload path
+
+If you only need to run analysis code that reads from production DJ, you don't need this — just configure `datajoint_config.json` with production credentials.
+
+## Architecture
+
+```
+   ┌──────────────────────────────┐         ┌────────────────────────────┐
+   │      mocap-test-dj           │         │      datajoint-test        │
+   │      (isr/mct_acquisition)   │         │      (mysql:8.0)           │
+   │                              │         │                            │
+   │  /root/.datajoint_config.json│ ───────▶│  127.0.0.1:3307            │
+   │   ↑ mounted read-only from   │  MySQL  │  root / djtest             │
+   │   docker/datajoint_config    │         │                            │
+   │   .test.json                 │         │  Volume: datajoint_test_db │
+   │                              │         │  (persists across restarts)│
+   │  /datajoint_external         │         └────────────────────────────┘
+   │   ↑ mounted from
+   │   ${TEST_DJ_EXTERNAL:-/tmp/datajoint_external_test}
+   └──────────────────────────────┘
+```
+
+Two containers cooperate:
+
+- **`datajoint-test`** — MySQL 8.0 bound to `127.0.0.1:3307`. Data persists in the `datajoint_test_db` named volume across restarts. Healthcheck (`mysqladmin ping`) gates dependent services.
+- **`mocap-test-dj`** — Same image as `mocap`, but with `docker/datajoint_config.test.json` mounted over the in-image `datajoint_config.json`. Points at `127.0.0.1:3307`, root user, password `djtest`. External storage redirects to `${TEST_DJ_EXTERNAL:-/tmp/datajoint_external_test}`.
+
+## First-time setup
+
+```bash
+make init-dj-test
+```
+
+Creates the external-storage directory and writes a sentinel file (`.multi_cam_mount_check`) that the DataJoint mount-check logic uses to verify the external store is mounted. Override the path with `TEST_DJ_EXTERNAL`:
+
+```bash
+make init-dj-test TEST_DJ_EXTERNAL=/path/to/external
+```
+
+You only need to run this once per workstation.
+
+## Daily workflow
+
+```bash
+make run-mocap-test-dj
+```
+
+This starts `datajoint-test`, waits for its health check to pass, then launches `mocap-test-dj` in the foreground against it. Ctrl-C stops the acquisition container; **the MySQL container keeps running** so subsequent launches start fast.
+
+Cannot run simultaneously with `make run` or `make run-mocap-test` (all three bind host ports 8000 and 3000).
+
+## Cleanup
+
+| Goal | Command | Effect |
+|---|---|---|
+| Stop MySQL, keep data | `docker compose stop datajoint-test` | Container stops; `datajoint_test_db` volume preserved; resumes on next `make run-mocap-test-dj` |
+| Drop and recreate (clean slate) | `make reset-dj-test` | Stops container, removes it, deletes the `datajoint_test_db` volume, restarts fresh |
+
+> **Note:** A `make stop-dj-test` shortcut is tracked as issue #21 — it has not landed yet. Use `docker compose stop datajoint-test` directly in the meantime.
+
+`make reset-dj-test` is the right call when:
+- Schema changed and you want a fresh DB
+- A failed insert left data in an inconsistent state
+- You want to confirm a setup script works from zero
+
+## Configuration
+
+### DataJoint config
+
+`docker/datajoint_config.test.json` is mounted read-only over the container's `~/.datajoint_config.json`. Defaults:
+
+```json
+{
+    "database.host": "127.0.0.1",
+    "database.port": 3307,
+    "database.user": "root",
+    "database.password": "djtest",
+    "enable_python_native_blobs": true,
+    "stores": { "localattach": { "protocol": "file", "location": "/datajoint_external" } }
+}
+```
+
+### Environment variables
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `DJ_TEST_PASS` | `djtest` | MySQL root password. **If you change this, also update `database.password` in `datajoint_config.test.json`.** |
+| `TEST_DJ_EXTERNAL` | `/tmp/datajoint_external_test` | Host path for DataJoint external blob storage |
+| `TEST_DATA_VOLUME` | `/data-test` | Host path for recording data |
+
+## Troubleshooting
+
+**`make run-mocap-test-dj` hangs at "waiting for datajoint-test to be healthy"**
+
+The MySQL container's healthcheck has a 30-second start period, then polls every 10 s with up to 5 retries. If it never becomes healthy, check the logs:
+
+```bash
+docker compose logs datajoint-test
+```
+
+Common causes: another process is bound to `127.0.0.1:3307`, or a previous `datajoint_test_db` volume was created with a different `MYSQL_ROOT_PASSWORD` (MySQL persists the root password on first init — see "Drop and recreate" above).
+
+**`port 3307 already in use`**
+
+Another process is bound there. Identify it:
+
+```bash
+sudo lsof -i :3307
+```
+
+Either stop that process or change the host port in `docker-compose.yml` (and update `database.port` in `datajoint_config.test.json` to match).
+
+**`Mount point not detected`**
+
+The external-storage sentinel is missing. Re-run `make init-dj-test`.
+
+**Schema looks stale after pulling new code**
+
+Run `make reset-dj-test` to drop the database and let the new schema create cleanly on next launch.
+
+## See also
+
+- [Container Reference](container_reference.md) — `datajoint-test` and `mocap-test-dj` service details
+- [Backend Architecture](../development/backend_architecture.md) — how the dual-DB pattern works

--- a/multi_camera/backend/fastapi.py
+++ b/multi_camera/backend/fastapi.py
@@ -845,8 +845,14 @@ async def set_session(
     if fin and fin.strip():
         from multi_camera.backend.recording_db import store_fin
 
-        store_fin(db, participant_name=subject_id, fin=fin.strip())
-        print(f"FIN stored for participant {subject_id}")
+        store_fin(
+            db,
+            participant_name=subject_id,
+            session_date=date,
+            session_path=session_dir,
+            fin=fin.strip(),
+        )
+        print(f"FIN stored for session {subject_id} / {date}")
 
     return state.current_session
 

--- a/multi_camera/backend/fastapi.py
+++ b/multi_camera/backend/fastapi.py
@@ -821,6 +821,17 @@ async def set_session(
         dict: A dictionary with the recording directory and filename
     """
 
+    fin = fin.strip() if fin else None
+    # Mirrors subject_extended.FIN_MAX_LENGTH (varchar(20)), which can't be
+    # imported here: importing that module activates its DataJoint schema,
+    # and /session must work without DataJoint connectivity. Validate before
+    # any side effects so a rejected request leaves no session behind.
+    if fin and len(fin) > 20:
+        raise HTTPException(
+            status_code=422,
+            detail=f"FIN must be at most 20 characters (got {len(fin)})",
+        )
+
     date = datetime.date.today()
     session_dir = os.path.join(RECORDING_BASE, subject_id, date.strftime("%Y%m%d"))
     os.makedirs(session_dir, exist_ok=True)
@@ -842,7 +853,7 @@ async def set_session(
         if saved_salt:
             print(f"Restored config_hash_salt from {_session_salt_path(state.current_session)}")
 
-    if fin and fin.strip():
+    if fin:
         from multi_camera.backend.recording_db import store_fin
 
         store_fin(
@@ -850,7 +861,7 @@ async def set_session(
             participant_name=subject_id,
             session_date=date,
             session_path=session_dir,
-            fin=fin.strip(),
+            fin=fin,
         )
         print(f"FIN stored for session {subject_id} / {date}")
 

--- a/multi_camera/backend/recording_db.py
+++ b/multi_camera/backend/recording_db.py
@@ -26,6 +26,7 @@ class Session(Base):
     session_date = Column(Date)
     session_path = Column(String)
     participant_id = Column(Integer, ForeignKey("participants.id"))
+    fin = Column(String, nullable=True)
 
     participant = relationship("Participant", back_populates="sessions")
     recordings = relationship("Recording", back_populates="session")
@@ -77,11 +78,11 @@ class Photo(Base):
 
 
 class ParticipantFIN(Base):
-    """Maps a participant to their Financial Identification Number (FIN, from wristband).
+    """DEPRECATED: FIN is now stored per-session on `Session.fin`.
 
-    One FIN per participant — upserted on conflict. Stored alongside other recording
-    metadata in recordings.db; proper PHI access control is deferred to the DataJoint
-    export layer (future work).
+    Kept for one release to support rollback and to feed the one-shot migration in
+    `_ensure_session_fin_column`. Do not write to this table; remove in a follow-up
+    once the new path is verified in production.
     """
 
     __tablename__ = "participant_fin"
@@ -124,35 +125,27 @@ def _get_or_create_session(db: Session, participant_name: str, session_date, ses
     return session
 
 
-def store_fin(db, participant_name: str, fin: str) -> ParticipantFIN:
-    """Upsert a FIN for the given participant. Creates the participant row if needed."""
-    participant = _get_or_create_participant(db, participant_name)
-
-    existing = db.query(ParticipantFIN).filter(
-        ParticipantFIN.participant_id == participant.id
-    ).first()
-
-    if existing:
-        existing.fin = fin
-        existing.updated_at = datetime.now()
-    else:
-        existing = ParticipantFIN(participant_id=participant.id, fin=fin)
-        db.add(existing)
-
+def store_fin(db, participant_name: str, session_date, session_path: str, fin: str) -> "Session":
+    """Set the FIN on the matching session row. Creates participant/session if needed."""
+    session = _get_or_create_session(db, participant_name, session_date, session_path)
+    session.fin = fin
     db.commit()
-    db.refresh(existing)
-    return existing
+    db.refresh(session)
+    return session
 
 
-def get_fin(db, participant_name: str) -> Optional[str]:
-    """Look up the FIN for a participant by name. Returns None if not found."""
-    record = (
-        db.query(ParticipantFIN)
-        .join(Participant, ParticipantFIN.participant_id == Participant.id)
-        .filter(Participant.name == participant_name)
+def get_fin(db, participant_name: str, session_date) -> Optional[str]:
+    """Look up the FIN for a (participant, session_date). Returns None if not set."""
+    if isinstance(session_date, str):
+        session_date = datetime.strptime(session_date, "%Y-%m-%d").date()
+
+    session = (
+        db.query(Session)
+        .join(Participant, Session.participant_id == Participant.id)
+        .filter(Participant.name == participant_name, Session.session_date == session_date)
         .first()
     )
-    return record.fin if record else None
+    return session.fin if session and session.fin else None
 
 
 def add_recording(
@@ -593,7 +586,7 @@ def _push_calibration_videos(
 
 
 def push_to_datajoint(db: Session, participant_id: str, session_date: date, video_project: str):
-    from multi_camera.datajoint.sessions import import_session
+    from multi_camera.datajoint.sessions import import_session, PhotoSpec
 
     # get the list of recordings from the database with their comments
     # that match the participant and session date
@@ -604,6 +597,21 @@ def push_to_datajoint(db: Session, participant_id: str, session_date: date, vide
     sessions: SessionOut = db_recordings[0].sessions
     assert len(sessions) == 1, "Did not find exactly one session for this participant and date."
     recordings: List[RecordingOut] = sessions[0].recordings
+
+    # SQLite stores the un-normalized participant name (Participant.name == subject_id
+    # passed to /session), so look up FIN before normalization below.
+    fin = get_fin(db, participant_name=participant_id, session_date=session_date)
+
+    photo = None
+    if sessions[0].photos:
+        p = max(sessions[0].photos, key=lambda x: x.upload_timestamp)
+        photo = PhotoSpec(
+            saved_path=p.saved_path,
+            filename=p.filename,
+            original_filename=p.original_filename,
+            upload_timestamp=p.upload_timestamp,
+            description=p.description,
+        )
 
     # Split into trial recordings (push to DataJoint Recording chain) and calibration
     # recordings (push raw videos only; Calibration computation still happens in the
@@ -627,13 +635,14 @@ def push_to_datajoint(db: Session, participant_id: str, session_date: date, vide
 
     participant_id = normalize_participant_id(participant_id)
 
-    # TODO(@ktshah04): Include FIN when pushing to DataJoint.
-    # FIN is stored alongside the participant in this same database:
-    #   fin = get_fin(db, participant_name=participant_id)
-    # Pass fin to import_session() once the DataJoint schema supports it. This is also
-    # the layer where proper PHI access control should be enforced.
-
-    import_session(participant_id, session_date, video_project=video_project, recordings=trial_recordings)
+    import_session(
+        participant_id,
+        session_date,
+        video_project=video_project,
+        recordings=trial_recordings,
+        fin=fin,
+        photo=photo,
+    )
 
     # Calibration videos + recording metadata are pushed so they're queryable from DataJoint.
     # Calibration computation still happens when the user runs run_calibration_and_insert
@@ -644,6 +653,38 @@ def push_to_datajoint(db: Session, participant_id: str, session_date: date, vide
     synchronize_to_datajoint(db)
 
 
+def _ensure_session_fin_column(engine):
+    """Add `sessions.fin` column on existing DBs that pre-date #15.
+
+    SQLAlchemy's create_all only creates missing tables, not missing columns.
+    Best-effort backfill: copy ParticipantFIN.fin to the most recent session
+    per participant. Older sessions are left NULL because the legacy
+    ParticipantFIN table only kept the latest FIN per participant.
+    """
+    from sqlalchemy import inspect, text
+
+    insp = inspect(engine)
+    if "sessions" not in insp.get_table_names():
+        return
+    cols = [c["name"] for c in insp.get_columns("sessions")]
+    if "fin" in cols:
+        return
+
+    with engine.begin() as conn:
+        conn.execute(text("ALTER TABLE sessions ADD COLUMN fin VARCHAR"))
+        if "participant_fin" in insp.get_table_names():
+            conn.execute(text("""
+                UPDATE sessions
+                SET fin = (
+                    SELECT pf.fin FROM participant_fin pf
+                    WHERE pf.participant_id = sessions.participant_id
+                )
+                WHERE sessions.id IN (
+                    SELECT MAX(id) FROM sessions GROUP BY participant_id
+                )
+            """))
+
+
 def get_db():
     from sqlalchemy.orm import Session, sessionmaker
 
@@ -651,6 +692,7 @@ def get_db():
 
     engine = create_engine(DATABASE_URL)
     Base.metadata.create_all(bind=engine)
+    _ensure_session_fin_column(engine)
 
     SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 

--- a/multi_camera/datajoint/sessions.py
+++ b/multi_camera/datajoint/sessions.py
@@ -127,7 +127,17 @@ def import_session(
     # tears down the surrounding transaction. The deferred import here also
     # breaks the sessions <-> subject_extended cycle at module load time.
     if fin is not None:
-        from multi_camera.datajoint.subject_extended import Fin
+        from multi_camera.datajoint.subject_extended import Fin, FIN_MAX_LENGTH
+
+        if len(fin) > FIN_MAX_LENGTH:
+            raise ValueError(
+                f"FIN is {len(fin)} characters; subject_extended.Fin allows at most {FIN_MAX_LENGTH}"
+            )
+
+    # Check the photo file before the transaction so a missing file fails fast
+    # instead of rolling back the (expensive) recording imports.
+    if photo is not None and not os.path.exists(photo.saved_path):
+        raise FileNotFoundError(f"Photo missing on disk: {photo.saved_path}")
 
     dj.conn().start_transaction()
     try:
@@ -152,8 +162,6 @@ def import_session(
             Recording.insert1(key)
 
         if photo is not None:
-            if not os.path.exists(photo.saved_path):
-                raise FileNotFoundError(f"Photo missing on disk: {photo.saved_path}")
             Photo.insert1({
                 **session_key,
                 "photo": photo.saved_path,

--- a/multi_camera/datajoint/sessions.py
+++ b/multi_camera/datajoint/sessions.py
@@ -26,13 +26,23 @@ the subject or session level that might be invalidated by a later recording.
 """
 
 import os
-from typing import List, Tuple
-from datetime import date
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import List, Optional, Tuple
 
 import datajoint as dj
 from .multi_camera_dj import import_recording, MultiCameraRecording
 
 schema = dj.schema("mocap_sessions")
+
+
+@dataclass
+class PhotoSpec:
+    saved_path: str
+    filename: str
+    original_filename: str
+    upload_timestamp: datetime
+    description: Optional[str] = None
 
 
 def get_subject_id_from_participant_id(participant_id: str) -> int:
@@ -72,11 +82,27 @@ class Recording(dj.Manual):
     """
 
 
+@schema
+class Photo(dj.Manual):
+    definition = """
+    # Most recent patient identification photo for the session.
+    -> Session
+    ---
+    photo: attach@localattach
+    filename: varchar(255)
+    original_filename: varchar(255)
+    description=null: varchar(255)
+    upload_timestamp: datetime
+    """
+
+
 def import_session(
     participant_id: str,
     session_date: date,
     video_project: str,
     recordings: List[Tuple[str, str]],
+    fin: Optional[str] = None,
+    photo: Optional[PhotoSpec] = None,
 ):
     """
     Import a session with a list of recordings
@@ -86,6 +112,8 @@ def import_session(
         session_date (date): session date
         video_project (str): video project
         recordings (List[Tuple(str, str)]): list of recording tuples
+        fin (Optional[str]): hospital FIN for this session (pushed to subject_extended.Fin)
+        photo (Optional[PhotoSpec]): most recent patient identification photo for this session
 
     """
 
@@ -93,6 +121,13 @@ def import_session(
     session_key = {"participant_id": participant_id, "session_date": session_date}
 
     assert not Session & session_key, "Session already exists"
+
+    # Activate subject_extended outside the transaction: first import triggers DDL
+    # (create schema + ~log table), and MySQL implicitly commits DDL, which
+    # tears down the surrounding transaction. The deferred import here also
+    # breaks the sessions <-> subject_extended cycle at module load time.
+    if fin is not None:
+        from multi_camera.datajoint.subject_extended import Fin
 
     dj.conn().start_transaction()
     try:
@@ -115,6 +150,21 @@ def import_session(
             key["comment"] = comment
 
             Recording.insert1(key)
+
+        if photo is not None:
+            if not os.path.exists(photo.saved_path):
+                raise FileNotFoundError(f"Photo missing on disk: {photo.saved_path}")
+            Photo.insert1({
+                **session_key,
+                "photo": photo.saved_path,
+                "filename": photo.filename,
+                "original_filename": photo.original_filename,
+                "description": photo.description,
+                "upload_timestamp": photo.upload_timestamp,
+            })
+
+        if fin is not None:
+            Fin.insert1({**session_key, "fin": fin})
 
     except Exception as e:
         dj.conn().cancel_transaction()

--- a/multi_camera/datajoint/subject_extended.py
+++ b/multi_camera/datajoint/subject_extended.py
@@ -1,0 +1,21 @@
+"""
+Subject-identity extension tables. Schema isolates PHI (e.g., hospital FIN)
+from the session/recording data in mocap_sessions. Tables here are
+session-keyed via cross-schema FK to mocap_sessions.Session.
+"""
+
+import datajoint as dj
+
+from multi_camera.datajoint import sessions
+
+schema = dj.schema("subject_extended")
+
+
+@schema
+class Fin(dj.Manual):
+    definition = """
+    # Hospital FIN for a session (PHI). Row presence implies FIN was provided.
+    -> sessions.Session
+    ---
+    fin: varchar(20)
+    """

--- a/multi_camera/datajoint/subject_extended.py
+++ b/multi_camera/datajoint/subject_extended.py
@@ -10,12 +10,17 @@ from multi_camera.datajoint import sessions
 
 schema = dj.schema("subject_extended")
 
+# Enforced at the API entry point (backend/fastapi.py /session, which mirrors the
+# value because importing this module activates the schema) and again in
+# sessions.import_session before the push transaction.
+FIN_MAX_LENGTH = 20
+
 
 @schema
 class Fin(dj.Manual):
-    definition = """
+    definition = f"""
     # Hospital FIN for a session (PHI). Row presence implies FIN was provided.
     -> sessions.Session
     ---
-    fin: varchar(20)
+    fin: varchar({FIN_MAX_LENGTH})
     """

--- a/tests/test_data_integrity.py
+++ b/tests/test_data_integrity.py
@@ -31,10 +31,12 @@ from multi_camera.backend.recording_db import (
     get_db,
     Participant,
     Session as SQLiteSession,
+    Photo as SQLitePhoto,
     Imported
 )
-from multi_camera.datajoint.sessions import Subject, Session as DJSession, Recording
+from multi_camera.datajoint.sessions import Subject, Session as DJSession, Recording, Photo as DJPhoto
 from multi_camera.datajoint.multi_camera_dj import MultiCameraRecording, SingleCameraVideo
+from multi_camera.datajoint.subject_extended import Fin
 
 
 # ============================================================================
@@ -115,6 +117,23 @@ def check_session_in_datajoint(participant_id: str, session_date: str) -> bool:
 
             # Check that SingleCameraVideo entries exist for this recording
             if not (SingleCameraVideo & mcr_key):
+                return False
+
+        # If SQLite recorded a FIN, the subject_extended.Fin row must match.
+        if session.fin:
+            fin_rows = Fin & session_key
+            if not fin_rows or fin_rows.fetch1("fin") != session.fin:
+                return False
+
+        # If SQLite has any photos, exactly one row must exist in DataJoint
+        # and it must correspond to the most recent SQLite photo.
+        sqlite_photos = db.query(SQLitePhoto).filter(
+            SQLitePhoto.session_id == session.id
+        ).all()
+        if sqlite_photos:
+            latest = max(sqlite_photos, key=lambda x: x.upload_timestamp)
+            dj_photos = DJPhoto & session_key
+            if not dj_photos or dj_photos.fetch1("filename") != latest.filename:
                 return False
 
         # All checks passed - data exists in DataJoint


### PR DESCRIPTION
## Summary

Closes ROADMAP #15 — `push_to_datajoint()` now propagates session FIN and patient identification photos to DataJoint alongside recordings, so downstream consumers get the full identifying record.

A clarification surfaced during planning that overrides the original ROADMAP framing: **FIN is session-dependent** (a subject can have different FINs across visits). The original triage put FIN on `Subject`; this change puts it on a session-keyed `subject_extended.Fin` table in DataJoint and on a `fin` column on `sessions` in SQLite. The legacy `ParticipantFIN` table's one-FIN-per-participant model has been deprecated in favor of the new per-session storage, with `store_fin`/`get_fin` rewritten to be session-keyed.

A new top-level `mocap_sessions.Photo` table holds the most recent patient identification photo per session via `attach@localattach`.

Also ships a **local DataJoint test container** so the full acquisition → DataJoint upload path can be exercised end-to-end without touching production DJ. This PR was validated against that environment.

## Why this matters

- FIN was being stored locally but never reaching DataJoint; the existing TODO in `recording_db.py` was waiting on a schema decision.
- Patient ID photos were captured at session setup but had no path into the analytical schema at all — the SQLite `Photo` rows existed in isolation.
- Without per-session FIN storage, re-pushing a historical session would attach the wrong (latest) FIN — a data-integrity hazard for retrospective analysis.
- The lab had no safe way to test schema/push changes before pointing at production DJ; the new test container closes that gap.

## DataJoint schema

### New schema: `subject_extended`

```python
# multi_camera/datajoint/subject_extended.py
schema = dj.schema("subject_extended")

@schema
class Fin(dj.Manual):
    definition = """
    # Hospital FIN for a session (PHI). Row presence implies FIN was provided.
    -> sessions.Session
    ---
    fin: varchar(20)
    """
```

### New table in `mocap_sessions`

```python
@schema  # mocap_sessions
class Photo(dj.Manual):
    definition = """
    # Most recent patient identification photo for the session.
    -> Session
    ---
    photo: attach@localattach
    filename: varchar(255)
    original_filename: varchar(255)
    description=null: varchar(255)
    upload_timestamp: datetime
    """
```

`Subject`, `Session`, and `Recording` are unchanged.

**Design decisions:**

- **Separate `subject_extended` schema for FIN** so the PHI lives behind its own access-control surface, decoupled from `mocap_sessions` which downstream analytical code freely reads.
- **Row presence implies FIN was provided** — `Fin` is `dj.Manual` keyed by session FK; pushes that don't carry a FIN simply don't create a row. No nullable FIN column on `Session`, which keeps `Session`'s row size and indexes lean.
- **`Photo` is a top-level table, not a `Session.Photo` Part** — the original PR draft used a Part for photo grouping, but pushing only the most-recent photo per session reduces it to a 1:1 with `Session`, so a top-level table is the natural shape.
- **Class name `Fin` (PEP 8), not `FIN`** — DataJoint converts each uppercase letter to its own snake_case word, so `class FIN` would yield `subject_extended.f_i_n`. `Fin` gives the much friendlier `subject_extended.fin`.
- **`subject_extended` schema activated outside the import transaction** — first-touch of the module triggers `CREATE SCHEMA` + `~log` table DDL, which MySQL implicitly commits and which DataJoint rejects from inside a transaction. The deferred import in `import_session` runs before `dj.conn().start_transaction()` so the DDL happens cleanly; the actual `Fin.insert1` still runs inside the transaction.
- **`attach@localattach`** matches the existing storage pattern for source videos and derived video outputs. DataJoint copies the source file into `/datajoint_external` on insert.
- **Hard-fail on missing photo files at push time** (`raise FileNotFoundError`) matches the existing video-import pattern in `import_recording`.
- **Zero photos for a session is allowed** — no Photo row is inserted; the photo loop is a no-op.

### No `Session.alter()` required

The original draft scoped a `Session.alter()` migration to add a `fin` column and a `Session.Photo` Part. The current design adds **only new tables** (`subject_extended.Fin`, `mocap_sessions.Photo`) and leaves `Session` untouched — both new tables are created automatically by DataJoint on first insert. No schema migration step is needed before deploying this code to production.

## SQLite changes

- Added `fin: VARCHAR NULL` column to the `sessions` table.
- `ParticipantFIN` model marked deprecated (kept in code for one release as a rollback safety net; remove in a follow-up).
- `store_fin(db, participant_name, session_date, session_path, fin)` writes to the matching `Session.fin` row.
- `get_fin(db, participant_name, session_date)` reads from the matching session.

### SQLite migration

`recording_db._ensure_session_fin_column(engine)` runs from `get_db()` on engine creation. It:

1. ALTERs the existing `sessions` table to add `fin VARCHAR` if missing.
2. Best-effort backfills `Session.fin` from `ParticipantFIN.fin` for the **most recent session per participant**. Older sessions stay NULL — their original FIN was overwritten when the legacy schema collapsed FIN to participant.

Idempotent: returns early if the column already exists.

## Pipeline wiring

- `push_to_datajoint()` looks up FIN **before** participant-ID normalization (SQLite stores the un-normalized name) and selects the most recent `Session.photos` entry from the eagerly-loaded relationship, then passes both into `import_session()` via the new `fin` and `photo: PhotoSpec` parameters.
- `import_session()` activates `subject_extended` (if FIN is present) before opening its transaction, then writes `Fin.insert1`, `Photo.insert1`, and the existing Subject/Session/Recording inserts inside the transaction.

## Local DataJoint test container

A second compose stack runs an isolated MySQL 8 instance plus a parallel `mocap-test-dj` acquisition container that talks to it. Lets you exercise the full upload path safely.

```bash
make init-dj-test          # one-time: create external-storage dir + sentinel
make run-mocap-test-dj     # starts datajoint-test (MySQL), waits for healthy,
                           # then launches mocap-test-dj built from current source
make reset-dj-test         # drops the test DB volume for a clean slate
```

`docker/datajoint_config.test.json` is mounted read-only over the container's `~/.datajoint_config.json` — points at `127.0.0.1:3307`, `database.reconnect: true` (so the long-lived FastAPI connection recovers from drops), and an isolated `localattach` store at `/datajoint_external`. The `run-mocap-test-dj` target passes `--build` so source changes get picked up on every launch.

Docs live in `docs/operations/datajoint_test_environment.md` and `docs/operations/container_reference.md`; the dual-DB architecture is documented in `docs/development/backend_architecture.md`.

## What's NOT in this PR (out of scope)

- **PHI access control on `subject_extended.Fin`** — `fin` is PHI; isolating it in `subject_extended` is a structural step toward access control, but no auth/visibility layer is added. Should be a separate issue at the DataJoint export layer.
- **FIN sync after push** — if FIN is added or corrected in SQLite *after* the corresponding session was already pushed, it won't propagate to DataJoint (re-push is blocked by `assert not Session & session_key`). If this becomes a real workflow, add a separate sync step.
- **Removing `ParticipantFIN`** — kept in code for rollback safety. Remove in a follow-up once the new path is verified in production.
- **`make stop-dj-test`** — tracked separately as MCT issue #21.
- **Friendlier duplicate-push error** — re-pushing a session currently raises a bare `AssertionError → 500`. A 409 Conflict would be better UX; not blocking #15.
- **Removing `ParticipantFIN` from the SQLite schema** — only the SQLAlchemy model is marked deprecated; the table itself remains for rollback.
- **Automated tests for `push_to_datajoint`/`import_session`** — `tests/test_data_integrity.py` has FIN/Photo assertions wired in but still requires live DJ + SQLite per CLAUDE.md. CI integration is out of scope here.

## Test plan

All checks below were exercised against the new local test DataJoint environment.

- [x] `make init-dj-test && make run-mocap-test-dj` — fresh MySQL + acquisition stack comes up; healthcheck gates `mocap-test-dj` correctly.
- [x] `_ensure_session_fin_column` runs on engine creation; `fin` column appears in `sessions`; backfill copies `ParticipantFIN.fin` to the most recent session per participant.
- [x] FIN entered via barcode scanner at session start propagates to `sessions.fin` in SQLite via `store_fin`.
- [x] `push_to_datajoint` end-to-end: Subject + Session + Recording×N inserts land in `mocap_sessions`; `subject_extended.Fin` row appears keyed by `(participant_id, session_date)`; `mocap_sessions.photo` row appears with the patient ID photo attached at `/datajoint_external/...`.
- [x] DDL-outside-transaction: first `subject_extended` import on a fresh DB creates the schema + `~log` table before the transaction opens; no `DataJointError: Cannot declare new tables inside a transaction`.
- [x] `database.reconnect: true` — confirmed the long-lived FastAPI connection survives transient drops (previously failed with `LostConnectionError`).
- [x] Idempotent re-push: second push of the same session raises `AssertionError: Session already exists` without duplicating rows.
- [x] `make reset-dj-test` drops the volume cleanly; subsequent `make run-mocap-test-dj` brings everything back up empty; SQLite `Imported` flags are reconciled by `synchronize_to_datajoint` at startup.
- [ ] Production deploy plan: pull on the rig, restart the acquisition container, push one real session, verify in production DJ.

## Files changed

- `multi_camera/datajoint/subject_extended.py` — **new** module; `subject_extended` schema with `Fin(dj.Manual)`.
- `multi_camera/datajoint/sessions.py` — `PhotoSpec` dataclass; new top-level `Photo(dj.Manual)`; deferred `Fin` import outside the transaction; updated `import_session` signature and transaction body.
- `multi_camera/backend/recording_db.py` — `fin` column on `Session` SQLAlchemy model, `_ensure_session_fin_column` migration helper wired into `get_db()`, rewritten `store_fin`/`get_fin`, updated `push_to_datajoint` to thread FIN + photo.
- `multi_camera/backend/fastapi.py` — single-line update to the `/session` endpoint to use the new `store_fin` signature.
- `tests/test_data_integrity.py` — extended to assert FIN and Photo round-trip parity between SQLite and DataJoint.
- `docker-compose.yml` — new `datajoint-test` (MySQL 8) and `mocap-test-dj` services.
- `docker/datajoint_config.test.json` — **new**; mounted over the in-image config when `mocap-test-dj` runs.
- `Makefile` — `init-dj-test`, `run-mocap-test-dj`, `reset-dj-test`; `run-mocap-test-dj` passes `--build`.
- `docs/operations/datajoint_test_environment.md` — **new**; usage guide for the test stack.
- `docs/operations/container_reference.md` — **new**; per-service reference for the compose stack.
- `docs/development/backend_architecture.md` — **new**; dual-DB pattern, DataJoint + SQLite interaction.
- `docs/README.md`, `docs/acquisition/docker_setup.md` — link in the new docs.
