### PR TITLE
Feat/diagnostics v3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # This is the build file for the docker. Note this should be run from the
 # parent directory for the necessary files to be available
 
-.PHONY: clean build run run-no-checks _docker-run run-mocap-test test test-matrix test-diagnostics validate-sync diag-recording diag-analyze
+.PHONY: clean build run run-no-checks _docker-run run-mocap-test test test-matrix test-diagnostics validate-sync diag-recording diag-analyze health health-fix
 
 DIR := ${CURDIR}
 
@@ -75,3 +75,14 @@ diag-analyze:
 	docker compose run --rm --entrypoint python3 test \
 		-m multi_camera.acquisition.diagnostics.json_parser \
 		$(or $(DATA),/data) --no-plots
+
+# Quick host health check (DHCP, host-network MTU/rmem, camera reachability).
+health:
+	docker compose run --rm --entrypoint python3 test \
+		-m multi_camera.acquisition.health
+
+# Same as `make health` but auto-remediates known drift before reporting.
+# Requires passwordless sudo for ip link / sysctl / systemctl.
+health-fix:
+	docker compose run --rm --entrypoint python3 test \
+		-m multi_camera.acquisition.health --remediate

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,11 @@ services:
     environment:
       REACT_APP_BASE_URL: ${REACT_APP_BASE_URL:-localhost}
       PYTHONUNBUFFERED: 1
+      DEPLOYMENT_MODE: ${DEPLOYMENT_MODE:-network}
+      NETWORK_INTERFACE: ${NETWORK_INTERFACE:-enp5s0}
+      DHCP_LEASE_FILE: ${DHCP_LEASE_FILE:-/var/lib/dhcp/dhcpd.leases}
+      DISK_SPACE_WARNING_THRESHOLD_GB: ${DISK_SPACE_WARNING_THRESHOLD_GB:-50}
+      HEALTH_IDLE_POLL_S: ${HEALTH_IDLE_POLL_S:-30}
     volumes:
       - ${DATA_VOLUME:-/data}:/data
       - ${CAMERA_CONFIGS:-/camera_configs}:/configs
@@ -28,6 +33,11 @@ services:
       REACT_APP_BASE_URL: ${REACT_APP_BASE_URL:-localhost}
       REACT_APP_TEST_MODE: "true"
       PYTHONUNBUFFERED: 1
+      DEPLOYMENT_MODE: ${DEPLOYMENT_MODE:-network}
+      NETWORK_INTERFACE: ${NETWORK_INTERFACE:-enp5s0}
+      DHCP_LEASE_FILE: ${DHCP_LEASE_FILE:-/var/lib/dhcp/dhcpd.leases}
+      DISK_SPACE_WARNING_THRESHOLD_GB: ${DISK_SPACE_WARNING_THRESHOLD_GB:-50}
+      HEALTH_IDLE_POLL_S: ${HEALTH_IDLE_POLL_S:-30}
     volumes:
       - ${TEST_DATA_VOLUME:-/data-test}:/data
       - ${CAMERA_CONFIGS:-/camera_configs}:/configs
@@ -39,6 +49,13 @@ services:
   test:
     image: isr/mct_acquisition
     command: /Mocap/entrypoints/run_tests.sh
+    environment:
+      PYTHONUNBUFFERED: 1
+      DEPLOYMENT_MODE: ${DEPLOYMENT_MODE:-network}
+      NETWORK_INTERFACE: ${NETWORK_INTERFACE:-enp5s0}
+      DHCP_LEASE_FILE: ${DHCP_LEASE_FILE:-/var/lib/dhcp/dhcpd.leases}
+      DISK_SPACE_WARNING_THRESHOLD_GB: ${DISK_SPACE_WARNING_THRESHOLD_GB:-50}
+      HEALTH_IDLE_POLL_S: ${HEALTH_IDLE_POLL_S:-30}
     volumes:
       - ${DATA_VOLUME:-/data}:/data
       - ${CAMERA_CONFIGS:-/camera_configs}:/configs

--- a/multi_camera/acquisition/diagnostics/json_parser.py
+++ b/multi_camera/acquisition/diagnostics/json_parser.py
@@ -29,6 +29,14 @@ PTP_DRIFT_THRESHOLD_US = 100
 TEMPERATURE_RISE_THRESHOLD_C = 5.0
 TIMESTAMP_JUMP_THRESHOLD_FACTOR = 10
 TIMESTAMP_JUMP_PAIR_TOLERANCE = 2.0
+WARMUP_SETTLED_RATIO = 10.0
+WARMUP_MIN_SETTLED_TRIALS = 2
+FRAME_COUNT_ANOMALY_FRACTION = 0.10
+FRAME_COUNT_ANOMALY_MIN_TOTAL = 500
+PTP_CLUSTER_WITHIN_US = 500
+PTP_CLUSTER_MIN_OFFSET_US = 50
+PTP_CONVERGENCE_MIN_TRIALS = 3
+PTP_CONVERGENCE_RATIO = 3.0
 
 
 @dataclass(frozen=True)
@@ -400,6 +408,20 @@ def print_report(report: SessionSyncReport, file: TextIOBase | None = None) -> N
         for insight in insights:
             for line in insight.split("\n"):
                 print(f"  {line}", file=out)
+
+    session_insights, session_recs = diagnose_session_issues(report)
+    if session_insights:
+        print(file=out)
+        print("Session Insights", file=out)
+        print("\u2500" * width, file=out)
+        for insight in session_insights:
+            print(f"  {insight}", file=out)
+    if session_recs:
+        print(file=out)
+        print("Recommendations", file=out)
+        print("\u2500" * width, file=out)
+        for i, rec in enumerate(session_recs, 1):
+            print(f"  {i}. {rec}", file=out)
     print(file=out)
 
 
@@ -1039,6 +1061,252 @@ def diagnose_sync_issues(report: SessionSyncReport) -> list[str]:
                 )
 
     return insights
+
+
+def _detect_warmup(report: SessionSyncReport) -> tuple[list[str], list[str], list[int]]:
+    """Detector 17: Identify warm-up trials with unstable sync that settles later.
+
+    Returns (insights, recommendations, warmup_indices).
+    """
+    insights: list[str] = []
+    recs: list[str] = []
+    warmup_indices: list[int] = []
+
+    if report.n_trials < WARMUP_MIN_SETTLED_TRIALS + 1:
+        return insights, recs, warmup_indices
+
+    spreads = [t.max_timestamp_spread_ms for t in report.trials]
+    mid = report.n_trials // 2
+    settled = spreads[mid:]
+    if len(settled) < WARMUP_MIN_SETTLED_TRIALS:
+        return insights, recs, warmup_indices
+
+    settled_median = float(np.median(settled))
+    if settled_median <= 0:
+        return insights, recs, warmup_indices
+
+    for i in range(mid):
+        if spreads[i] > settled_median * WARMUP_SETTLED_RATIO:
+            warmup_indices.append(i)
+
+    if not warmup_indices:
+        return insights, recs, warmup_indices
+
+    max_warmup = max(spreads[i] for i in warmup_indices)
+    if max_warmup > 1000:
+        warmup_str = f"{max_warmup / 1000:.1f}s"
+    else:
+        warmup_str = f"{max_warmup:.1f}ms"
+
+    if settled_median > 1000:
+        settled_str = f"{settled_median / 1000:.1f}s"
+    else:
+        settled_str = f"{settled_median:.3f}ms"
+
+    trial_str = ", ".join(str(i) for i in warmup_indices)
+    first_good = max(warmup_indices) + 1
+    insights.append(
+        f"Trials {trial_str} show warm-up sync instability (max {warmup_str}). "
+        f"Trials {first_good}+ stable (<{settled_str})."
+    )
+    recs.append("Run `make validate-sync` before recording to avoid warm-up trials.")
+
+    return insights, recs, warmup_indices
+
+
+def _detect_frame_count_anomaly(
+    report: SessionSyncReport,
+) -> tuple[list[str], list[str]]:
+    """Detector 18: Flag cameras acquiring significantly fewer frames than peers.
+
+    Fires only if the deficit is large (>10%), the session has enough frames to
+    be meaningful (>500 median), and the camera was affected in more than half
+    of the trials (so a single bad trial doesn't produce a scary session-wide
+    message). Intentionally conservative — false positives here lead operators
+    to unnecessary cable-swap interventions.
+    """
+    insights: list[str] = []
+    recs: list[str] = []
+
+    diag_trials = [t for t in report.trials if t.camera_error_summary]
+    if not diag_trials:
+        return insights, recs
+
+    camera_totals: dict[str, int] = {}
+    per_trial_counts: dict[str, list[int]] = {}
+    for t in diag_trials:
+        for cam, counters in t.camera_error_summary.items():
+            acquired = counters.get("total_acquired", 0)
+            camera_totals[cam] = camera_totals.get(cam, 0) + acquired
+            per_trial_counts.setdefault(cam, []).append(acquired)
+
+    if len(camera_totals) < 2:
+        return insights, recs
+
+    counts = sorted(camera_totals.values())
+    median_count = float(np.median(counts))
+    if median_count < FRAME_COUNT_ANOMALY_MIN_TOTAL:
+        return insights, recs
+
+    n_trials = len(diag_trials)
+    trial_threshold = max(1, n_trials // 2 + 1)
+
+    for cam, total in sorted(camera_totals.items()):
+        deficit = (median_count - total) / median_count
+        if deficit <= FRAME_COUNT_ANOMALY_FRACTION:
+            continue
+
+        # Count per-trial deficits: only flag if this was persistent across
+        # trials, not driven by one bad trial with many retries.
+        trials_with_deficit = sum(
+            1
+            for c in per_trial_counts.get(cam, [])
+            if c < median_count / n_trials * (1 - FRAME_COUNT_ANOMALY_FRACTION)
+        )
+        if trials_with_deficit < trial_threshold:
+            continue
+
+        deficit_pct = int(round(deficit * 100))
+        scope = (
+            "across all trials"
+            if trials_with_deficit == n_trials
+            else f"across {trials_with_deficit}/{n_trials} trials"
+        )
+        insights.append(
+            f"Camera {cam} acquired ~{deficit_pct}% fewer frames than peers "
+            f"({total:,} vs {int(median_count):,} median {scope})."
+        )
+        recs.append(
+            f"Check the cable/port for camera {cam}. If it persists, unplug/replug "
+            f"and re-run a short validation recording."
+        )
+
+    return insights, recs
+
+
+def _detect_ptp_clusters(report: SessionSyncReport) -> tuple[list[str], list[str]]:
+    """Detector 19: Identify groups of cameras sharing similar PTP offsets."""
+    insights: list[str] = []
+    recs: list[str] = []
+
+    last_with_ptp = None
+    for t in reversed(report.trials):
+        if t.ptp_offset_end:
+            last_with_ptp = t
+            break
+
+    if last_with_ptp is None:
+        return insights, recs
+
+    offsets_ns = last_with_ptp.ptp_offset_end
+    cameras = sorted(offsets_ns.keys(), key=lambda c: offsets_ns[c])
+    if len(cameras) < 2:
+        return insights, recs
+
+    offsets_us = {cam: offsets_ns[cam] / 1000.0 for cam in cameras}
+
+    groups: list[list[str]] = []
+    current_group = [cameras[0]]
+    for i in range(1, len(cameras)):
+        if (
+            abs(offsets_us[cameras[i]] - offsets_us[cameras[i - 1]])
+            <= PTP_CLUSTER_WITHIN_US
+        ):
+            current_group.append(cameras[i])
+        else:
+            groups.append(current_group)
+            current_group = [cameras[i]]
+    groups.append(current_group)
+
+    for group in groups:
+        if len(group) < 2:
+            continue
+        mean_offset = sum(offsets_us[c] for c in group) / len(group)
+        if abs(mean_offset) < PTP_CLUSTER_MIN_OFFSET_US:
+            continue
+        cam_set = "{" + ", ".join(sorted(group)) + "}"
+        insights.append(
+            f"PTP cluster detected: cameras {cam_set} share similar offsets "
+            f"(~{mean_offset / 1000:.1f}ms from reference), suggesting a shared network segment."
+        )
+        recs.append(
+            f"Cameras {cam_set} are likely on a separate network switch from the reference camera. "
+            f"Try connecting all cameras to the same switch, or contact network admin."
+        )
+
+    return insights, recs
+
+
+def _detect_ptp_convergence(
+    report: SessionSyncReport, warmup_indices: list[int]
+) -> tuple[list[str], list[str]]:
+    """Detector 20: Detect PTP offsets converging across the session."""
+    insights: list[str] = []
+    recs: list[str] = []
+
+    trials_with_ptp = [
+        t
+        for t in report.trials
+        if t.ptp_offset_end and t.trial_index not in warmup_indices
+    ]
+    if len(trials_with_ptp) < PTP_CONVERGENCE_MIN_TRIALS:
+        return insights, recs
+
+    def _mean_abs_offset_us(t: TrialSyncMetrics) -> float:
+        offsets = t.ptp_offset_end
+        ref = t.reference_camera
+        non_ref = [cam for cam in offsets if cam != ref]
+        if not non_ref:
+            return 0.0
+        return sum(abs(offsets[cam]) / 1000.0 for cam in non_ref) / len(non_ref)
+
+    first_mean = _mean_abs_offset_us(trials_with_ptp[0])
+    last_mean = _mean_abs_offset_us(trials_with_ptp[-1])
+
+    if last_mean <= 0 or first_mean / last_mean < PTP_CONVERGENCE_RATIO:
+        return insights, recs
+
+    first_idx = trials_with_ptp[0].trial_index
+    last_idx = trials_with_ptp[-1].trial_index
+    insights.append(
+        f"PTP offsets converging across session "
+        f"(Trial {first_idx}: {first_mean / 1000:.1f}ms avg → "
+        f"Trial {last_idx}: {last_mean / 1000:.2f}ms avg). "
+        f"System was not fully converged when recording started."
+    )
+    recs.append(
+        "Wait longer after camera startup for PTP to converge, "
+        "or run `make validate-sync` before recording."
+    )
+
+    return insights, recs
+
+
+def diagnose_session_issues(report: SessionSyncReport) -> tuple[list[str], list[str]]:
+    """Run session-level root cause detectors and return (insights, recommendations)."""
+    all_insights: list[str] = []
+    all_recs: list[str] = []
+
+    warmup_insights, warmup_recs, warmup_indices = _detect_warmup(report)
+    all_insights.extend(warmup_insights)
+    all_recs.extend(warmup_recs)
+
+    for detector in [
+        _detect_frame_count_anomaly,
+    ]:
+        ins, rec = detector(report)
+        all_insights.extend(ins)
+        all_recs.extend(rec)
+
+    ptp_cluster_ins, ptp_cluster_recs = _detect_ptp_clusters(report)
+    all_insights.extend(ptp_cluster_ins)
+    all_recs.extend(ptp_cluster_recs)
+
+    convergence_ins, convergence_recs = _detect_ptp_convergence(report, warmup_indices)
+    all_insights.extend(convergence_ins)
+    all_recs.extend(convergence_recs)
+
+    return all_insights, all_recs
 
 
 def _build_trial_boundary_shapes(

--- a/multi_camera/acquisition/health.py
+++ b/multi_camera/acquisition/health.py
@@ -1,0 +1,1367 @@
+"""Live health checks for the acquisition system.
+
+Quick, one-shot checks that can run between recordings or be polled by an
+operator-facing client (phone app, React GUI). Narrow scope: DHCP server
+status and camera reachability. Per-trial / per-session sync analysis lives in
+``diagnostics/json_parser.py``; continuous NIC/CPU/disk sampling during
+recording lives in ``diagnostics/system_monitor.py``.
+
+All I/O-doing helpers accept injectable runners/paths so the module
+unit-tests without hardware or a live DHCP server.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import datetime
+import ipaddress
+import logging
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Callable, Literal, Protocol
+
+from pydantic import BaseModel, ConfigDict, Field
+
+Severity = Literal["ok", "warn", "error", "unknown"]
+
+_SEVERITY_ORDER: dict[Severity, int] = {"unknown": 0, "ok": 1, "warn": 2, "error": 3}
+
+
+def max_severity(levels: list[Severity]) -> Severity:
+    """Return the worst severity in the list. Empty list returns ``"ok"``."""
+    if not levels:
+        return "ok"
+    return max(levels, key=lambda s: _SEVERITY_ORDER[s])
+
+
+class Finding(BaseModel):
+    """A single plain-English health observation for display to the operator."""
+
+    level: Severity
+    code: str
+    message: str
+    details: dict[str, Any] = Field(default_factory=dict)
+
+
+class DhcpServerStatus(BaseModel):
+    applicable: bool
+    service_active: bool | None = None
+    lease_file_path: str | None = None
+    lease_count: int = 0
+    interface_ip: str | None = None
+    findings: list[Finding] = Field(default_factory=list)
+
+    @property
+    def severity(self) -> Severity:
+        return max_severity([f.level for f in self.findings])
+
+
+class CameraReachability(BaseModel):
+    serial: str
+    detected: bool
+    expected: bool
+    ip: str | None = None
+    link_speed_mbps: int | None = None
+    locked_by_other_process: bool = False
+    last_error: str | None = None
+
+
+class CameraReachabilityReport(BaseModel):
+    expected: list[str]
+    detected: list[str]
+    missing: list[str]
+    extra: list[str]
+    cameras: list[CameraReachability]
+    enumerated: bool
+    findings: list[Finding] = Field(default_factory=list)
+
+    @property
+    def severity(self) -> Severity:
+        return max_severity([f.level for f in self.findings])
+
+
+class HostNetworkStatus(BaseModel):
+    """Host-side network configuration the cameras depend on."""
+
+    interface: str
+    interface_present: bool
+    carrier_up: bool | None = None
+    mtu: int | None = None
+    expected_mtu: int = 9000
+    rmem_max: int | None = None
+    expected_rmem_max: int = 10_000_000
+    findings: list[Finding] = Field(default_factory=list)
+
+    @property
+    def severity(self) -> Severity:
+        return max_severity([f.level for f in self.findings])
+
+
+class HealthCheckReport(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    generated_at: datetime.datetime
+    deployment_mode: Literal["laptop", "network"]
+    overall: Severity
+    dhcp: DhcpServerStatus
+    cameras: CameraReachabilityReport
+    host_network: HostNetworkStatus
+    recording_state: str
+    findings: list[Finding]
+
+
+class HealthConfig(BaseModel):
+    """Tunable thresholds and paths. Load with :func:`HealthConfig.from_env`."""
+
+    deployment_mode: Literal["laptop", "network"] = "laptop"
+    network_interface: str = "enp5s0"
+    dhcp_lease_file: Path = Path("/var/lib/dhcp/dhcpd.leases")
+    dhcp_expected_interface_ip: str = "192.168.1.1"
+    cache_ttl_s: float = 2.0
+    dhcp_timeout_s: float = 1.0
+    # 8s absorbs PySpin GigE-broadcast enumeration on a populated network-mode
+    # subnet; the fast path (recorder already holds handles) returns in <1s.
+    camera_timeout_s: float = 8.0
+    host_network_timeout_s: float = 1.0
+    total_timeout_s: float = 10.0
+    idle_poll_s: float = 30.0
+    inter_trial_health_check: bool = True
+    preflight_camera_check: bool = True
+    minimum_link_speed_mbps: int = 1000
+
+    @classmethod
+    def from_env(cls, env: dict[str, str] | None = None) -> "HealthConfig":
+        """Populate from environment variables. Unknown/missing vars fall back to defaults.
+
+        Recognized env vars: DEPLOYMENT_MODE, NETWORK_INTERFACE, DHCP_LEASE_FILE,
+        DHCP_EXPECTED_INTERFACE_IP, HEALTH_IDLE_POLL_S, HEALTH_CACHE_TTL_S.
+        """
+        env = env if env is not None else dict(os.environ)
+        kwargs: dict[str, Any] = {}
+
+        mode = env.get("DEPLOYMENT_MODE", "").strip().lower()
+        if mode in ("laptop", "network"):
+            kwargs["deployment_mode"] = mode
+
+        iface = env.get("NETWORK_INTERFACE", "").strip()
+        if iface:
+            kwargs["network_interface"] = iface
+
+        lease_file = env.get("DHCP_LEASE_FILE", "").strip()
+        if lease_file:
+            kwargs["dhcp_lease_file"] = Path(lease_file)
+
+        expected_ip = env.get("DHCP_EXPECTED_INTERFACE_IP", "").strip()
+        if expected_ip:
+            kwargs["dhcp_expected_interface_ip"] = expected_ip
+
+        for key, env_name, caster in [
+            ("idle_poll_s", "HEALTH_IDLE_POLL_S", float),
+            ("cache_ttl_s", "HEALTH_CACHE_TTL_S", float),
+        ]:
+            raw = env.get(env_name, "").strip()
+            if raw:
+                try:
+                    kwargs[key] = caster(raw)
+                except ValueError:
+                    pass
+
+        return cls(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# DHCP server check
+# ---------------------------------------------------------------------------
+
+SystemctlRunner = Callable[[str], tuple[str, int]]
+IpAddrRunner = Callable[[str], str]
+
+
+def _default_systemctl_runner(service: str, timeout_s: float = 1.0) -> tuple[str, int]:
+    result = subprocess.run(
+        ["systemctl", "is-active", service],
+        capture_output=True,
+        text=True,
+        timeout=timeout_s,
+    )
+    return result.stdout.strip(), result.returncode
+
+
+def _default_ip_addr_runner(interface: str, timeout_s: float = 1.0) -> str:
+    result = subprocess.run(
+        ["ip", "-4", "addr", "show", interface],
+        capture_output=True,
+        text=True,
+        timeout=timeout_s,
+    )
+    return result.stdout
+
+
+def _parse_interface_ipv4(ip_addr_output: str) -> str | None:
+    """Extract the first IPv4 address from `ip -4 addr show` output."""
+    match = re.search(r"inet\s+(\d+\.\d+\.\d+\.\d+)", ip_addr_output)
+    return match.group(1) if match else None
+
+
+def _parse_lease_file(lease_file_text: str, now: datetime.datetime) -> int:
+    """Count non-expired, non-abandoned DHCP leases in an isc-dhcp-server lease file.
+
+    The format (one block per lease)::
+
+        lease 192.168.1.50 {
+          starts N 2026/04/22 12:34:56;
+          ends N 2026/04/22 14:34:56;
+          ...
+          abandoned;    # optional
+        }
+    """
+    count = 0
+    for block in re.finditer(
+        r"lease\s+\d+\.\d+\.\d+\.\d+\s*\{(.*?)\}", lease_file_text, re.DOTALL
+    ):
+        body = block.group(1)
+        if "abandoned" in body:
+            continue
+        ends_match = re.search(
+            r"ends\s+\d+\s+(\d{4})/(\d{1,2})/(\d{1,2})\s+(\d{1,2}):(\d{1,2}):(\d{1,2})",
+            body,
+        )
+        if ends_match is None:
+            # Malformed or lease with "never" expiration: count it.
+            if re.search(r"ends\s+never", body):
+                count += 1
+            continue
+        year, month, day, hour, minute, second = (int(g) for g in ends_match.groups())
+        try:
+            ends = datetime.datetime(
+                year, month, day, hour, minute, second, tzinfo=datetime.timezone.utc
+            )
+        except ValueError:
+            continue
+        if ends > now:
+            count += 1
+    return count
+
+
+def check_dhcp_server(
+    mode: Literal["laptop", "network"],
+    lease_file: Path = Path("/var/lib/dhcp/dhcpd.leases"),
+    interface: str | None = None,
+    expected_interface_ip: str = "192.168.1.1",
+    systemctl_runner: SystemctlRunner = _default_systemctl_runner,
+    ip_addr_runner: IpAddrRunner = _default_ip_addr_runner,
+    now: datetime.datetime | None = None,
+) -> DhcpServerStatus:
+    """Check the DHCP server and interface state the cameras depend on.
+
+    In ``network`` mode the upstream lab infrastructure manages DHCP so this
+    check short-circuits and returns ``applicable=False``.
+    """
+    findings: list[Finding] = []
+
+    if mode == "network":
+        findings.append(
+            Finding(
+                level="ok",
+                code="dhcp_not_applicable",
+                message="Running in network mode — DHCP is managed upstream.",
+            )
+        )
+        return DhcpServerStatus(
+            applicable=False,
+            lease_file_path=str(lease_file),
+            findings=findings,
+        )
+
+    service_active: bool | None = None
+    try:
+        stdout, returncode = systemctl_runner("isc-dhcp-server")
+        service_active = stdout == "active" and returncode == 0
+        if not service_active:
+            findings.append(
+                Finding(
+                    level="error",
+                    code="dhcp_service_down",
+                    message=(
+                        "The camera IP server is not running. "
+                        "Run: sudo systemctl start isc-dhcp-server"
+                    ),
+                    details={"systemctl_output": stdout, "returncode": returncode},
+                )
+            )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
+        findings.append(
+            Finding(
+                level="warn",
+                code="dhcp_service_check_failed",
+                message="Could not check DHCP server status.",
+                details={"error": str(e)},
+            )
+        )
+
+    interface_ip: str | None = None
+    if interface:
+        try:
+            output = ip_addr_runner(interface)
+            interface_ip = _parse_interface_ipv4(output)
+            if interface_ip is None:
+                findings.append(
+                    Finding(
+                        level="error",
+                        code="dhcp_interface_no_ip",
+                        message=f"Network interface {interface} has no IPv4 address.",
+                    )
+                )
+            elif interface_ip != expected_interface_ip:
+                findings.append(
+                    Finding(
+                        level="warn",
+                        code="dhcp_interface_ip_unexpected",
+                        message=(
+                            f"Network interface {interface} has IP {interface_ip} "
+                            f"(expected {expected_interface_ip})."
+                        ),
+                        details={
+                            "actual": interface_ip,
+                            "expected": expected_interface_ip,
+                        },
+                    )
+                )
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
+            findings.append(
+                Finding(
+                    level="warn",
+                    code="dhcp_interface_check_failed",
+                    message=f"Could not read interface {interface}.",
+                    details={"error": str(e)},
+                )
+            )
+
+    lease_count = 0
+    if lease_file.exists():
+        try:
+            text = lease_file.read_text()
+            lease_count = _parse_lease_file(
+                text, now or datetime.datetime.now(datetime.timezone.utc)
+            )
+            if service_active and lease_count == 0:
+                findings.append(
+                    Finding(
+                        level="warn",
+                        code="dhcp_no_leases",
+                        message=(
+                            "DHCP server is running but no cameras have leases. "
+                            "Cameras may be unplugged or still booting."
+                        ),
+                    )
+                )
+        except OSError as e:
+            findings.append(
+                Finding(
+                    level="warn",
+                    code="dhcp_lease_file_unreadable",
+                    message=f"Could not read DHCP lease file at {lease_file}.",
+                    details={"error": str(e)},
+                )
+            )
+    else:
+        # Missing lease file is not necessarily an error: server may not have issued leases yet.
+        findings.append(
+            Finding(
+                level="warn",
+                code="dhcp_lease_file_missing",
+                message=f"DHCP lease file not found at {lease_file}.",
+            )
+        )
+
+    if not findings:
+        findings.append(
+            Finding(level="ok", code="dhcp_ok", message="DHCP server is healthy.")
+        )
+
+    return DhcpServerStatus(
+        applicable=True,
+        service_active=service_active,
+        lease_file_path=str(lease_file),
+        lease_count=lease_count,
+        interface_ip=interface_ip,
+        findings=findings,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Camera reachability check
+# ---------------------------------------------------------------------------
+
+
+class DetectedCamera(BaseModel):
+    """Minimal snapshot of a camera seen by PySpin or a held recorder handle."""
+
+    serial: str
+    ip: str | None = None
+    link_speed_mbps: int | None = None
+
+
+class RecorderLike(Protocol):
+    cams: list[Any]
+
+
+def _read_camera_attribute(cam: Any, attr: str) -> Any:
+    """Safely read a PySpin attribute from a ``simple_pyspin.Camera`` handle."""
+    try:
+        value = getattr(cam, attr)
+        if callable(value):
+            return value()
+        return value
+    except Exception:  # noqa: BLE001 — PySpin raises many custom exceptions
+        return None
+
+
+def _snapshot_from_recorder(cam: Any) -> DetectedCamera | None:
+    """Build a DetectedCamera from a ``simple_pyspin.Camera`` handle already held open
+    by a running FlirRecorder. Read-only attribute access; safe while recording."""
+    serial = _read_camera_attribute(cam, "DeviceSerialNumber")
+    if not serial:
+        return None
+    ip_int = _read_camera_attribute(cam, "GevCurrentIPAddress")
+    ip = _int_to_ipv4(ip_int) if isinstance(ip_int, int) else None
+    link_speed = _read_camera_attribute(cam, "GevLinkSpeed")
+    link_mbps = (
+        int(link_speed) // 1_000_000
+        if isinstance(link_speed, int) and link_speed > 0
+        else None
+    )
+    return DetectedCamera(serial=str(serial), ip=ip, link_speed_mbps=link_mbps)
+
+
+def _int_to_ipv4(value: int) -> str | None:
+    try:
+        return str(ipaddress.IPv4Address(value))
+    except (ValueError, ipaddress.AddressValueError):
+        return None
+
+
+CameraEnumerator = Callable[[], list[DetectedCamera]]
+
+
+def _default_camera_enumerator() -> list[DetectedCamera]:
+    """Enumerate cameras via PySpin without initializing them.
+
+    Read-only: opens the transport-layer node map for each GigE device, reads
+    ``DeviceSerialNumber`` / ``GevDeviceIPAddress`` / ``GevDeviceLinkSpeed``,
+    and returns a list. Never calls ``Camera.init()`` or any mutating operation.
+
+    Importing PySpin requires the Spinnaker SDK; this function is only called
+    from code paths that also depend on PySpin, so lazy import is fine.
+    """
+    try:
+        import PySpin  # type: ignore[import-untyped]
+    except ImportError:
+        return []
+
+    detected: list[DetectedCamera] = []
+    system = PySpin.System.GetInstance()
+    try:
+        cam_list = system.GetCameras()
+        try:
+            for i in range(cam_list.GetSize()):
+                cam = cam_list.GetByIndex(i)
+                try:
+                    tl_node_map = cam.GetTLDeviceNodeMap()
+                    serial = _read_tl_string(tl_node_map, "DeviceSerialNumber")
+                    if not serial:
+                        continue
+                    ip_int = _read_tl_int(tl_node_map, "GevDeviceIPAddress")
+                    link_speed = _read_tl_int(tl_node_map, "GevDeviceLinkSpeed")
+                    detected.append(
+                        DetectedCamera(
+                            serial=serial,
+                            ip=_int_to_ipv4(ip_int) if ip_int is not None else None,
+                            link_speed_mbps=(
+                                link_speed // 1_000_000
+                                if link_speed is not None and link_speed > 0
+                                else None
+                            ),
+                        )
+                    )
+                finally:
+                    del cam
+        finally:
+            cam_list.Clear()
+    finally:
+        # Don't release the system — simple_pyspin caches a singleton instance.
+        pass
+
+    return detected
+
+
+def _read_tl_string(node_map: Any, name: str) -> str | None:
+    try:
+        import PySpin  # type: ignore[import-untyped]
+
+        node = PySpin.CStringPtr(node_map.GetNode(name))
+        if PySpin.IsAvailable(node) and PySpin.IsReadable(node):
+            return node.GetValue()
+    except Exception:  # noqa: BLE001
+        return None
+    return None
+
+
+def _read_tl_int(node_map: Any, name: str) -> int | None:
+    try:
+        import PySpin  # type: ignore[import-untyped]
+
+        node = PySpin.CIntegerPtr(node_map.GetNode(name))
+        if PySpin.IsAvailable(node) and PySpin.IsReadable(node):
+            return int(node.GetValue())
+    except Exception:  # noqa: BLE001
+        return None
+    return None
+
+
+def check_camera_reachability(
+    expected_serials: list[str],
+    recorder: RecorderLike | None = None,
+    minimum_link_speed_mbps: int = 1000,
+    include_unexpected: bool = False,
+    enumerator: CameraEnumerator = _default_camera_enumerator,
+) -> CameraReachabilityReport:
+    """Report which expected cameras are reachable right now.
+
+    - If ``recorder`` has open camera handles, read serials / IP / link speed
+      directly off those handles — no new enumeration, no lock contention,
+      safe during recording.
+    - Otherwise, enumerate via PySpin transport-layer nodes (read-only; never
+      calls ``Camera.init()``).
+    - If neither the recorder has cams nor any expected serials are known,
+      short-circuit: PySpin discovery in that state produces no useful signal
+      and can be slow (GigE broadcast in network mode).
+    """
+    expected = [str(s) for s in expected_serials]
+    recorder_has_cams = recorder is not None and bool(getattr(recorder, "cams", None))
+
+    if not recorder_has_cams and not expected:
+        return CameraReachabilityReport(
+            expected=[],
+            detected=[],
+            missing=[],
+            extra=[],
+            cameras=[],
+            enumerated=False,
+            findings=[
+                Finding(
+                    level="ok",
+                    code="cameras_not_configured",
+                    message=(
+                        "No camera config loaded — select a config to enable "
+                        "camera reachability checks."
+                    ),
+                )
+            ],
+        )
+
+    detected_cams: list[DetectedCamera] = []
+    enumerated_fresh = True
+    if recorder_has_cams:
+        enumerated_fresh = False
+        for cam in recorder.cams:
+            snapshot = _snapshot_from_recorder(cam)
+            if snapshot is not None:
+                detected_cams.append(snapshot)
+    else:
+        try:
+            detected_cams = enumerator()
+        except Exception as e:  # noqa: BLE001 — PySpin raises custom exceptions
+            return CameraReachabilityReport(
+                expected=expected,
+                detected=[],
+                missing=expected,
+                extra=[],
+                cameras=[
+                    CameraReachability(
+                        serial=s, detected=False, expected=True, last_error=str(e)
+                    )
+                    for s in expected
+                ],
+                enumerated=True,
+                findings=[
+                    Finding(
+                        level="error",
+                        code="camera_enumeration_failed",
+                        message="Could not enumerate cameras via PySpin.",
+                        details={"error": str(e)},
+                    )
+                ],
+            )
+
+    detected_by_serial = {c.serial: c for c in detected_cams}
+    detected_serials = sorted(detected_by_serial.keys())
+    expected_set = set(expected)
+    detected_set = set(detected_serials)
+    missing = sorted(expected_set - detected_set)
+    extra = sorted(detected_set - expected_set)
+
+    cameras: list[CameraReachability] = []
+    for serial in sorted(expected_set | detected_set):
+        cam = detected_by_serial.get(serial)
+        cameras.append(
+            CameraReachability(
+                serial=serial,
+                detected=cam is not None,
+                expected=serial in expected_set,
+                ip=cam.ip if cam else None,
+                link_speed_mbps=cam.link_speed_mbps if cam else None,
+            )
+        )
+
+    findings: list[Finding] = []
+    for serial in missing:
+        findings.append(
+            Finding(
+                level="error",
+                code="camera_unreachable",
+                message=f"Camera {serial} is not reachable. Check its ethernet cable and power.",
+                details={"serial": serial},
+            )
+        )
+
+    # When some expected cameras are missing, confirm which ones ARE working
+    # so the operator can distinguish per-camera issues from a system-wide one.
+    # When all expected are reachable, fall through to the summary at the end.
+    expected_detected = [c for c in cameras if c.detected and c.expected]
+    if missing and expected_detected:
+        for cam_info in expected_detected:
+            speed_str = (
+                f" at {cam_info.link_speed_mbps} Mbps"
+                if cam_info.link_speed_mbps is not None
+                else ""
+            )
+            findings.append(
+                Finding(
+                    level="ok",
+                    code="camera_reachable",
+                    message=f"Camera {cam_info.serial} is reachable{speed_str}.",
+                    details={
+                        "serial": cam_info.serial,
+                        "ip": cam_info.ip,
+                        "link_speed_mbps": cam_info.link_speed_mbps,
+                    },
+                )
+            )
+
+    # Hidden by default: in network mode the subnet is shared with other lab
+    # setups, so detected-but-unexpected cameras are routine, not actionable.
+    if include_unexpected:
+        for serial in extra:
+            findings.append(
+                Finding(
+                    level="ok",
+                    code="unexpected_camera",
+                    message=f"Camera {serial} is on the network but not in the current config.",
+                    details={"serial": serial},
+                )
+            )
+
+    for cam_info in cameras:
+        if cam_info.detected and cam_info.link_speed_mbps is not None:
+            if cam_info.link_speed_mbps < minimum_link_speed_mbps:
+                findings.append(
+                    Finding(
+                        level="warn",
+                        code="camera_link_speed_low",
+                        message=(
+                            f"Camera {cam_info.serial} is negotiated at "
+                            f"{cam_info.link_speed_mbps} Mbps "
+                            f"(expected ≥{minimum_link_speed_mbps}). Check cable/switch."
+                        ),
+                        details={
+                            "serial": cam_info.serial,
+                            "link_speed_mbps": cam_info.link_speed_mbps,
+                        },
+                    )
+                )
+
+    if not missing and expected:
+        findings.append(
+            Finding(
+                level="ok",
+                code="cameras_ok",
+                message=f"All {len(expected)} expected cameras are reachable.",
+            )
+        )
+
+    if not findings:
+        findings.append(
+            Finding(
+                level="ok",
+                code="cameras_ok",
+                message="Camera reachability check complete.",
+            )
+        )
+
+    return CameraReachabilityReport(
+        expected=expected,
+        detected=detected_serials,
+        missing=missing,
+        extra=extra,
+        cameras=cameras,
+        enumerated=enumerated_fresh,
+        findings=findings,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Host-network check
+# ---------------------------------------------------------------------------
+
+
+def _read_link_state(interface: str, timeout_s: float = 1.0) -> dict[str, Any]:
+    """Read interface presence, carrier state, and MTU from /sys/class/net.
+
+    Sysfs reads avoid the iproute2 dependency. With ``network_mode: host`` the
+    container's /sys/class/net is the host's. ``timeout_s`` is unused but kept
+    so integration tests can monkeypatch with the same signature.
+    """
+    base = Path("/sys/class/net") / interface
+    if not base.exists():
+        return {"present": False, "carrier": None, "mtu": None}
+
+    mtu: int | None = None
+    try:
+        mtu = int((base / "mtu").read_text().strip())
+    except (OSError, ValueError):
+        pass
+
+    carrier: bool | None = None
+    try:
+        carrier = (base / "carrier").read_text().strip() == "1"
+    except OSError:
+        # /sys/class/net/<iface>/carrier is unreadable when the interface is
+        # administratively DOWN — for our purposes that's "no carrier."
+        carrier = False
+
+    return {"present": True, "carrier": carrier, "mtu": mtu}
+
+
+def _read_sysctl_int(key: str, timeout_s: float = 1.0) -> int | None:
+    """Read a sysctl integer from /proc/sys directly.
+
+    Translates dot-separated keys (e.g. ``net.core.rmem_max``) to procfs paths
+    (``/proc/sys/net/core/rmem_max``). Avoids the ``sysctl`` binary dependency.
+    """
+    path = Path("/proc/sys") / key.replace(".", "/")
+    try:
+        return int(path.read_text().strip())
+    except (OSError, ValueError):
+        return None
+
+
+def check_host_network(
+    interface: str,
+    expected_mtu: int = 9000,
+    expected_rmem_max: int = 10_000_000,
+) -> HostNetworkStatus:
+    """Verify the interface exists, has carrier, jumbo MTU, and adequate rmem_max."""
+    findings: list[Finding] = []
+
+    link = _read_link_state(interface)
+    interface_present = bool(link.get("present"))
+    carrier = link.get("carrier")
+    mtu = link.get("mtu")
+
+    if not interface_present:
+        findings.append(
+            Finding(
+                level="error",
+                code="host_iface_missing",
+                message=(
+                    f"Network interface {interface} not found. Plug the camera-network "
+                    "ethernet adapter into the laptop, or check NETWORK_INTERFACE in .env."
+                ),
+                details={"interface": interface},
+            )
+        )
+    else:
+        if carrier is False:
+            findings.append(
+                Finding(
+                    level="error",
+                    code="host_iface_no_carrier",
+                    message=(
+                        f"Network interface {interface} has no link. Check the ethernet "
+                        "cable from the laptop to the network switch, and verify the switch "
+                        "is powered on."
+                    ),
+                    details={"interface": interface},
+                )
+            )
+        if mtu is not None and mtu != expected_mtu:
+            findings.append(
+                Finding(
+                    level="error",
+                    code="host_iface_mtu_mismatch",
+                    message=(
+                        f"Network interface {interface} MTU is {mtu}, expected "
+                        f"{expected_mtu}. Run: sudo ip link set {interface} mtu "
+                        f"{expected_mtu}"
+                    ),
+                    details={
+                        "interface": interface,
+                        "actual": mtu,
+                        "expected": expected_mtu,
+                    },
+                )
+            )
+
+    rmem_max = _read_sysctl_int("net.core.rmem_max")
+    if rmem_max is None:
+        findings.append(
+            Finding(
+                level="warn",
+                code="host_rmem_unreadable",
+                message="Could not read net.core.rmem_max — skipping buffer-size check.",
+            )
+        )
+    elif rmem_max < expected_rmem_max:
+        findings.append(
+            Finding(
+                level="error",
+                code="host_rmem_too_low",
+                message=(
+                    f"Network receive buffer (net.core.rmem_max) is {rmem_max:,} bytes, "
+                    f"expected at least {expected_rmem_max:,}. Run: "
+                    f"sudo sysctl -w net.core.rmem_max={expected_rmem_max}"
+                ),
+                details={"actual": rmem_max, "expected": expected_rmem_max},
+            )
+        )
+
+    if not findings:
+        findings.append(
+            Finding(
+                level="ok",
+                code="host_network_ok",
+                message=(
+                    f"Host network is configured correctly "
+                    f"(MTU {mtu}, rmem_max {rmem_max:,})."
+                ),
+            )
+        )
+
+    return HostNetworkStatus(
+        interface=interface,
+        interface_present=interface_present,
+        carrier_up=carrier,
+        mtu=mtu,
+        expected_mtu=expected_mtu,
+        rmem_max=rmem_max,
+        expected_rmem_max=expected_rmem_max,
+        findings=findings,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+
+def run_health_check(
+    config: HealthConfig,
+    expected_serials: list[str],
+    recorder: RecorderLike | None = None,
+    recording_state: str = "Idle",
+    include_unexpected_cameras: bool = False,
+    dhcp_runner: SystemctlRunner | None = None,
+    ip_addr_runner: IpAddrRunner | None = None,
+    camera_enumerator: CameraEnumerator | None = None,
+    now: datetime.datetime | None = None,
+) -> HealthCheckReport:
+    """Run DHCP + camera-reachability + host-network checks concurrently.
+
+    ``include_unexpected_cameras`` controls whether cameras detected on the
+    network but not in the current config emit findings. Default False — in
+    network-mode deployments other lab setups share the subnet and produce
+    routine "extras" that aren't actionable. Operators can opt in via the
+    CLI's ``--show-all-cameras`` flag.
+    """
+    now = now or datetime.datetime.now(datetime.timezone.utc)
+
+    # Do NOT use `with ThreadPoolExecutor(...)`: the context manager waits for
+    # all submitted tasks to finish before exiting, so a hung PySpin call
+    # would block the HTTP response even after we've already given up on the
+    # future via future.result(timeout=...). Use an explicit non-waiting
+    # shutdown so we return as soon as the per-check timeouts fire.
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=3)
+    try:
+        dhcp_future = executor.submit(
+            check_dhcp_server,
+            mode=config.deployment_mode,
+            lease_file=config.dhcp_lease_file,
+            interface=config.network_interface,
+            expected_interface_ip=config.dhcp_expected_interface_ip,
+            systemctl_runner=dhcp_runner or _default_systemctl_runner,
+            ip_addr_runner=ip_addr_runner or _default_ip_addr_runner,
+            now=now,
+        )
+        camera_future = executor.submit(
+            check_camera_reachability,
+            expected_serials=expected_serials,
+            recorder=recorder,
+            minimum_link_speed_mbps=config.minimum_link_speed_mbps,
+            include_unexpected=include_unexpected_cameras,
+            enumerator=camera_enumerator or _default_camera_enumerator,
+        )
+        host_future = executor.submit(
+            check_host_network,
+            interface=config.network_interface,
+        )
+
+        try:
+            dhcp = dhcp_future.result(timeout=config.dhcp_timeout_s)
+        except concurrent.futures.TimeoutError:
+            dhcp = DhcpServerStatus(
+                applicable=config.deployment_mode == "laptop",
+                lease_file_path=str(config.dhcp_lease_file),
+                findings=[
+                    Finding(
+                        level="warn",
+                        code="dhcp_check_timeout",
+                        message=f"DHCP check timed out after {config.dhcp_timeout_s}s.",
+                    )
+                ],
+            )
+
+        try:
+            cameras = camera_future.result(timeout=config.camera_timeout_s)
+        except concurrent.futures.TimeoutError:
+            cameras = CameraReachabilityReport(
+                expected=list(expected_serials),
+                detected=[],
+                missing=list(expected_serials),
+                extra=[],
+                cameras=[],
+                enumerated=recorder is None,
+                findings=[
+                    Finding(
+                        level="warn",
+                        code="camera_check_timeout",
+                        message=(
+                            f"Camera reachability check timed out after "
+                            f"{config.camera_timeout_s}s."
+                        ),
+                    )
+                ],
+            )
+
+        try:
+            host_network = host_future.result(timeout=config.host_network_timeout_s)
+        except concurrent.futures.TimeoutError:
+            host_network = HostNetworkStatus(
+                interface=config.network_interface,
+                interface_present=False,
+                findings=[
+                    Finding(
+                        level="warn",
+                        code="host_network_check_timeout",
+                        message=(
+                            f"Host-network check timed out after "
+                            f"{config.host_network_timeout_s}s."
+                        ),
+                    )
+                ],
+            )
+    finally:
+        executor.shutdown(wait=False)
+
+    all_findings = (
+        list(host_network.findings) + list(dhcp.findings) + list(cameras.findings)
+    )
+    severities = [host_network.severity, dhcp.severity, cameras.severity]
+    overall = max_severity(severities)
+
+    return HealthCheckReport(
+        generated_at=now,
+        deployment_mode=config.deployment_mode,
+        overall=overall,
+        dhcp=dhcp,
+        cameras=cameras,
+        host_network=host_network,
+        recording_state=recording_state,
+        findings=_prioritize_findings(all_findings),
+    )
+
+
+def _prioritize_findings(findings: list[Finding]) -> list[Finding]:
+    """Sort findings by severity (worst first), preserving order within the same level."""
+    return sorted(findings, key=lambda f: -_SEVERITY_ORDER[f.level])
+
+
+class CameraUnreachableError(RuntimeError):
+    """Raised when a preflight reachability check finds expected cameras missing."""
+
+    def __init__(self, missing: list[str], message: str | None = None):
+        self.missing = list(missing)
+        super().__init__(message or f"Cameras unreachable: {', '.join(self.missing)}")
+
+
+# ---------------------------------------------------------------------------
+# Auto-remediation
+# ---------------------------------------------------------------------------
+
+
+class RemediationAttempt(BaseModel):
+    """One attempted fix for a known-remediable finding."""
+
+    code: str
+    success: bool
+    message: str
+    details: dict[str, Any] = Field(default_factory=dict)
+
+
+class RemediationReport(BaseModel):
+    attempts: list[RemediationAttempt] = Field(default_factory=list)
+
+    @property
+    def any_attempted(self) -> bool:
+        return bool(self.attempts)
+
+    @property
+    def all_succeeded(self) -> bool:
+        return all(a.success for a in self.attempts)
+
+
+SudoRunner = Callable[[list[str]], tuple[str, int]]
+
+
+def _default_sudo_runner(args: list[str], timeout_s: float = 5.0) -> tuple[str, int]:
+    """Run a sudo command non-interactively.
+
+    Returns (combined_output, returncode). ``-n`` makes sudo fail rather than
+    prompt for a password — the caller should already have passwordless sudo
+    set up for the specific commands we issue here.
+    """
+    cmd = ["sudo", "-n", *args]
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout_s
+        )
+        return (result.stdout + result.stderr).strip(), result.returncode
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
+        return f"command failed: {e}", -1
+
+
+def run_host_remediation(
+    report: HealthCheckReport,
+    config: HealthConfig,
+    sudo_runner: SudoRunner = _default_sudo_runner,
+) -> RemediationReport:
+    """Try to fix known drift before failing.
+
+    For each remediable finding code in ``report``, dispatches to a handler
+    that issues a single non-interactive sudo command. Handlers do not
+    re-check — the caller should re-run :func:`run_health_check` after this
+    to confirm the drift is resolved.
+
+    Currently remediates:
+      - ``host_iface_mtu_mismatch`` → ``ip link set <iface> mtu <expected>``
+      - ``host_rmem_too_low``       → ``sysctl -w net.core.rmem_max=<expected>``
+      - ``dhcp_service_down``       → ``systemctl start isc-dhcp-server``
+    """
+    attempts: list[RemediationAttempt] = []
+    finding_codes = {f.code for f in report.findings}
+    host = report.host_network
+
+    if "host_iface_mtu_mismatch" in finding_codes:
+        out, rc = sudo_runner(
+            [
+                "ip",
+                "link",
+                "set",
+                config.network_interface,
+                "mtu",
+                str(host.expected_mtu),
+            ]
+        )
+        attempts.append(
+            RemediationAttempt(
+                code="fix_host_iface_mtu",
+                success=(rc == 0),
+                message=(
+                    f"Applied MTU {host.expected_mtu} to {config.network_interface}."
+                    if rc == 0
+                    else f"Failed to apply MTU: {out.splitlines()[0] if out else 'no output'}"
+                ),
+                details={
+                    "interface": config.network_interface,
+                    "output": out,
+                    "returncode": rc,
+                },
+            )
+        )
+
+    if "host_rmem_too_low" in finding_codes:
+        out, rc = sudo_runner(
+            ["sysctl", "-w", f"net.core.rmem_max={host.expected_rmem_max}"]
+        )
+        attempts.append(
+            RemediationAttempt(
+                code="fix_host_rmem_max",
+                success=(rc == 0),
+                message=(
+                    f"Applied net.core.rmem_max={host.expected_rmem_max}."
+                    if rc == 0
+                    else f"Failed to apply sysctl: {out}"
+                ),
+                details={"output": out, "returncode": rc},
+            )
+        )
+
+    if "dhcp_service_down" in finding_codes:
+        out, rc = sudo_runner(["systemctl", "start", "isc-dhcp-server"])
+        attempts.append(
+            RemediationAttempt(
+                code="start_dhcp_service",
+                success=(rc == 0),
+                message=(
+                    "Started isc-dhcp-server."
+                    if rc == 0
+                    else f"Failed to start isc-dhcp-server: {out}"
+                ),
+                details={"output": out, "returncode": rc},
+            )
+        )
+
+    return RemediationReport(attempts=attempts)
+
+
+__all__ = [
+    "CameraEnumerator",
+    "CameraReachability",
+    "CameraReachabilityReport",
+    "CameraUnreachableError",
+    "DetectedCamera",
+    "DhcpServerStatus",
+    "Finding",
+    "HealthCheckReport",
+    "HealthConfig",
+    "HostNetworkStatus",
+    "IpAddrRunner",
+    "RecorderLike",
+    "RemediationAttempt",
+    "RemediationReport",
+    "Severity",
+    "SudoRunner",
+    "SystemctlRunner",
+    "check_camera_reachability",
+    "check_dhcp_server",
+    "check_host_network",
+    "max_severity",
+    "run_health_check",
+    "run_host_remediation",
+]
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _format_finding(f: Finding) -> str:
+    sigil = {"ok": "✓", "warn": "!", "error": "✗", "unknown": "?"}[f.level]
+    return f"  [{sigil}] {f.message}"
+
+
+def _list_camera_configs(configs_dir: Path) -> list[Path]:
+    """Return YAML/YML files under the camera-configs directory, sorted by name."""
+    if not configs_dir.is_dir():
+        return []
+    return sorted(
+        p
+        for p in configs_dir.iterdir()
+        if p.is_file() and p.suffix.lower() in (".yaml", ".yml")
+    )
+
+
+def _serials_from_config(config_path: Path) -> list[str]:
+    """Extract camera serials from a camera-config YAML.
+
+    The expected schema (mirrored elsewhere in the acquisition system)::
+
+        camera-info:
+          "23015083": { lens_info: ... }
+          "23106526": { lens_info: ... }
+    """
+    import yaml
+
+    data = yaml.safe_load(config_path.read_text()) or {}
+    camera_info = data.get("camera-info") or {}
+    return [str(serial) for serial in camera_info.keys()]
+
+
+def _prompt_camera_config(configs_dir: Path) -> list[str]:
+    """Interactive picker. Returns selected serials or [] on opt-out / non-TTY."""
+    if not sys.stdin.isatty():
+        return []
+
+    configs = _list_camera_configs(configs_dir)
+    if not configs:
+        print(f"No camera configs found in {configs_dir} — skipping camera check.")
+        print()
+        return []
+
+    print(f"Camera configs in {configs_dir}:")
+    print("  [0] Skip — don't run camera reachability check  (default)")
+    print("  " + "─" * 58)
+    for i, path in enumerate(configs, start=1):
+        print(f"   {i:>2}. {path.name}")
+    print()
+
+    while True:
+        try:
+            raw = input("Select a config (number, default 0): ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return []
+        if raw == "" or raw == "0":
+            return []
+        try:
+            idx = int(raw)
+        except ValueError:
+            print(f"Not a number: {raw!r}. Try again.")
+            continue
+        if not (1 <= idx <= len(configs)):
+            print(f"Out of range. Pick 0–{len(configs)}.")
+            continue
+        chosen = configs[idx - 1]
+        try:
+            serials = _serials_from_config(chosen)
+        except Exception as e:  # noqa: BLE001 — yaml errors, missing key, etc.
+            print(f"Could not read {chosen.name}: {e}")
+            return []
+        if not serials:
+            print(f"{chosen.name} has no camera-info entries.")
+            return []
+        print(
+            f"Using {chosen.name} ({len(serials)} cameras: "
+            f"{', '.join(serials[:3])}{'...' if len(serials) > 3 else ''})"
+        )
+        print()
+        return serials
+
+
+def _cli_main(argv: list[str] | None = None) -> int:
+    """Operator-facing CLI: ``python -m multi_camera.acquisition.health``.
+
+    Runs a single health check against the host's current state, prints a
+    prioritized findings list, and exits with a code indicating severity:
+
+      0 — OK
+      1 — warnings (transient or non-blocking issues)
+      2 — errors (something the operator should act on)
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="python -m multi_camera.acquisition.health",
+        description="Quick health check for the camera acquisition host.",
+    )
+    parser.add_argument(
+        "--remediate",
+        action="store_true",
+        help="Attempt safe auto-remediation (MTU, rmem_max, isc-dhcp-server) "
+        "for any remediable findings, then re-check and report.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the report as JSON instead of human-readable text "
+        "(also disables the interactive config picker).",
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=None,
+        help="Path to a camera-config YAML to use for the camera-reachability "
+        "check. If omitted, the CLI prompts interactively (see --no-config).",
+    )
+    parser.add_argument(
+        "--no-config",
+        action="store_true",
+        help="Skip the camera-config picker and run the host/DHCP checks only.",
+    )
+    parser.add_argument(
+        "--configs-dir",
+        type=Path,
+        default=Path("/configs"),
+        help="Directory holding camera-config YAMLs (default: /configs, "
+        "matching the docker-compose volume mount).",
+    )
+    parser.add_argument(
+        "--show-all-cameras",
+        action="store_true",
+        help="Also list cameras detected on the network that aren't in the "
+        "selected config. Off by default — in network-mode deployments other "
+        "lab setups produce routine extras that aren't actionable.",
+    )
+    args = parser.parse_args(argv)
+
+    config = HealthConfig.from_env()
+
+    expected_serials: list[str] = []
+    if args.config is not None:
+        try:
+            expected_serials = _serials_from_config(args.config)
+        except Exception as e:  # noqa: BLE001
+            print(f"Could not read {args.config}: {e}", file=sys.stderr)
+            return 2
+    elif not args.no_config and not args.json:
+        expected_serials = _prompt_camera_config(args.configs_dir)
+
+    report = run_health_check(
+        config=config,
+        expected_serials=expected_serials,
+        include_unexpected_cameras=args.show_all_cameras,
+    )
+
+    remediation: RemediationReport | None = None
+    if args.remediate:
+        remediation = run_host_remediation(report=report, config=config)
+        report = run_health_check(
+            config=config,
+            expected_serials=expected_serials,
+            include_unexpected_cameras=args.show_all_cameras,
+        )
+
+    if args.json:
+        import json
+
+        payload: dict[str, Any] = {
+            "report": report.model_dump(mode="json"),
+        }
+        if remediation is not None:
+            payload["remediation"] = remediation.model_dump(mode="json")
+        print(json.dumps(payload, indent=2, default=str))
+    else:
+        print(f"Acquisition host health — overall: {report.overall.upper()}")
+        print(f"Deployment mode: {config.deployment_mode}")
+        print(f"Network interface: {config.network_interface}")
+        if remediation is not None and remediation.any_attempted:
+            print()
+            print("Remediation:")
+            for attempt in remediation.attempts:
+                sigil = "✓" if attempt.success else "✗"
+                print(f"  [{sigil}] {attempt.message}")
+        print()
+        print("Findings:")
+        for finding in report.findings:
+            print(_format_finding(finding))
+
+    severity_to_exit = {"ok": 0, "unknown": 0, "warn": 1, "error": 2}
+    return severity_to_exit[report.overall]
+
+
+if __name__ == "__main__":  # pragma: no cover — exercised via subprocess
+    sys.exit(_cli_main(sys.argv[1:]))

--- a/multi_camera/backend/fastapi.py
+++ b/multi_camera/backend/fastapi.py
@@ -267,7 +267,9 @@ app.add_middleware(
 
 @app.get("/")
 async def read_root(request: Request):
-    return templates.TemplateResponse("index.html", context={"request": request})
+    # Newer Starlette versions require ``request`` as a positional/named arg
+    # on TemplateResponse, not as a field in ``context``. Pass it explicitly.
+    return templates.TemplateResponse(request=request, name="index.html")
 
 
 class NewTrialData(BaseModel):
@@ -514,13 +516,10 @@ async def new_trial(data: NewTrialData, db: Session = Depends(db_dependency)):
     config = await get_current_config()
 
     def task_done_callback(task):
-        print("Task completed.")
-        # You can retrieve the result (or exception) of the task using `result()` method.
         try:
             result = task.result()
-            print(f"Task result: {result}")
 
-            # The result now contains a list of all the recordings after acquisition was started
+            # The result contains a list of all the recordings after acquisition was started
             for record in result:
                 add_recording(
                     db,
@@ -534,7 +533,7 @@ async def new_trial(data: NewTrialData, db: Session = Depends(db_dependency)):
                     timestamp_spread=record["timestamp_spread"],
                 )
         except Exception as e:
-            print(f"Task raised an exception: {e}")
+            acquisition_logger.error(f"Trial failed: {e}", exc_info=True)
 
     task.add_done_callback(task_done_callback)
 

--- a/scripts/acquisition/acquisition_diagnostics.sh
+++ b/scripts/acquisition/acquisition_diagnostics.sh
@@ -14,6 +14,12 @@
 # on the Ubuntu laptop used for acquisition (HOST system, not inside container)
 ################################################################################
 
+# Anchor all cwd-relative paths (.env, ./diagnostics_output) to the repo root
+# so this script runs correctly from any directory.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$REPO_ROOT"
+
 # Parse command line arguments
 VERBOSE=false
 QUICK=false

--- a/scripts/acquisition/make_settings_persistent.sh
+++ b/scripts/acquisition/make_settings_persistent.sh
@@ -53,7 +53,7 @@ if [ "$DEPLOYMENT_MODE" = "laptop" ]; then
     # In laptop mode, modify the DHCP-Server connection profile
     if nmcli con show DHCP-Server &>/dev/null; then
         nmcli con modify DHCP-Server ethernet.mtu 9000
-        echo -e "${GREEN}✓${NC} MTU set to 9000 on DHCP-Server connection"
+        echo -e "${GREEN}✓${NC} MTU set to 9000 on DHCP-Server connection (persistent)"
     else
         echo -e "${RED}Error: DHCP-Server connection profile not found${NC}"
         echo "Please complete DHCP setup before running this script."
@@ -64,11 +64,21 @@ else
     ACTIVE_CON=$(nmcli -t -f NAME,DEVICE con show --active | grep "$NETWORK_INTERFACE" | cut -d: -f1)
     if [ -n "$ACTIVE_CON" ]; then
         nmcli con modify "$ACTIVE_CON" ethernet.mtu 9000
-        echo -e "${GREEN}✓${NC} MTU set to 9000 on connection '$ACTIVE_CON'"
+        echo -e "${GREEN}✓${NC} MTU set to 9000 on connection '$ACTIVE_CON' (persistent)"
     else
         echo -e "${YELLOW}Warning: No active connection found on $NETWORK_INTERFACE${NC}"
         echo "You may need to manually set MTU with: nmcli con modify <connection-name> ethernet.mtu 9000"
     fi
+fi
+
+# Apply MTU to the live interface so it takes effect immediately — nmcli con
+# modify only writes the profile; without this, the new MTU would only apply
+# on next connection activation or reboot.
+if sudo ip link set "$NETWORK_INTERFACE" mtu 9000 2>/dev/null; then
+    echo -e "${GREEN}✓${NC} MTU applied to live interface $NETWORK_INTERFACE (immediate)"
+else
+    echo -e "${YELLOW}Warning: Could not apply MTU to live interface $NETWORK_INTERFACE.${NC}"
+    echo "It will take effect on next connection activation or reboot."
 fi
 
 # 2. Make network buffer settings persistent via sysctl.conf
@@ -78,21 +88,30 @@ echo "Configuring persistent network buffer settings..."
 SYSCTL_CONF="/etc/sysctl.conf"
 SETTINGS_ADDED=0
 
-if ! grep -q "^net.core.rmem_max=10000000" "$SYSCTL_CONF" 2>/dev/null; then
-    echo "net.core.rmem_max=10000000" | sudo tee -a "$SYSCTL_CONF" > /dev/null
-    SETTINGS_ADDED=1
-    echo -e "${GREEN}✓${NC} Added net.core.rmem_max to $SYSCTL_CONF"
-else
-    echo -e "${GREEN}✓${NC} net.core.rmem_max already configured"
-fi
+# Check by key (not exact line). Updates the value in place if a wrong value
+# was hand-edited; appends if the key isn't present at all.
+ensure_sysctl_value() {
+    local key="$1"
+    local desired="$2"
+    if grep -qE "^${key}[[:space:]]*=" "$SYSCTL_CONF" 2>/dev/null; then
+        local current
+        current=$(grep -E "^${key}[[:space:]]*=" "$SYSCTL_CONF" | tail -1 | sed -E "s/^${key}[[:space:]]*=[[:space:]]*//")
+        if [ "$current" != "$desired" ]; then
+            sudo sed -i -E "s|^${key}[[:space:]]*=.*|${key}=${desired}|" "$SYSCTL_CONF"
+            SETTINGS_ADDED=1
+            echo -e "${GREEN}✓${NC} Updated ${key} in $SYSCTL_CONF (was ${current}, now ${desired})"
+        else
+            echo -e "${GREEN}✓${NC} ${key} already set to ${desired}"
+        fi
+    else
+        echo "${key}=${desired}" | sudo tee -a "$SYSCTL_CONF" > /dev/null
+        SETTINGS_ADDED=1
+        echo -e "${GREEN}✓${NC} Added ${key} to $SYSCTL_CONF"
+    fi
+}
 
-if ! grep -q "^net.core.rmem_default=10000000" "$SYSCTL_CONF" 2>/dev/null; then
-    echo "net.core.rmem_default=10000000" | sudo tee -a "$SYSCTL_CONF" > /dev/null
-    SETTINGS_ADDED=1
-    echo -e "${GREEN}✓${NC} Added net.core.rmem_default to $SYSCTL_CONF"
-else
-    echo -e "${GREEN}✓${NC} net.core.rmem_default already configured"
-fi
+ensure_sysctl_value "net.core.rmem_max" "10000000"
+ensure_sysctl_value "net.core.rmem_default" "10000000"
 
 # Apply sysctl settings immediately
 if [ $SETTINGS_ADDED -eq 1 ]; then

--- a/scripts/acquisition/set_mtu.sh
+++ b/scripts/acquisition/set_mtu.sh
@@ -1,13 +1,25 @@
-#/bin/env sh
-# Source the environment variables from the .env file
-# Change the path to your .env file if necessary
-ENV_FILE=".env"
+#!/bin/bash
+# Source the environment variables from the .env file at the repo root.
+# Works regardless of the caller's current working directory.
 
-if [ -f $ENV_FILE ]; then
-  export $(grep -v '^#' $ENV_FILE | xargs)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+ENV_FILE="$REPO_ROOT/.env"
+
+if [ -f "$ENV_FILE" ]; then
+  export $(grep -v '^#' "$ENV_FILE" | xargs)
+else
+  echo "Error: .env file not found at $ENV_FILE" >&2
+  echo "Create it from .env.template first." >&2
+  exit 1
 fi
 
-sudo ip link set ${NETWORK_INTERFACE} mtu 9000
+if [ -z "$NETWORK_INTERFACE" ]; then
+  echo "Error: NETWORK_INTERFACE not set in $ENV_FILE" >&2
+  exit 1
+fi
+
+sudo ip link set "${NETWORK_INTERFACE}" mtu 9000
 
 sysctl -w net.core.rmem_max=10000000
 sysctl -w net.core.rmem_default=10000000

--- a/scripts/acquisition/setup_acquisition_system.sh
+++ b/scripts/acquisition/setup_acquisition_system.sh
@@ -550,7 +550,7 @@ EOF
             print_info "Updating existing DHCP-Server profile..."
             nmcli con modify DHCP-Server \
                 ifname "$NETWORK_INTERFACE" \
-                autoconnect no \
+                autoconnect yes \
                 ipv4.method manual \
                 ipv4.addresses 192.168.1.1/24 \
                 ipv4.gateway 192.168.1.1 \
@@ -561,7 +561,7 @@ EOF
         fi
     else
         nmcli con add type ethernet con-name DHCP-Server ifname "$NETWORK_INTERFACE" \
-            autoconnect no \
+            autoconnect yes \
             ipv4.method manual \
             ipv4.addresses 192.168.1.1/24 \
             ipv4.gateway 192.168.1.1 \

--- a/scripts/acquisition/start_acquisition.sh
+++ b/scripts/acquisition/start_acquisition.sh
@@ -140,28 +140,54 @@ run_system_checks() {
         print_success "Network interface $NETWORK_INTERFACE found"
     fi
 
-    # Check 4: MTU setting
+    # Check 4: MTU setting (auto-remediate before failing).
     print_step "4/7" "Checking MTU setting"
     if ip link show "$NETWORK_INTERFACE" &>/dev/null; then
         local mtu=$(ip link show "$NETWORK_INTERFACE" | grep -oP 'mtu \K\d+')
         if [ "$mtu" = "9000" ]; then
             print_success "MTU set to 9000"
         else
-            print_warning "MTU is $mtu, should be 9000"
-            print_info "Run: ./scripts/acquisition/make_settings_persistent.sh"
-            checks_passed=false
+            print_warning "MTU is $mtu, attempting auto-fix"
+            if sudo -n ip link set "$NETWORK_INTERFACE" mtu 9000 2>/dev/null; then
+                local mtu_after=$(ip link show "$NETWORK_INTERFACE" | grep -oP 'mtu \K\d+')
+                if [ "$mtu_after" = "9000" ]; then
+                    print_success "Auto-fixed MTU to 9000 (was $mtu)"
+                else
+                    print_error "MTU still $mtu_after after auto-fix attempt"
+                    print_info "Run: ./scripts/acquisition/make_settings_persistent.sh"
+                    checks_passed=false
+                fi
+            else
+                print_error "MTU is $mtu, expected 9000 — auto-fix failed (passwordless sudo unavailable?)"
+                print_info "Run: sudo ip link set $NETWORK_INTERFACE mtu 9000"
+                print_info "Or persist via: ./scripts/acquisition/make_settings_persistent.sh"
+                checks_passed=false
+            fi
         fi
     fi
 
-    # Check 5: Network buffers
+    # Check 5: Network buffers (auto-remediate before failing).
     print_step "5/7" "Checking network buffer settings"
     local rmem_max=$(sysctl -n net.core.rmem_max 2>/dev/null)
     if [ -n "$rmem_max" ] && [ "$rmem_max" -ge 10000000 ]; then
         print_success "Network buffers configured correctly"
     else
-        print_warning "Network buffers not optimally configured"
-        print_info "Run: ./scripts/acquisition/make_settings_persistent.sh"
-        checks_passed=false
+        print_warning "rmem_max is ${rmem_max:-unset}, attempting auto-fix"
+        if sudo -n sysctl -w net.core.rmem_max=10000000 >/dev/null 2>&1; then
+            local rmem_after=$(sysctl -n net.core.rmem_max 2>/dev/null)
+            if [ -n "$rmem_after" ] && [ "$rmem_after" -ge 10000000 ]; then
+                print_success "Auto-fixed net.core.rmem_max to $rmem_after"
+            else
+                print_error "rmem_max still $rmem_after after auto-fix attempt"
+                print_info "Run: ./scripts/acquisition/make_settings_persistent.sh"
+                checks_passed=false
+            fi
+        else
+            print_error "rmem_max is ${rmem_max:-unset} — auto-fix failed (passwordless sudo unavailable?)"
+            print_info "Run: sudo sysctl -w net.core.rmem_max=10000000"
+            print_info "Or persist via: ./scripts/acquisition/make_settings_persistent.sh"
+            checks_passed=false
+        fi
     fi
 
     # Check 6: Disk space
@@ -251,15 +277,29 @@ activate_network() {
         print_warning "Network interface IP is $ip_addr (expected 192.168.1.1)"
     fi
 
-    # Check DHCP server status
+    # Check DHCP server status. In laptop mode there is no fallback DHCP
+    # server upstream — if isc-dhcp-server isn't running, no cameras will
+    # boot. Auto-remediate before failing.
     print_step "2/2" "Checking DHCP server status"
     if systemctl is-active --quiet isc-dhcp-server 2>/dev/null; then
         print_success "DHCP server is running"
     else
-        print_warning "DHCP server is not running"
-        print_info "If you ran the persistence script, it should start automatically on boot"
-        print_info "Start manually with: sudo systemctl start isc-dhcp-server"
-        # Don't fail here - cameras might still work if DHCP server was started manually
+        print_warning "DHCP server not running, attempting to start it"
+        if sudo -n systemctl start isc-dhcp-server >/dev/null 2>&1; then
+            sleep 1
+            if systemctl is-active --quiet isc-dhcp-server 2>/dev/null; then
+                print_success "Auto-started isc-dhcp-server"
+            else
+                print_error "isc-dhcp-server still not running after start attempt"
+                print_info "Check logs: journalctl -u isc-dhcp-server -n 50"
+                return 1
+            fi
+        else
+            print_error "Could not start isc-dhcp-server (passwordless sudo unavailable?)"
+            print_info "Start manually: sudo systemctl start isc-dhcp-server"
+            print_info "Or enable on boot: ./scripts/acquisition/make_settings_persistent.sh"
+            return 1
+        fi
     fi
 
     echo ""
@@ -286,11 +326,36 @@ wait_for_cameras() {
         # This is a basic check - the actual acquisition software does more thorough detection
 
         if [ "$DEPLOYMENT_MODE" = "laptop" ]; then
-            # In laptop mode, check DHCP leases
+            # Count current leases only — the previous `grep -c '^lease'` counted
+            # stale leases from previous boots and reported false-positive counts.
             if [ -f /var/lib/dhcp/dhcpd.leases ]; then
-                local lease_count=$(grep -c "^lease" /var/lib/dhcp/dhcpd.leases 2>/dev/null || echo 0)
+                local lease_count=$(python3 - /var/lib/dhcp/dhcpd.leases <<'PY' 2>/dev/null || echo 0
+import datetime, re, sys
+try:
+    text = open(sys.argv[1]).read()
+except OSError:
+    print(0); sys.exit(0)
+now = datetime.datetime.utcnow()
+n = 0
+for m in re.finditer(r"lease\s+\d+\.\d+\.\d+\.\d+\s*\{(.*?)\}", text, re.DOTALL):
+    body = m.group(1)
+    if "abandoned" in body:
+        continue
+    em = re.search(r"ends\s+\d+\s+(\d{4})/(\d+)/(\d+)\s+(\d+):(\d+):(\d+)", body)
+    if em is None:
+        if re.search(r"ends\s+never", body):
+            n += 1
+        continue
+    try:
+        if datetime.datetime(*map(int, em.groups())) > now:
+            n += 1
+    except ValueError:
+        pass
+print(n)
+PY
+)
                 if [ "$lease_count" -gt 0 ]; then
-                    print_success "DHCP has issued $lease_count lease(s)"
+                    print_success "DHCP has issued $lease_count current lease(s)"
                     break
                 fi
             fi

--- a/tests/acquisition/test_health_cameras.py
+++ b/tests/acquisition/test_health_cameras.py
@@ -1,0 +1,382 @@
+"""Tests for ``health.check_camera_reachability`` and ``run_health_check``.
+
+Uses fake PySpin handles + injected enumerator/runners — no Spinnaker SDK,
+no real cameras, no live DHCP server.
+"""
+
+from __future__ import annotations
+
+import datetime
+from pathlib import Path
+
+
+from multi_camera.acquisition.health import (
+    DetectedCamera,
+    HealthConfig,
+    _int_to_ipv4,
+    _snapshot_from_recorder,
+    check_camera_reachability,
+    run_health_check,
+)
+
+
+UTC = datetime.timezone.utc
+
+
+class FakeRecorderCam:
+    """Stand-in for a ``simple_pyspin.Camera`` handle.
+
+    Mirrors the read-only attribute access pattern used by ``_snapshot_from_recorder``:
+    ``DeviceSerialNumber`` / ``GevCurrentIPAddress`` / ``GevLinkSpeed``.
+    """
+
+    def __init__(
+        self, serial: str, ip_int: int | None = None, link_speed_bps: int | None = None
+    ):
+        self.DeviceSerialNumber = serial
+        if ip_int is not None:
+            self.GevCurrentIPAddress = ip_int
+        if link_speed_bps is not None:
+            self.GevLinkSpeed = link_speed_bps
+
+
+class FakeRecorder:
+    def __init__(self, cams: list[FakeRecorderCam]):
+        self.cams = cams
+
+
+class TestIpInt:
+    def test_converts_ipv4_int(self) -> None:
+        # 192.168.1.50 = 0xC0A80132
+        assert _int_to_ipv4(0xC0A80132) == "192.168.1.50"
+
+    def test_invalid_returns_none(self) -> None:
+        assert _int_to_ipv4(-1) is None
+
+
+class TestRecorderSnapshot:
+    def test_reads_full_snapshot(self) -> None:
+        cam = FakeRecorderCam(
+            "22315678", ip_int=0xC0A80132, link_speed_bps=1_000_000_000
+        )
+        snap = _snapshot_from_recorder(cam)
+        assert snap is not None
+        assert snap.serial == "22315678"
+        assert snap.ip == "192.168.1.50"
+        assert snap.link_speed_mbps == 1000
+
+    def test_missing_serial_returns_none(self) -> None:
+        cam = FakeRecorderCam("")
+        cam.DeviceSerialNumber = None
+        assert _snapshot_from_recorder(cam) is None
+
+    def test_partial_snapshot_when_attrs_missing(self) -> None:
+        cam = FakeRecorderCam("22315678")
+        snap = _snapshot_from_recorder(cam)
+        assert snap is not None
+        assert snap.ip is None
+        assert snap.link_speed_mbps is None
+
+
+class TestEnumeratorPath:
+    def test_all_expected_detected(self) -> None:
+        def fake_enum() -> list[DetectedCamera]:
+            return [
+                DetectedCamera(serial="111", ip="192.168.1.51", link_speed_mbps=1000),
+                DetectedCamera(serial="222", ip="192.168.1.52", link_speed_mbps=1000),
+            ]
+
+        report = check_camera_reachability(
+            expected_serials=["111", "222"],
+            recorder=None,
+            enumerator=fake_enum,
+        )
+        assert report.missing == []
+        assert report.extra == []
+        assert report.detected == ["111", "222"]
+        assert report.enumerated is True
+        assert [f.code for f in report.findings] == ["cameras_ok"]
+        assert report.severity == "ok"
+
+    def test_one_missing(self) -> None:
+        def fake_enum() -> list[DetectedCamera]:
+            return [DetectedCamera(serial="111")]
+
+        report = check_camera_reachability(
+            expected_serials=["111", "222"],
+            recorder=None,
+            enumerator=fake_enum,
+        )
+        assert report.missing == ["222"]
+        assert any(f.code == "camera_unreachable" for f in report.findings)
+        assert report.severity == "error"
+        missing_cam = next(c for c in report.cameras if c.serial == "222")
+        assert missing_cam.detected is False
+        assert missing_cam.expected is True
+
+    def test_one_extra_silent_by_default(self) -> None:
+        def fake_enum() -> list[DetectedCamera]:
+            return [
+                DetectedCamera(serial="111"),
+                DetectedCamera(serial="222"),
+                DetectedCamera(serial="999"),
+            ]
+
+        report = check_camera_reachability(
+            expected_serials=["111", "222"],
+            recorder=None,
+            enumerator=fake_enum,
+        )
+        assert report.extra == ["999"]
+        assert not any(f.code == "unexpected_camera" for f in report.findings)
+        assert report.severity == "ok"
+
+    def test_one_extra_visible_with_include_unexpected(self) -> None:
+        def fake_enum() -> list[DetectedCamera]:
+            return [
+                DetectedCamera(serial="111"),
+                DetectedCamera(serial="222"),
+                DetectedCamera(serial="999"),
+            ]
+
+        report = check_camera_reachability(
+            expected_serials=["111", "222"],
+            recorder=None,
+            include_unexpected=True,
+            enumerator=fake_enum,
+        )
+        unexpected = [f for f in report.findings if f.code == "unexpected_camera"]
+        assert len(unexpected) == 1
+        # Demoted to ok-level — informational, not actionable.
+        assert unexpected[0].level == "ok"
+
+    def test_low_link_speed_flagged(self) -> None:
+        def fake_enum() -> list[DetectedCamera]:
+            return [DetectedCamera(serial="111", link_speed_mbps=100)]
+
+        report = check_camera_reachability(
+            expected_serials=["111"],
+            recorder=None,
+            enumerator=fake_enum,
+            minimum_link_speed_mbps=1000,
+        )
+        assert any(f.code == "camera_link_speed_low" for f in report.findings)
+        assert report.severity == "warn"
+
+    def test_enumeration_failure_is_error(self) -> None:
+        def raising_enum() -> list[DetectedCamera]:
+            raise RuntimeError("PySpin bus failure")
+
+        report = check_camera_reachability(
+            expected_serials=["111"],
+            recorder=None,
+            enumerator=raising_enum,
+        )
+        assert report.missing == ["111"]
+        assert any(f.code == "camera_enumeration_failed" for f in report.findings)
+        assert report.severity == "error"
+
+
+class TestShortCircuit:
+    def test_no_recorder_no_expected_short_circuits(self) -> None:
+        """When nothing is configured, skip PySpin enumeration entirely."""
+
+        def boom() -> list[DetectedCamera]:  # pragma: no cover - should not be called
+            raise AssertionError("enumerator should not run when nothing to check")
+
+        report = check_camera_reachability(
+            expected_serials=[],
+            recorder=None,
+            enumerator=boom,
+        )
+        assert report.enumerated is False
+        assert report.missing == []
+        assert report.detected == []
+        assert [f.code for f in report.findings] == ["cameras_not_configured"]
+        assert report.severity == "ok"
+
+    def test_empty_recorder_no_expected_also_short_circuits(self) -> None:
+        class _EmptyRecorder:
+            cams: list = []
+
+        def boom() -> list[DetectedCamera]:  # pragma: no cover
+            raise AssertionError("enumerator should not run")
+
+        report = check_camera_reachability(
+            expected_serials=[],
+            recorder=_EmptyRecorder(),
+            enumerator=boom,
+        )
+        assert [f.code for f in report.findings] == ["cameras_not_configured"]
+
+
+class TestRecorderHandlePath:
+    def test_reads_from_held_handles_no_enumeration(self) -> None:
+        recorder = FakeRecorder(
+            cams=[
+                FakeRecorderCam("111", ip_int=0xC0A80133, link_speed_bps=1_000_000_000),
+                FakeRecorderCam("222", ip_int=0xC0A80134, link_speed_bps=1_000_000_000),
+            ]
+        )
+
+        def boom() -> list[DetectedCamera]:  # pragma: no cover - should not be called
+            raise AssertionError("enumerator should not run when recorder has cams")
+
+        report = check_camera_reachability(
+            expected_serials=["111", "222"],
+            recorder=recorder,
+            enumerator=boom,
+        )
+        assert report.enumerated is False
+        assert report.missing == []
+        cam_111 = next(c for c in report.cameras if c.serial == "111")
+        assert cam_111.ip == "192.168.1.51"
+        assert cam_111.link_speed_mbps == 1000
+
+    def test_empty_recorder_falls_through_to_enumerator(self) -> None:
+        recorder = FakeRecorder(cams=[])
+
+        def fake_enum() -> list[DetectedCamera]:
+            return [DetectedCamera(serial="111")]
+
+        report = check_camera_reachability(
+            expected_serials=["111"],
+            recorder=recorder,
+            enumerator=fake_enum,
+        )
+        assert report.enumerated is True
+        assert report.missing == []
+
+
+class TestRunHealthCheck:
+    def test_end_to_end_all_green(self, tmp_path: Path) -> None:
+        lease_file = tmp_path / "dhcpd.leases"
+        lease_file.write_text(
+            "lease 192.168.1.50 {\n  ends 1 2099/01/01 12:00:00;\n}\n"
+        )
+        config = HealthConfig(
+            deployment_mode="laptop",
+            network_interface="enp5s0",
+            dhcp_lease_file=lease_file,
+            dhcp_expected_interface_ip="192.168.1.1",
+        )
+
+        def fake_enum() -> list[DetectedCamera]:
+            return [
+                DetectedCamera(serial="111", ip="192.168.1.50", link_speed_mbps=1000)
+            ]
+
+        report = run_health_check(
+            config=config,
+            expected_serials=["111"],
+            recorder=None,
+            recording_state="Idle",
+            dhcp_runner=lambda service, timeout_s=1.0: ("active", 0),
+            ip_addr_runner=lambda iface, timeout_s=1.0: "    inet 192.168.1.1/24",
+            camera_enumerator=fake_enum,
+            now=datetime.datetime(2026, 4, 22, 12, 0, 0, tzinfo=UTC),
+        )
+        # host_network runs against the real host here; in the dev container
+        # MTU/rmem aren't configured for jumbo frames, so just verify the dhcp
+        # and camera arms are green and that host_network ran (any severity).
+        assert report.cameras.severity == "ok"
+        assert report.dhcp.severity == "ok"
+        assert report.host_network is not None
+        assert report.recording_state == "Idle"
+
+    def test_overall_is_worst_severity(self, tmp_path: Path) -> None:
+        lease_file = tmp_path / "dhcpd.leases"
+        lease_file.write_text(
+            "lease 192.168.1.50 {\n  ends 1 2099/01/01 12:00:00;\n}\n"
+        )
+        config = HealthConfig(
+            deployment_mode="laptop",
+            network_interface="enp5s0",
+            dhcp_lease_file=lease_file,
+        )
+
+        def fake_enum() -> list[DetectedCamera]:
+            return []  # missing camera -> error
+
+        report = run_health_check(
+            config=config,
+            expected_serials=["111"],
+            recorder=None,
+            dhcp_runner=lambda service, timeout_s=1.0: ("active", 0),
+            ip_addr_runner=lambda iface, timeout_s=1.0: "    inet 192.168.1.1/24",
+            camera_enumerator=fake_enum,
+            now=datetime.datetime(2026, 4, 22, 12, 0, 0, tzinfo=UTC),
+        )
+        assert report.overall == "error"
+        assert report.findings[0].level == "error"  # prioritized
+
+    def test_serializes_to_json(self, tmp_path: Path) -> None:
+        config = HealthConfig(
+            deployment_mode="network",
+            dhcp_lease_file=tmp_path / "never-read",
+        )
+        report = run_health_check(
+            config=config,
+            expected_serials=[],
+            camera_enumerator=lambda: [],
+            now=datetime.datetime(2026, 4, 22, 12, 0, 0, tzinfo=UTC),
+        )
+        dumped = report.model_dump(mode="json")
+        assert set(dumped.keys()) >= {
+            "generated_at",
+            "deployment_mode",
+            "overall",
+            "dhcp",
+            "cameras",
+            "recording_state",
+            "findings",
+        }
+
+    def test_completes_quickly_with_recorder(self, tmp_path: Path) -> None:
+        lease_file = tmp_path / "dhcpd.leases"
+        lease_file.write_text("")
+        config = HealthConfig(
+            deployment_mode="laptop",
+            dhcp_lease_file=lease_file,
+        )
+        recorder = FakeRecorder(
+            cams=[
+                FakeRecorderCam("111", ip_int=0xC0A80132, link_speed_bps=1_000_000_000)
+            ]
+        )
+        import time
+
+        start = time.monotonic()
+        report = run_health_check(
+            config=config,
+            expected_serials=["111"],
+            recorder=recorder,
+            dhcp_runner=lambda service, timeout_s=1.0: ("active", 0),
+            ip_addr_runner=lambda iface, timeout_s=1.0: "    inet 192.168.1.1/24",
+        )
+        elapsed = time.monotonic() - start
+        assert elapsed < 0.2, f"run_health_check took {elapsed:.3f}s, expected <0.2s"
+        assert report.cameras.enumerated is False
+
+
+class TestHealthConfigFromEnv:
+    def test_reads_common_env_vars(self) -> None:
+        cfg = HealthConfig.from_env(
+            {
+                "DEPLOYMENT_MODE": "network",
+                "NETWORK_INTERFACE": "eth0",
+                "HEALTH_IDLE_POLL_S": "15.0",
+            }
+        )
+        assert cfg.deployment_mode == "network"
+        assert cfg.network_interface == "eth0"
+        assert cfg.idle_poll_s == 15.0
+
+    def test_bad_interval_falls_back_to_default(self) -> None:
+        cfg = HealthConfig.from_env({"HEALTH_IDLE_POLL_S": "not a number"})
+        assert cfg.idle_poll_s == 30.0
+
+    def test_empty_env_uses_defaults(self) -> None:
+        cfg = HealthConfig.from_env({})
+        assert cfg.deployment_mode == "laptop"
+        assert cfg.network_interface == "enp5s0"

--- a/tests/acquisition/test_health_dhcp.py
+++ b/tests/acquisition/test_health_dhcp.py
@@ -1,0 +1,249 @@
+"""Tests for ``health.check_dhcp_server`` and related parsing helpers.
+
+All tests use temporary lease files and injected subprocess runners — no
+actual DHCP server or systemctl call required.
+"""
+
+from __future__ import annotations
+
+import datetime
+from pathlib import Path
+
+
+from multi_camera.acquisition.health import (
+    DhcpServerStatus,
+    _parse_interface_ipv4,
+    _parse_lease_file,
+    check_dhcp_server,
+)
+
+
+UTC = datetime.timezone.utc
+
+
+def _make_runner(stdout: str, returncode: int = 0):
+    def runner(service: str, timeout_s: float = 1.0) -> tuple[str, int]:
+        return stdout, returncode
+
+    return runner
+
+
+def _make_ip_runner(stdout: str):
+    def runner(interface: str, timeout_s: float = 1.0) -> str:
+        return stdout
+
+    return runner
+
+
+class TestLeaseFileParsing:
+    def test_counts_active_leases(self) -> None:
+        text = """
+        lease 192.168.1.50 {
+          starts 1 2026/04/20 12:00:00;
+          ends 1 2027/04/20 12:00:00;
+          hardware ethernet 00:11:22:33:44:55;
+        }
+        lease 192.168.1.51 {
+          starts 1 2026/04/21 12:00:00;
+          ends 1 2027/04/21 12:00:00;
+        }
+        """
+        now = datetime.datetime(2026, 4, 22, 12, 0, 0, tzinfo=UTC)
+        assert _parse_lease_file(text, now) == 2
+
+    def test_skips_expired_leases(self) -> None:
+        text = """
+        lease 192.168.1.50 {
+          ends 1 2025/01/01 12:00:00;
+        }
+        lease 192.168.1.51 {
+          ends 1 2099/01/01 12:00:00;
+        }
+        """
+        now = datetime.datetime(2026, 4, 22, 12, 0, 0, tzinfo=UTC)
+        assert _parse_lease_file(text, now) == 1
+
+    def test_skips_abandoned_leases(self) -> None:
+        text = """
+        lease 192.168.1.50 {
+          ends 1 2099/01/01 12:00:00;
+          abandoned;
+        }
+        """
+        now = datetime.datetime(2026, 4, 22, 12, 0, 0, tzinfo=UTC)
+        assert _parse_lease_file(text, now) == 0
+
+    def test_empty_file_returns_zero(self) -> None:
+        assert _parse_lease_file("", datetime.datetime.now(UTC)) == 0
+
+    def test_handles_ends_never(self) -> None:
+        text = """
+        lease 192.168.1.50 {
+          ends never;
+        }
+        """
+        assert _parse_lease_file(text, datetime.datetime.now(UTC)) == 1
+
+    def test_handles_malformed_gracefully(self) -> None:
+        text = "garbage { not a real lease }"
+        assert _parse_lease_file(text, datetime.datetime.now(UTC)) == 0
+
+
+class TestInterfaceIpParsing:
+    def test_extracts_first_ipv4(self) -> None:
+        text = "3: enp5s0: <...> mtu 9000 ...\n    inet 192.168.1.1/24 brd 192.168.1.255 scope global enp5s0\n"
+        assert _parse_interface_ipv4(text) == "192.168.1.1"
+
+    def test_returns_none_if_no_ipv4(self) -> None:
+        text = "3: enp5s0: <...> mtu 9000 ...\n"
+        assert _parse_interface_ipv4(text) is None
+
+
+class TestNetworkMode:
+    def test_short_circuits_in_network_mode(self) -> None:
+        # Even if runners would fail, network mode should not call them.
+        def boom(*args, **kwargs):  # noqa: ARG001
+            raise AssertionError("should not be called in network mode")
+
+        status = check_dhcp_server(
+            mode="network",
+            lease_file=Path("/nonexistent"),
+            interface="fake",
+            systemctl_runner=boom,
+            ip_addr_runner=boom,
+        )
+        assert status.applicable is False
+        assert any(f.code == "dhcp_not_applicable" for f in status.findings)
+        assert status.severity == "ok"
+
+
+class TestLaptopModeHappyPath:
+    def test_all_green(self, tmp_path: Path) -> None:
+        lease_file = tmp_path / "dhcpd.leases"
+        lease_file.write_text(
+            "lease 192.168.1.50 {\n  ends 1 2099/01/01 12:00:00;\n}\n"
+        )
+        status = check_dhcp_server(
+            mode="laptop",
+            lease_file=lease_file,
+            interface="enp5s0",
+            expected_interface_ip="192.168.1.1",
+            systemctl_runner=_make_runner("active", 0),
+            ip_addr_runner=_make_ip_runner("    inet 192.168.1.1/24 brd 192.168.1.255"),
+            now=datetime.datetime(2026, 4, 22, 12, 0, 0, tzinfo=UTC),
+        )
+        assert status.applicable is True
+        assert status.service_active is True
+        assert status.lease_count == 1
+        assert status.interface_ip == "192.168.1.1"
+        assert status.severity == "ok"
+        assert [f.code for f in status.findings] == ["dhcp_ok"]
+
+
+class TestLaptopModeFailures:
+    def test_service_down(self, tmp_path: Path) -> None:
+        lease_file = tmp_path / "dhcpd.leases"
+        lease_file.write_text("")
+        status = check_dhcp_server(
+            mode="laptop",
+            lease_file=lease_file,
+            interface="enp5s0",
+            systemctl_runner=_make_runner("inactive", 3),
+            ip_addr_runner=_make_ip_runner("    inet 192.168.1.1/24"),
+        )
+        assert status.service_active is False
+        assert status.severity == "error"
+        assert any(f.code == "dhcp_service_down" for f in status.findings)
+
+    def test_interface_has_wrong_ip(self, tmp_path: Path) -> None:
+        lease_file = tmp_path / "dhcpd.leases"
+        lease_file.write_text(
+            "lease 192.168.1.50 {\n  ends 1 2099/01/01 12:00:00;\n}\n"
+        )
+        status = check_dhcp_server(
+            mode="laptop",
+            lease_file=lease_file,
+            interface="enp5s0",
+            expected_interface_ip="192.168.1.1",
+            systemctl_runner=_make_runner("active", 0),
+            ip_addr_runner=_make_ip_runner("    inet 10.0.0.5/24"),
+        )
+        assert status.interface_ip == "10.0.0.5"
+        assert any(f.code == "dhcp_interface_ip_unexpected" for f in status.findings)
+        assert status.severity == "warn"
+
+    def test_interface_has_no_ip(self, tmp_path: Path) -> None:
+        lease_file = tmp_path / "dhcpd.leases"
+        lease_file.write_text("")
+        status = check_dhcp_server(
+            mode="laptop",
+            lease_file=lease_file,
+            interface="enp5s0",
+            systemctl_runner=_make_runner("active", 0),
+            ip_addr_runner=_make_ip_runner(""),
+        )
+        assert status.interface_ip is None
+        assert any(f.code == "dhcp_interface_no_ip" for f in status.findings)
+        assert status.severity == "error"
+
+    def test_lease_file_missing(self, tmp_path: Path) -> None:
+        status = check_dhcp_server(
+            mode="laptop",
+            lease_file=tmp_path / "does_not_exist.leases",
+            interface=None,
+            systemctl_runner=_make_runner("active", 0),
+            ip_addr_runner=_make_ip_runner(""),
+        )
+        assert any(f.code == "dhcp_lease_file_missing" for f in status.findings)
+
+    def test_active_but_no_leases(self, tmp_path: Path) -> None:
+        lease_file = tmp_path / "dhcpd.leases"
+        lease_file.write_text("")
+        status = check_dhcp_server(
+            mode="laptop",
+            lease_file=lease_file,
+            interface=None,
+            systemctl_runner=_make_runner("active", 0),
+            ip_addr_runner=_make_ip_runner(""),
+        )
+        codes = [f.code for f in status.findings]
+        assert "dhcp_no_leases" in codes
+        assert status.severity == "warn"
+
+    def test_systemctl_subprocess_error_is_warn_not_error(self, tmp_path: Path) -> None:
+        import subprocess
+
+        def raising_runner(service: str, timeout_s: float = 1.0):
+            raise subprocess.TimeoutExpired(["systemctl"], timeout_s)
+
+        lease_file = tmp_path / "dhcpd.leases"
+        lease_file.write_text("")
+        status = check_dhcp_server(
+            mode="laptop",
+            lease_file=lease_file,
+            systemctl_runner=raising_runner,
+            ip_addr_runner=_make_ip_runner(""),
+        )
+        codes = [f.code for f in status.findings]
+        assert "dhcp_service_check_failed" in codes
+        assert status.severity == "warn"
+
+
+class TestDhcpServerStatusShape:
+    def test_serializes_to_json(self, tmp_path: Path) -> None:
+        lease_file = tmp_path / "dhcpd.leases"
+        lease_file.write_text("")
+        status = check_dhcp_server(
+            mode="network",
+            lease_file=lease_file,
+            interface=None,
+            systemctl_runner=_make_runner("active", 0),
+            ip_addr_runner=_make_ip_runner(""),
+        )
+        dumped = status.model_dump(mode="json")
+        assert "findings" in dumped
+        assert dumped["applicable"] is False
+
+    def test_severity_property(self) -> None:
+        status = DhcpServerStatus(applicable=True, findings=[])
+        assert status.severity == "ok"

--- a/tests/acquisition/test_sync_diagnostics.py
+++ b/tests/acquisition/test_sync_diagnostics.py
@@ -14,6 +14,7 @@ import pytest
 from multi_camera.acquisition.diagnostics.json_parser import (
     create_sync_wait_figure,
     detect_timestamp_jumps,
+    diagnose_session_issues,
     diagnose_sync_issues,
     load_session,
     load_trial,
@@ -1000,3 +1001,380 @@ class TestSaveReport:
 
         assert path == tmp_path / "diagnostics" / "sync_report.txt"
         assert path.exists()
+
+
+def _write_multi_trial(
+    tmp_path: Path,
+    n_trials: int,
+    trial_overrides: dict[int, dict] | None = None,
+) -> None:
+    """Write multiple trial JSON files with optional per-trial overrides."""
+    overrides = trial_overrides or {}
+    for i in range(n_trials):
+        kwargs = overrides.get(i, {})
+        data = _make_json_data(**kwargs)
+        _write_json(
+            tmp_path, data, filename=f"test_20250101_{120000 + i * 100:06d}.json"
+        )
+
+
+class TestWarmupDetection:
+    def test_warmup_detected(self, tmp_path: Path) -> None:
+        """2 bad trials + 3 clean → warm-up flagged."""
+        for i in range(5):
+            n = 20
+            timestamps = []
+            for f in range(n):
+                row = [
+                    BASE_TIMESTAMP_NS + f * FRAME_PERIOD_NS + c * 100 for c in range(3)
+                ]
+                if i < 2 and f == 5:
+                    row[2] += 500_000_000  # 500ms jitter on one camera → big spread
+                timestamps.append(row)
+            data = _make_json_data(n_frames=n)
+            data["timestamps"] = timestamps
+            _write_json(
+                tmp_path, data, filename=f"test_20250101_{120000 + i * 100:06d}.json"
+            )
+
+        report = load_session(tmp_path)
+        session_insights, recs = diagnose_session_issues(report)
+
+        warmup = [i for i in session_insights if "warm-up" in i]
+        assert len(warmup) == 1
+        assert "validate-sync" in recs[0]
+
+    def test_all_clean_no_warmup(self, tmp_path: Path) -> None:
+        _write_multi_trial(tmp_path, 5)
+        report = load_session(tmp_path)
+        session_insights, recs = diagnose_session_issues(report)
+
+        warmup = [i for i in session_insights if "warm-up" in i]
+        assert len(warmup) == 0
+
+    def test_all_bad_no_warmup(self, tmp_path: Path) -> None:
+        """When all trials are bad, there's no settled baseline → no warm-up flag."""
+        for i in range(5):
+            n = 20
+            timestamps = []
+            for f in range(n):
+                row = [
+                    BASE_TIMESTAMP_NS + f * FRAME_PERIOD_NS + c * 100 for c in range(3)
+                ]
+                if f == 5:
+                    row[2] += 500_000_000  # all trials have big spread
+                timestamps.append(row)
+            data = _make_json_data(n_frames=n)
+            data["timestamps"] = timestamps
+            _write_json(
+                tmp_path, data, filename=f"test_20250101_{120000 + i * 100:06d}.json"
+            )
+
+        report = load_session(tmp_path)
+        session_insights, _ = diagnose_session_issues(report)
+
+        warmup = [i for i in session_insights if "warm-up" in i]
+        assert len(warmup) == 0
+
+    def test_single_trial_no_warmup(self, tmp_path: Path) -> None:
+        _write_multi_trial(tmp_path, 1)
+        report = load_session(tmp_path)
+        session_insights, _ = diagnose_session_issues(report)
+
+        warmup = [i for i in session_insights if "warm-up" in i]
+        assert len(warmup) == 0
+
+
+class TestFrameCountAnomaly:
+    def test_large_deficit_flags(self, tmp_path: Path) -> None:
+        """A camera acquiring 20% fewer frames should fire the anomaly."""
+        error_summary = {
+            "CAM_A": {
+                "total_acquired": 3500,
+                "incomplete_frames": 0,
+                "exceptions": 0,
+                "frame_id_gaps": 0,
+            },
+            "CAM_B": {
+                "total_acquired": 4400,
+                "incomplete_frames": 0,
+                "exceptions": 0,
+                "frame_id_gaps": 0,
+            },
+            "CAM_C": {
+                "total_acquired": 4400,
+                "incomplete_frames": 0,
+                "exceptions": 0,
+                "frame_id_gaps": 0,
+            },
+        }
+        data = _make_json_data(
+            include_diagnostics=True, camera_error_summary=error_summary
+        )
+        _write_json(tmp_path, data)
+        report = load_session(tmp_path)
+
+        session_insights, recs = diagnose_session_issues(report)
+
+        anomaly = [i for i in session_insights if "CAM_A" in i and "frames" in i]
+        assert len(anomaly) == 1
+        assert "3,500" in anomaly[0]
+        assert "30fps" not in anomaly[0], "message should not hard-code 30fps"
+        cable_recs = [r for r in recs if "cable" in r.lower()]
+        assert len(cable_recs) == 1
+
+    def test_small_deficit_does_not_flag(self, tmp_path: Path) -> None:
+        """A 4.5% deficit is within normal variance — should NOT fire."""
+        error_summary = {
+            "CAM_A": {
+                "total_acquired": 4200,
+                "incomplete_frames": 0,
+                "exceptions": 0,
+                "frame_id_gaps": 0,
+            },
+            "CAM_B": {
+                "total_acquired": 4400,
+                "incomplete_frames": 0,
+                "exceptions": 0,
+                "frame_id_gaps": 0,
+            },
+            "CAM_C": {
+                "total_acquired": 4400,
+                "incomplete_frames": 0,
+                "exceptions": 0,
+                "frame_id_gaps": 0,
+            },
+        }
+        data = _make_json_data(
+            include_diagnostics=True, camera_error_summary=error_summary
+        )
+        _write_json(tmp_path, data)
+        report = load_session(tmp_path)
+
+        session_insights, _ = diagnose_session_issues(report)
+
+        anomaly = [i for i in session_insights if "CAM_A" in i and "frames" in i]
+        assert len(anomaly) == 0, f"small deficit should not flag; got: {anomaly}"
+
+    def test_short_trial_does_not_flag(self, tmp_path: Path) -> None:
+        """Below the minimum total frames, don't flag even a large deficit."""
+        error_summary = {
+            "CAM_A": {
+                "total_acquired": 50,
+                "incomplete_frames": 0,
+                "exceptions": 0,
+                "frame_id_gaps": 0,
+            },
+            "CAM_B": {
+                "total_acquired": 200,
+                "incomplete_frames": 0,
+                "exceptions": 0,
+                "frame_id_gaps": 0,
+            },
+            "CAM_C": {
+                "total_acquired": 200,
+                "incomplete_frames": 0,
+                "exceptions": 0,
+                "frame_id_gaps": 0,
+            },
+        }
+        data = _make_json_data(
+            include_diagnostics=True, camera_error_summary=error_summary
+        )
+        _write_json(tmp_path, data)
+        report = load_session(tmp_path)
+        session_insights, _ = diagnose_session_issues(report)
+        anomaly = [i for i in session_insights if "CAM_A" in i and "frames" in i]
+        assert len(anomaly) == 0
+
+    def test_uniform_no_flag(self, tmp_path: Path) -> None:
+        error_summary = {
+            "CAM_A": {
+                "total_acquired": 4400,
+                "incomplete_frames": 0,
+                "exceptions": 0,
+                "frame_id_gaps": 0,
+            },
+            "CAM_B": {
+                "total_acquired": 4400,
+                "incomplete_frames": 0,
+                "exceptions": 0,
+                "frame_id_gaps": 0,
+            },
+            "CAM_C": {
+                "total_acquired": 4400,
+                "incomplete_frames": 0,
+                "exceptions": 0,
+                "frame_id_gaps": 0,
+            },
+        }
+        data = _make_json_data(
+            include_diagnostics=True, camera_error_summary=error_summary
+        )
+        _write_json(tmp_path, data)
+        report = load_session(tmp_path)
+
+        session_insights, _ = diagnose_session_issues(report)
+
+        anomaly = [i for i in session_insights if "frames vs" in i]
+        assert len(anomaly) == 0
+
+    def test_no_error_summary_no_crash(self, tmp_path: Path) -> None:
+        data = _make_json_data(include_diagnostics=True)
+        _write_json(tmp_path, data)
+        report = load_session(tmp_path)
+
+        session_insights, _ = diagnose_session_issues(report)
+        anomaly = [i for i in session_insights if "frames vs" in i]
+        assert len(anomaly) == 0
+
+
+class TestPtpClusterDetection:
+    def test_two_groups_detected(self, tmp_path: Path) -> None:
+        """Cameras with two distinct offset clusters → cluster reported."""
+        ptp_end = {
+            "CAM_A": 0,
+            "CAM_B": 100_000,  # 100µs
+            "CAM_C": -2_000_000,  # -2ms
+            "CAM_D": -2_100_000,  # -2.1ms
+            "CAM_E": -1_900_000,  # -1.9ms
+        }
+        data = _make_json_data(
+            camera_ids=["CAM_A", "CAM_B", "CAM_C", "CAM_D", "CAM_E"],
+            include_diagnostics=True,
+            diagnostics_version=2,
+            ptp_offset_end=ptp_end,
+        )
+        _write_json(tmp_path, data)
+        report = load_session(tmp_path)
+
+        session_insights, recs = diagnose_session_issues(report)
+
+        cluster = [i for i in session_insights if "PTP cluster" in i]
+        assert len(cluster) >= 1
+        assert "CAM_C" in cluster[0]
+        assert "CAM_D" in cluster[0]
+        assert "CAM_E" in cluster[0]
+        switch_recs = [r for r in recs if "switch" in r.lower()]
+        assert len(switch_recs) >= 1
+
+    def test_all_close_no_cluster(self, tmp_path: Path) -> None:
+        ptp_end = {
+            "CAM_A": 0,
+            "CAM_B": 10_000,  # 10µs
+            "CAM_C": -15_000,  # -15µs
+        }
+        data = _make_json_data(
+            include_diagnostics=True,
+            diagnostics_version=2,
+            ptp_offset_end=ptp_end,
+        )
+        _write_json(tmp_path, data)
+        report = load_session(tmp_path)
+
+        session_insights, _ = diagnose_session_issues(report)
+
+        cluster = [i for i in session_insights if "PTP cluster" in i]
+        assert len(cluster) == 0
+
+    def test_no_ptp_data_no_crash(self, tmp_path: Path) -> None:
+        data = _make_json_data(include_diagnostics=True)
+        _write_json(tmp_path, data)
+        report = load_session(tmp_path)
+
+        session_insights, _ = diagnose_session_issues(report)
+        cluster = [i for i in session_insights if "PTP cluster" in i]
+        assert len(cluster) == 0
+
+
+class TestPtpConvergence:
+    def test_decreasing_offsets_flagged(self, tmp_path: Path) -> None:
+        """PTP offsets decreasing across trials → convergence flagged."""
+        offsets = [2_000_000, 1_500_000, 1_000_000, 500_000, 100_000]  # ns, decreasing
+        for i, offset in enumerate(offsets):
+            data = _make_json_data(
+                include_diagnostics=True,
+                diagnostics_version=2,
+                ptp_offset_end={"CAM_A": 0, "CAM_B": offset, "CAM_C": -offset},
+            )
+            _write_json(
+                tmp_path, data, filename=f"test_20250101_{120000 + i * 100:06d}.json"
+            )
+
+        report = load_session(tmp_path)
+        session_insights, recs = diagnose_session_issues(report)
+
+        convergence = [i for i in session_insights if "converging" in i]
+        assert len(convergence) == 1
+        assert "Trial 0" in convergence[0]
+        wait_recs = [r for r in recs if "converge" in r.lower()]
+        assert len(wait_recs) == 1
+
+    def test_stable_offsets_no_flag(self, tmp_path: Path) -> None:
+        for i in range(5):
+            data = _make_json_data(
+                include_diagnostics=True,
+                diagnostics_version=2,
+                ptp_offset_end={"CAM_A": 0, "CAM_B": 50_000, "CAM_C": -50_000},
+            )
+            _write_json(
+                tmp_path, data, filename=f"test_20250101_{120000 + i * 100:06d}.json"
+            )
+
+        report = load_session(tmp_path)
+        session_insights, _ = diagnose_session_issues(report)
+
+        convergence = [i for i in session_insights if "converging" in i]
+        assert len(convergence) == 0
+
+    def test_fewer_than_3_trials_no_flag(self, tmp_path: Path) -> None:
+        for i in range(2):
+            data = _make_json_data(
+                include_diagnostics=True,
+                diagnostics_version=2,
+                ptp_offset_end={"CAM_A": 0, "CAM_B": 2_000_000, "CAM_C": -2_000_000},
+            )
+            _write_json(
+                tmp_path, data, filename=f"test_20250101_{120000 + i * 100:06d}.json"
+            )
+
+        report = load_session(tmp_path)
+        session_insights, _ = diagnose_session_issues(report)
+
+        convergence = [i for i in session_insights if "converging" in i]
+        assert len(convergence) == 0
+
+
+class TestSessionInsightsInReport:
+    def test_sections_appear_in_save_report(self, tmp_path: Path) -> None:
+        """Session Insights and Recommendations sections appear in saved report."""
+        offsets = [2_000_000, 1_500_000, 1_000_000, 500_000, 100_000]
+        for i, offset in enumerate(offsets):
+            data = _make_json_data(
+                include_diagnostics=True,
+                diagnostics_version=2,
+                ptp_offset_end={"CAM_A": 0, "CAM_B": offset, "CAM_C": -offset},
+            )
+            _write_json(
+                tmp_path, data, filename=f"test_20250101_{120000 + i * 100:06d}.json"
+            )
+
+        report = load_session(tmp_path)
+        output_dir = tmp_path / "output"
+        path = save_report(report, output_dir=output_dir)
+
+        contents = path.read_text()
+        assert "Session Insights" in contents
+        assert "Recommendations" in contents
+        assert "converging" in contents
+
+    def test_no_recommendations_section_omitted(self, tmp_path: Path) -> None:
+        """When no session issues, sections are omitted."""
+        _write_multi_trial(tmp_path, 3)
+        report = load_session(tmp_path)
+        output_dir = tmp_path / "output"
+        path = save_report(report, output_dir=output_dir)
+
+        contents = path.read_text()
+        assert "Session Insights" not in contents
+        assert "Recommendations" not in contents


### PR DESCRIPTION
## Summary                                                                                                                      
                                                                                                                                  
  Operator-machine hardening for the acquisition system. Adds host-network drift detection with auto-remediation, a `make health` CLI, and a handful of bash bug fixes that address real failure modes seen in production.                                                                                                                                                       
                                          
  ### `health.py` + `make health` / `make health-fix`                                                                             
                                                                                                                                  
  Single source of truth for operator-facing health. Three pillars:
                                                                                                                                  
  - **DHCP server** (laptop mode only): isc-dhcp-server installed + active + listening on the configured interface + leases issued
  - **Camera reachability**: PySpin GigE broadcast, missing/extra against the loaded YAML
  - **Host network** (sysfs/procfs, no iproute2 dep): interface present, carrier up, MTU 9000, `net.core.rmem_max >= 10MB`
                                                                                                                                  
  Each finding pairs a structured code with a plain-English message and the exact remediation command.  run_host_remediation()` attempts a single non-interactive `sudo -n` per remediable code (MTU, rmem, isc-dhcp-server) and falls back to printing the manual command if passwordless sudo isn't configured.                                                                           
                                                                                                                                  
  CLI: `python -m multi_camera.acquisition.health [--remediate]` with an interactive camera-config picker.                        
  Make targets: `make health`, `make health-fix`. Both routed through the existing `test` service (which is already `network_mode:
   host`).                                                  
                                          
  ### Auto-remediation in `start_acquisition.sh`
                                                                                                                                  
  The startup gate (`make run`) now tries `sudo -n` to fix MTU, rmem, and isc-dhcp-server drift before failing. Operator sees 
  `"Auto-fixed MTU to 9000 (was 1500)"` instead of having to know which command to type.                                          
                                                            
  ### Bash bug fixes
                                                                                                                                  
  - **Stale-lease detector**: the `"DHCP has issued N leases"` count in `start_acquisition.sh` was matching expired entries from
  previous boots. Now filters by `ends` timestamp and skips abandoned blocks via a small inline python parser.                    
  - **"Already configured" key-match**: `make_settings_persistent.sh` was matching by full-line string, so a hand-edited `rmem`
  value silently passed the check. Now matches by key name and rewrites in place.
  - **`set_mtu.sh`**: applies MTU live in addition to persisting it.                                                              
  - **`acquisition_diagnostics.sh`**: anchors `.env` path resolution to the script's own directory rather than `$PWD`.
  - **`setup_acquisition_system.sh`**: DHCP-Server nmcli profile is now `autoconnect yes` (both create and modify branches),      
  eliminating the manual `nmcli con up DHCP-Server` step after every reboot.
                                                                                                                                  
  ### Session-level synthesizers (post-hoc CLI only)                                                                              
                                                                                                                                  
  Four cross-trial detectors complementing the 16 per-trial ones:                                                                 
                                                                                                                                  
  - `diagnose_warmup()` — flags warm-up-affected trials     
  - `diagnose_frame_count_anomaly()` — trials with frame counts diverging from the session median (tuned to require both absolute deficit AND relative deviation, so single-trial / short recordings don't trigger spurious warnings)
  - `diagnose_ptp_clusters()` — PTP-offset cluster boundaries                                                                     
  - `diagnose_ptp_convergence()` — flags PTP that hasn't converged before recording starts
                                                                                                                                  
  Usable today via `python -m multi_camera.acquisition.diagnostics.json_parser <data_dir>` (and `make diag-analyze`).
                                                                                                                                  
  ### Backend nits                                                                                                                
                                          
  - Newer Starlette versions require `request` as a positional/named arg on `TemplateResponse`, not in `context`. Was producing a deprecation warning that's now an error.                                                                                        
  - Replaced silent `print(f"Task raised an exception: {e}")` in `task_done_callback` with `acquisition_logger.error(...,
  exc_info=True)`. Recording-task failures now show up in operator logs with traceback instead of being swallowed.        