### PR TITLE
Feat/diagnostics pr3

### DIFF
--- a/frontend/acquisition/src/AcquisitionApi.js
+++ b/frontend/acquisition/src/AcquisitionApi.js
@@ -428,6 +428,13 @@ export const AcquisitionApi = (props) => {
         return response.data;
     };
 
+    const restoreCameraDefaults = async (serial) => {
+        const response = await axios.post(`${API_BASE_URL}/cameras/${serial}/restore_defaults`);
+        await fetchCameraStatus();
+        await fetchHealth(true);
+        return response.data;
+    };
+
     /* Code for editing recording database */
 
     const getMatchingPriorRecordings = async (participant, filename) => {
@@ -548,6 +555,7 @@ export const AcquisitionApi = (props) => {
         selectCamera,
         resetCameras,
         restartAcquisition,
+        restoreCameraDefaults,
         newSession,
         newTrial,
         previewVideo,

--- a/frontend/acquisition/src/AcquisitionApi.js
+++ b/frontend/acquisition/src/AcquisitionApi.js
@@ -435,6 +435,14 @@ export const AcquisitionApi = (props) => {
         return response.data;
     };
 
+    const setCameraExcluded = async (serial, excluded) => {
+        const path = excluded ? 'exclude' : 'include';
+        const response = await axios.post(`${API_BASE_URL}/cameras/${serial}/${path}`);
+        await fetchCameraStatus();
+        await fetchHealth(true);
+        return response.data;
+    };
+
     /* Code for editing recording database */
 
     const getMatchingPriorRecordings = async (participant, filename) => {
@@ -556,6 +564,7 @@ export const AcquisitionApi = (props) => {
         resetCameras,
         restartAcquisition,
         restoreCameraDefaults,
+        setCameraExcluded,
         newSession,
         newTrial,
         previewVideo,

--- a/frontend/acquisition/src/AcquisitionApi.js
+++ b/frontend/acquisition/src/AcquisitionApi.js
@@ -421,6 +421,13 @@ export const AcquisitionApi = (props) => {
         fetchCameraStatus();
     };
 
+    const restartAcquisition = async () => {
+        const response = await axios.post(`${API_BASE_URL}/restart_acquisition`);
+        await fetchCameraStatus();
+        await fetchHealth(true);
+        return response.data;
+    };
+
     /* Code for editing recording database */
 
     const getMatchingPriorRecordings = async (participant, filename) => {
@@ -540,6 +547,7 @@ export const AcquisitionApi = (props) => {
         selectedCamera: selectedCamera,
         selectCamera,
         resetCameras,
+        restartAcquisition,
         newSession,
         newTrial,
         previewVideo,

--- a/frontend/acquisition/src/components/CameraStatusTable.js
+++ b/frontend/acquisition/src/components/CameraStatusTable.js
@@ -1,7 +1,47 @@
-import React, { useContext } from 'react';
-import { Table } from 'react-bootstrap';
+import React, { useContext, useState } from 'react';
+import { Table, Button } from 'react-bootstrap';
 import Accordion from 'react-bootstrap/Accordion';
 import { AcquisitionState } from "../AcquisitionApi";
+
+const RestoreDefaultsButton = ({ serial }) => {
+    const { restoreCameraDefaults, recordingSystemStatus } = useContext(AcquisitionState);
+    const [busy, setBusy] = useState(false);
+    const [error, setError] = useState(null);
+    const isRecording = recordingSystemStatus === 'Recording';
+
+    const handleClick = async () => {
+        const ok = window.confirm(
+            `Restore camera ${serial} to factory defaults? ` +
+            `The acquisition system will reload to re-apply the current config.`
+        );
+        if (!ok) return;
+        setBusy(true);
+        setError(null);
+        try {
+            await restoreCameraDefaults(serial);
+        } catch (e) {
+            const msg = (e && e.response && e.response.data && e.response.data.detail) || e.message;
+            setError(msg || 'Restore failed.');
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    return (
+        <div>
+            <Button
+                onClick={handleClick}
+                disabled={busy || isRecording}
+                size="sm"
+                variant="outline-warning"
+                title={isRecording ? 'Stop the recording before restoring defaults' : 'Load factory UserSet on this camera and re-init'}
+            >
+                {busy ? 'Restoring…' : 'Restore defaults'}
+            </Button>
+            {error && <div className="text-danger small mt-1">{error}</div>}
+        </div>
+    );
+};
 
 const CameraStatusTable = ({ api }) => {
 
@@ -23,6 +63,7 @@ const CameraStatusTable = ({ api }) => {
                                 <th>Width</th>
                                 <th>Height</th>
                                 <th>Sync Offset</th>
+                                <th>Actions</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -36,6 +77,7 @@ const CameraStatusTable = ({ api }) => {
                                     <td>{cameraStatus.Width}</td>
                                     <td>{cameraStatus.Height}</td>
                                     <td>{cameraStatus.SyncOffset}</td>
+                                    <td><RestoreDefaultsButton serial={cameraStatus.SerialNumber} /></td>
                                 </tr>
                             ))}
                         </tbody>

--- a/frontend/acquisition/src/components/DiagnosticsPage.js
+++ b/frontend/acquisition/src/components/DiagnosticsPage.js
@@ -151,7 +151,7 @@ const HostHealthPanel = () => {
                                             <tr key={c.serial}>
                                                 <td>{c.serial}</td>
                                                 <td>{c.ip || '—'}</td>
-                                                <td>{c.link_speed_mbps != null ? `${c.link_speed_mbps} Mbps` : '—'}</td>
+                                                <td>{deriveLinkLabel(c)}</td>
                                                 <td>{c.link_throughput_bytes_per_sec != null
                                                     ? `${Math.round(c.link_throughput_bytes_per_sec * 8 / 1000000)} Mbps`
                                                     : '—'}</td>
@@ -338,6 +338,23 @@ const DiagnosticsPage = () => (
 );
 
 const describeBool = (b) => (b === true ? 'OK' : b === false ? 'down' : '—');
+
+// Derive a human-readable link rating. Some Blackfly firmware doesn't populate
+// GevLinkSpeed via the held-recorder snapshot path, so we fall back to the
+// observed payload throughput. A 1 Gbps link tops out around 700-750 Mbps
+// payload (jumbo frames at 30 fps); a 100 Mbps link tops out around 95-100.
+const deriveLinkLabel = (c) => {
+    if (c.link_speed_mbps != null && c.link_speed_mbps > 0) {
+        return `${c.link_speed_mbps} Mbps`;
+    }
+    if (c.link_throughput_bytes_per_sec != null) {
+        const mbps = c.link_throughput_bytes_per_sec * 8 / 1000000;
+        if (mbps > 200) return '1 Gbps';
+        if (mbps > 20) return '100 Mbps';
+        if (mbps > 0) return '10 Mbps';
+    }
+    return '—';
+};
 
 const SEVERITY_RANK = { unknown: 0, ok: 1, warn: 2, error: 3 };
 const maxLevel = (findings) => {

--- a/frontend/acquisition/src/components/DiagnosticsPage.js
+++ b/frontend/acquisition/src/components/DiagnosticsPage.js
@@ -262,9 +262,47 @@ const CurrentSessionPanel = () => {
     );
 };
 
+const RestartAcquisitionButton = () => {
+    const { restartAcquisition, recordingSystemStatus } = useContext(AcquisitionState);
+    const [busy, setBusy] = useState(false);
+    const [error, setError] = useState(null);
+    const isRecording = recordingSystemStatus === 'Recording';
+
+    const handleClick = async () => {
+        setBusy(true);
+        setError(null);
+        try {
+            await restartAcquisition();
+        } catch (e) {
+            const msg = (e && e.response && e.response.data && e.response.data.detail) || e.message;
+            setError(msg || 'Restart failed.');
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    return (
+        <div>
+            <Button
+                onClick={handleClick}
+                disabled={busy || isRecording}
+                size="sm"
+                variant="outline-warning"
+                title={isRecording ? 'Stop the recording before restarting' : 'Re-init PySpin and re-run PTP sync'}
+            >
+                {busy ? 'Restarting…' : 'Restart acquisition'}
+            </Button>
+            {error && <div className="text-danger small mt-1">{error}</div>}
+        </div>
+    );
+};
+
 const DiagnosticsPage = () => (
     <Container className="mt-3">
-        <h3 className="mb-3">Diagnostics</h3>
+        <div className="d-flex justify-content-between align-items-center mb-3">
+            <h3 className="mb-0">Diagnostics</h3>
+            <RestartAcquisitionButton />
+        </div>
         <HostHealthPanel />
         <CurrentSessionPanel />
     </Container>

--- a/frontend/acquisition/src/components/DiagnosticsPage.js
+++ b/frontend/acquisition/src/components/DiagnosticsPage.js
@@ -25,6 +25,13 @@ const FindingList = ({ findings }) => {
                 <ListGroup.Item key={`${f.code}-${i}`} className="d-flex justify-content-between align-items-start">
                     <div className="ms-2 me-auto">
                         <div className="fw-bold">{f.message}</div>
+                        {f.remediation && f.remediation.length > 0 && (
+                            <ol className="small mb-1 mt-1 ps-3">
+                                {f.remediation.map((step, j) => (
+                                    <li key={j}>{step}</li>
+                                ))}
+                            </ol>
+                        )}
                         <small className="text-muted">{f.code}</small>
                     </div>
                     <SeverityBadge level={f.level} />

--- a/frontend/acquisition/src/components/DiagnosticsPage.js
+++ b/frontend/acquisition/src/components/DiagnosticsPage.js
@@ -151,6 +151,7 @@ const HostHealthPanel = () => {
                                             <th>Link</th>
                                             <th>Throughput</th>
                                             <th>Status</th>
+                                            <th>Action</th>
                                         </tr>
                                     </thead>
                                     <tbody>
@@ -162,7 +163,12 @@ const HostHealthPanel = () => {
                                                 <td>{c.link_throughput_bytes_per_sec != null
                                                     ? `${Math.round(c.link_throughput_bytes_per_sec * 8 / 1000000)} Mbps`
                                                     : '—'}</td>
-                                                <td>{c.detected ? 'reachable' : (c.expected ? 'missing' : 'unexpected')}</td>
+                                                <td>{c.excluded
+                                                    ? 'excluded'
+                                                    : (c.detected ? 'reachable' : (c.expected ? 'missing' : 'unexpected'))}</td>
+                                                <td>{(c.excluded || c.expected || c.detected)
+                                                    ? <ExcludeCameraButton serial={c.serial} excluded={c.excluded} />
+                                                    : null}</td>
                                             </tr>
                                         ))}
                                     </tbody>
@@ -295,6 +301,50 @@ const CurrentSessionPanel = () => {
                 )}
             </Card.Body>
         </Card>
+    );
+};
+
+const ExcludeCameraButton = ({ serial, excluded }) => {
+    const { setCameraExcluded, recordingSystemStatus } = useContext(AcquisitionState);
+    const [busy, setBusy] = useState(false);
+    const [error, setError] = useState(null);
+    const isRecording = recordingSystemStatus === 'Recording';
+
+    const handleClick = async () => {
+        const target = !excluded;
+        const verb = target ? 'Exclude' : 'Include';
+        const ok = window.confirm(
+            target
+                ? `Exclude camera ${serial} from this session? The system will reconfigure ` +
+                  `with one fewer camera. You can re-include it later.`
+                : `Re-include camera ${serial}? The system will reconfigure with this camera back in the recording.`
+        );
+        if (!ok) return;
+        setBusy(true);
+        setError(null);
+        try {
+            await setCameraExcluded(serial, target);
+        } catch (e) {
+            const msg = (e && e.response && e.response.data && e.response.data.detail) || e.message;
+            setError(msg || `${verb} failed.`);
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    return (
+        <div>
+            <Button
+                onClick={handleClick}
+                disabled={busy || isRecording}
+                size="sm"
+                variant={excluded ? 'outline-success' : 'outline-secondary'}
+                title={isRecording ? 'Stop the recording first' : (excluded ? 'Re-include this camera in the recording' : 'Skip this camera in this session')}
+            >
+                {busy ? '…' : (excluded ? 'Include' : 'Exclude')}
+            </Button>
+            {error && <div className="text-danger small mt-1">{error}</div>}
+        </div>
     );
 };
 

--- a/frontend/acquisition/src/components/DiagnosticsPage.js
+++ b/frontend/acquisition/src/components/DiagnosticsPage.js
@@ -77,6 +77,7 @@ const HostHealthPanel = () => {
     const { overall, dhcp, cameras, host_network, recording_state, deployment_mode, generated_at } = healthReport;
     const dhcpFindings = (dhcp && dhcp.findings) || [];
     const cameraFindings = (cameras && cameras.findings) || [];
+    const perCamera = (cameras && cameras.cameras) || [];
     const hostFindings = (host_network && host_network.findings) || [];
     const expectedList = (cameras && cameras.expected) || [];
     const detectedList = (cameras && cameras.detected) || [];
@@ -125,14 +126,42 @@ const HostHealthPanel = () => {
                     severity={maxLevel(cameraFindings)}
                     findings={cameraFindings}
                     extra={
-                        <Table size="sm" borderless className="mb-2">
-                            <tbody>
-                                <tr><td>Expected</td><td>{expectedList.length}</td></tr>
-                                <tr><td>Detected</td><td>{detectedList.length}</td></tr>
-                                <tr><td>Missing</td><td>{missingList.join(', ') || '—'}</td></tr>
-                                <tr><td>Extra</td><td>{extraList.join(', ') || '—'}</td></tr>
-                            </tbody>
-                        </Table>
+                        <>
+                            <Table size="sm" borderless className="mb-2">
+                                <tbody>
+                                    <tr><td>Expected</td><td>{expectedList.length}</td></tr>
+                                    <tr><td>Detected</td><td>{detectedList.length}</td></tr>
+                                    <tr><td>Missing</td><td>{missingList.join(', ') || '—'}</td></tr>
+                                    <tr><td>Extra</td><td>{extraList.join(', ') || '—'}</td></tr>
+                                </tbody>
+                            </Table>
+                            {perCamera.length > 0 && (
+                                <Table size="sm" striped bordered className="mb-2">
+                                    <thead>
+                                        <tr>
+                                            <th>Serial</th>
+                                            <th>IP</th>
+                                            <th>Link</th>
+                                            <th>Throughput</th>
+                                            <th>Status</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {perCamera.map((c) => (
+                                            <tr key={c.serial}>
+                                                <td>{c.serial}</td>
+                                                <td>{c.ip || '—'}</td>
+                                                <td>{c.link_speed_mbps != null ? `${c.link_speed_mbps} Mbps` : '—'}</td>
+                                                <td>{c.link_throughput_bytes_per_sec != null
+                                                    ? `${Math.round(c.link_throughput_bytes_per_sec * 8 / 1_000_000)} Mbps`
+                                                    : '—'}</td>
+                                                <td>{c.detected ? 'reachable' : (c.expected ? 'missing' : 'unexpected')}</td>
+                                            </tr>
+                                        ))}
+                                    </tbody>
+                                </Table>
+                            )}
+                        </>
                     }
                 />
 

--- a/frontend/acquisition/src/components/DiagnosticsPage.js
+++ b/frontend/acquisition/src/components/DiagnosticsPage.js
@@ -153,7 +153,7 @@ const HostHealthPanel = () => {
                                                 <td>{c.ip || '—'}</td>
                                                 <td>{c.link_speed_mbps != null ? `${c.link_speed_mbps} Mbps` : '—'}</td>
                                                 <td>{c.link_throughput_bytes_per_sec != null
-                                                    ? `${Math.round(c.link_throughput_bytes_per_sec * 8 / 1_000_000)} Mbps`
+                                                    ? `${Math.round(c.link_throughput_bytes_per_sec * 8 / 1000000)} Mbps`
                                                     : '—'}</td>
                                                 <td>{c.detected ? 'reachable' : (c.expected ? 'missing' : 'unexpected')}</td>
                                             </tr>

--- a/multi_camera/acquisition/flir_recording_api.py
+++ b/multi_camera/acquisition/flir_recording_api.py
@@ -654,6 +654,7 @@ class FlirRecorder:
         self.image_queue_dict = {}
         self.config_file = None
         self.iface = None
+        self.excluded_serials: set[str] = set()
         self.status_callback = status_callback
 
         # Edge-fired diagnostic envelopes from the acquisition workers. Each
@@ -794,6 +795,16 @@ class FlirRecorder:
         if config_file:
             with open(config_file, "r") as file:
                 self.camera_config = yaml.safe_load(file)
+
+            # Drop operator-excluded cameras from both camera_info (so
+            # downstream code doesn't expect frames from them) and the
+            # requested_cameras list (so they're never Init'd).
+            if self.excluded_serials:
+                self.camera_config["camera-info"] = {
+                    k: v
+                    for k, v in self.camera_config["camera-info"].items()
+                    if str(k) not in self.excluded_serials
+                }
 
             # Updating interface_cameras if a config file is passed
             # with the camera IDs passed
@@ -1809,6 +1820,15 @@ class FlirRecorder:
 
     def stop_acquisition(self):
         self.stop_recording.set()
+
+    def set_excluded_serials(self, serials: set[str]) -> None:
+        """Replace the operator-excluded serial list. Cameras whose serials
+        appear here are skipped by configure_cameras — neither Init'd nor
+        recorded from. Used to work around a single broken camera without
+        editing the YAML config. Caller must trigger a reconfigure for the
+        change to take effect.
+        """
+        self.excluded_serials = {str(s) for s in serials}
 
     def restore_camera_defaults(self, serial: str) -> None:
         """Load the 'Default' UserSet on the named camera and pin it as the

--- a/multi_camera/acquisition/flir_recording_api.py
+++ b/multi_camera/acquisition/flir_recording_api.py
@@ -1867,7 +1867,6 @@ class FlirRecorder:
             f"DeviceLinkThroughputLimit before: {before_throughput}"
         )
 
-        # Step 1: select the 'Default' UserSet.
         selector = PySpin.CEnumerationPtr(nodemap.GetNode("UserSetSelector"))
         if not PySpin.IsAvailable(selector) or not PySpin.IsWritable(selector):
             raise RuntimeError(
@@ -1880,7 +1879,6 @@ class FlirRecorder:
             )
         selector.SetIntValue(default_entry.GetValue())
 
-        # Step 2: execute UserSetLoad — this writes Default values back.
         load_cmd = PySpin.CCommandPtr(nodemap.GetNode("UserSetLoad"))
         if not PySpin.IsAvailable(load_cmd) or not PySpin.IsWritable(load_cmd):
             raise RuntimeError(
@@ -1889,9 +1887,9 @@ class FlirRecorder:
         load_cmd.Execute()
         print(f"[restore_defaults] camera {serial} UserSetLoad executed")
 
-        # Step 3: pin 'Default' as the boot UserSet so this persists
-        # across power cycles (otherwise the camera could reload a
-        # different stored UserSet at next boot).
+        # Pin 'Default' as the boot UserSet so the restore survives a
+        # power-cycle (otherwise the camera could reload a different
+        # stored UserSet at next boot).
         user_default = PySpin.CEnumerationPtr(nodemap.GetNode("UserSetDefault"))
         if PySpin.IsAvailable(user_default) and PySpin.IsWritable(user_default):
             user_default_entry = user_default.GetEntryByName("Default")

--- a/multi_camera/acquisition/flir_recording_api.py
+++ b/multi_camera/acquisition/flir_recording_api.py
@@ -1810,6 +1810,28 @@ class FlirRecorder:
     def stop_acquisition(self):
         self.stop_recording.set()
 
+    def restore_camera_defaults(self, serial: str) -> None:
+        """Load the 'Default' UserSet on the named camera and pin it as the
+        boot-time UserSet. Equivalent to SpinView's 'Restore Factory Defaults'
+        — clears any latched feature state (e.g. DeviceLinkThroughputLimit)
+        without a hardware power-cycle.
+
+        Caller must guarantee no recording is in progress. The camera must be
+        present in self.cams (Init'd via configure_cameras).
+        """
+        target = next(
+            (c for c in self.cams if str(c.DeviceSerialNumber) == str(serial)),
+            None,
+        )
+        if target is None:
+            raise ValueError(
+                f"Camera {serial} not found in self.cams "
+                f"(have: {[c.DeviceSerialNumber for c in self.cams]})"
+            )
+        target.UserSetSelector = "Default"
+        target.UserSetLoad()
+        target.UserSetDefault = "Default"
+
     async def reset_cameras(self):
         """Reset all the cameras and reopen the system"""
 

--- a/multi_camera/acquisition/flir_recording_api.py
+++ b/multi_camera/acquisition/flir_recording_api.py
@@ -1816,6 +1816,10 @@ class FlirRecorder:
         — clears any latched feature state (e.g. DeviceLinkThroughputLimit)
         without a hardware power-cycle.
 
+        Uses explicit PySpin nodemap calls (not simple_pyspin attribute
+        syntax) because UserSetLoad is a Command node — simple_pyspin
+        doesn't reliably expose Command-node Execute() via attribute access.
+
         Caller must guarantee no recording is in progress. The camera must be
         present in self.cams (Init'd via configure_cameras).
         """
@@ -1828,9 +1832,58 @@ class FlirRecorder:
                 f"Camera {serial} not found in self.cams "
                 f"(have: {[c.DeviceSerialNumber for c in self.cams]})"
             )
-        target.UserSetSelector = "Default"
-        target.UserSetLoad()
-        target.UserSetDefault = "Default"
+
+        nodemap = target.cam.GetNodeMap()
+
+        def _read_int(name: str):
+            node = PySpin.CIntegerPtr(nodemap.GetNode(name))
+            if not PySpin.IsAvailable(node) or not PySpin.IsReadable(node):
+                return None
+            return node.GetValue()
+
+        before_throughput = _read_int("DeviceLinkThroughputLimit")
+        print(
+            f"[restore_defaults] camera {serial} "
+            f"DeviceLinkThroughputLimit before: {before_throughput}"
+        )
+
+        # Step 1: select the 'Default' UserSet.
+        selector = PySpin.CEnumerationPtr(nodemap.GetNode("UserSetSelector"))
+        if not PySpin.IsAvailable(selector) or not PySpin.IsWritable(selector):
+            raise RuntimeError(
+                f"Camera {serial}: UserSetSelector not writable (camera busy?)"
+            )
+        default_entry = selector.GetEntryByName("Default")
+        if default_entry is None or not PySpin.IsAvailable(default_entry):
+            raise RuntimeError(
+                f"Camera {serial}: 'Default' UserSet not available on this camera"
+            )
+        selector.SetIntValue(default_entry.GetValue())
+
+        # Step 2: execute UserSetLoad — this writes Default values back.
+        load_cmd = PySpin.CCommandPtr(nodemap.GetNode("UserSetLoad"))
+        if not PySpin.IsAvailable(load_cmd) or not PySpin.IsWritable(load_cmd):
+            raise RuntimeError(
+                f"Camera {serial}: UserSetLoad command not executable"
+            )
+        load_cmd.Execute()
+        print(f"[restore_defaults] camera {serial} UserSetLoad executed")
+
+        # Step 3: pin 'Default' as the boot UserSet so this persists
+        # across power cycles (otherwise the camera could reload a
+        # different stored UserSet at next boot).
+        user_default = PySpin.CEnumerationPtr(nodemap.GetNode("UserSetDefault"))
+        if PySpin.IsAvailable(user_default) and PySpin.IsWritable(user_default):
+            user_default_entry = user_default.GetEntryByName("Default")
+            if user_default_entry is not None and PySpin.IsAvailable(user_default_entry):
+                user_default.SetIntValue(user_default_entry.GetValue())
+
+        after_throughput = _read_int("DeviceLinkThroughputLimit")
+        print(
+            f"[restore_defaults] camera {serial} "
+            f"DeviceLinkThroughputLimit after: {after_throughput} "
+            f"(delta: {None if before_throughput is None or after_throughput is None else after_throughput - before_throughput})"
+        )
 
     async def reset_cameras(self):
         """Reset all the cameras and reopen the system"""

--- a/multi_camera/acquisition/health.py
+++ b/multi_camera/acquisition/health.py
@@ -729,12 +729,13 @@ def check_camera_reachability(
                 median_mbps = median_t * 8 // 1_000_000
                 findings.append(
                     Finding(
-                        level="warn",
+                        level="error",
                         code="camera_throughput_outlier",
                         message=(
                             f"Camera {cam_info.serial} link throughput is "
                             f"~{cam_mbps} Mbps vs median ~{median_mbps} Mbps "
                             f"across the rig — likely stuck at 100 Mbps. "
+                            f"Recording will be unusable until fixed. "
                             f"Try unplug/replug the camera's cable."
                         ),
                         details={

--- a/multi_camera/acquisition/health.py
+++ b/multi_camera/acquisition/health.py
@@ -717,10 +717,13 @@ def check_camera_reachability(
                     )
                 )
 
-    # Throughput-outlier detector: catches the case where GevDeviceLinkSpeed
-    # reports 1000 (camera firmware bug) but DeviceLinkThroughputLimit reveals
-    # the link is actually 100 Mbps. Fires when one camera's throughput is
-    # < 50% of the median across detected cameras.
+    # Throughput-outlier detector. DeviceLinkThroughputLimit is the camera's
+    # configured outbound cap, derived by Spinnaker from the link speed
+    # negotiated at Init. A value far below other cameras is strong (but
+    # indirect) evidence the link came up at a lower rate (e.g. 100 Mbps
+    # fallback) — useful when GevDeviceLinkSpeed reports 1000 but the
+    # negotiated PHY rate is actually lower. Fires when one camera's
+    # throughput is < 50% of the median across detected cameras.
     throughputs = [
         c.link_throughput_bytes_per_sec
         for c in cameras

--- a/multi_camera/acquisition/health.py
+++ b/multi_camera/acquisition/health.py
@@ -753,7 +753,6 @@ def check_camera_reachability(
                             "Unplug and re-plug the camera's ethernet cable at both ends to force PHY renegotiation.",
                             "If the issue returns within a session, swap the cable with a known-good one to rule out cable damage.",
                             "If a fresh cable doesn't help, move the camera to a different switch port.",
-                            "Software fixes (Restart acquisition, Restore defaults) won't help — this is a physical link issue.",
                         ],
                         details={
                             "serial": cam_info.serial,

--- a/multi_camera/acquisition/health.py
+++ b/multi_camera/acquisition/health.py
@@ -71,6 +71,7 @@ class CameraReachability(BaseModel):
     serial: str
     detected: bool
     expected: bool
+    excluded: bool = False
     ip: str | None = None
     link_speed_mbps: int | None = None
     link_throughput_bytes_per_sec: int | None = None
@@ -554,6 +555,7 @@ def check_camera_reachability(
     minimum_link_speed_mbps: int = 1000,
     include_unexpected: bool = False,
     enumerator: CameraEnumerator = _default_camera_enumerator,
+    excluded_serials: set[str] | None = None,
 ) -> CameraReachabilityReport:
     """Report which expected cameras are reachable right now.
 
@@ -630,14 +632,16 @@ def check_camera_reachability(
     missing = sorted(expected_set - detected_set)
     extra = sorted(detected_set - expected_set)
 
+    excluded_set = set(excluded_serials or set())
     cameras: list[CameraReachability] = []
-    for serial in sorted(expected_set | detected_set):
+    for serial in sorted(expected_set | detected_set | excluded_set):
         cam = detected_by_serial.get(serial)
         cameras.append(
             CameraReachability(
                 serial=serial,
                 detected=cam is not None,
                 expected=serial in expected_set,
+                excluded=serial in excluded_set,
                 ip=cam.ip if cam else None,
                 link_speed_mbps=cam.link_speed_mbps if cam else None,
                 link_throughput_bytes_per_sec=(
@@ -988,6 +992,11 @@ def run_health_check(
         )
         camera_future = None
         if not skip_camera_enumeration:
+            excluded_serials = (
+                getattr(recorder, "excluded_serials", None)
+                if recorder is not None
+                else None
+            )
             camera_future = executor.submit(
                 check_camera_reachability,
                 expected_serials=expected_serials,
@@ -995,6 +1004,7 @@ def run_health_check(
                 minimum_link_speed_mbps=config.minimum_link_speed_mbps,
                 include_unexpected=include_unexpected_cameras,
                 enumerator=camera_enumerator or _default_camera_enumerator,
+                excluded_serials=excluded_serials,
             )
         host_future = executor.submit(
             check_host_network,

--- a/multi_camera/acquisition/health.py
+++ b/multi_camera/acquisition/health.py
@@ -732,11 +732,17 @@ def check_camera_reachability(
                         level="error",
                         code="camera_throughput_outlier",
                         message=(
-                            f"Camera {cam_info.serial} link throughput is "
-                            f"~{cam_mbps} Mbps vs median ~{median_mbps} Mbps "
-                            f"across the rig — likely stuck at 100 Mbps. "
-                            f"Recording will be unusable until fixed. "
-                            f"Try unplug/replug the camera's cable."
+                            f"Camera {cam_info.serial} link is at ~{cam_mbps} Mbps "
+                            f"(others at ~{median_mbps} Mbps). Recordings will be "
+                            f"unusable until fixed. Software fixes (Restart "
+                            f"acquisition / Restore defaults) won't help — this is "
+                            f"a physical link issue. "
+                            f"(1) Unplug and re-plug the camera's ethernet cable at "
+                            f"both ends to force the link to renegotiate. "
+                            f"(2) If the issue returns, swap the cable with a "
+                            f"known-good one to rule out cable damage. "
+                            f"(3) If a fresh cable doesn't help, move the camera "
+                            f"to a different switch port."
                         ),
                         details={
                             "serial": cam_info.serial,

--- a/multi_camera/acquisition/health.py
+++ b/multi_camera/acquisition/health.py
@@ -39,12 +39,19 @@ def max_severity(levels: list[Severity]) -> Severity:
 
 
 class Finding(BaseModel):
-    """A single plain-English health observation for display to the operator."""
+    """A single plain-English health observation for display to the operator.
+
+    ``message`` is the short banner-friendly summary (kept under ~80 chars where
+    practical). ``remediation`` is an optional ordered list of recovery steps,
+    rendered as a numbered list inside the Diagnostics tab. Long step-by-step
+    text belongs in ``remediation``, not ``message``.
+    """
 
     level: Severity
     code: str
     message: str
     details: dict[str, Any] = Field(default_factory=dict)
+    remediation: list[str] | None = None
 
 
 class DhcpServerStatus(BaseModel):
@@ -733,17 +740,14 @@ def check_camera_reachability(
                         code="camera_throughput_outlier",
                         message=(
                             f"Camera {cam_info.serial} link is at ~{cam_mbps} Mbps "
-                            f"(others at ~{median_mbps} Mbps). Recordings will be "
-                            f"unusable until fixed. Software fixes (Restart "
-                            f"acquisition / Restore defaults) won't help — this is "
-                            f"a physical link issue. "
-                            f"(1) Unplug and re-plug the camera's ethernet cable at "
-                            f"both ends to force the link to renegotiate. "
-                            f"(2) If the issue returns, swap the cable with a "
-                            f"known-good one to rule out cable damage. "
-                            f"(3) If a fresh cable doesn't help, move the camera "
-                            f"to a different switch port."
+                            f"(others at ~{median_mbps} Mbps) — recordings unusable."
                         ),
+                        remediation=[
+                            "Unplug and re-plug the camera's ethernet cable at both ends to force PHY renegotiation.",
+                            "If the issue returns within a session, swap the cable with a known-good one to rule out cable damage.",
+                            "If a fresh cable doesn't help, move the camera to a different switch port.",
+                            "Software fixes (Restart acquisition, Restore defaults) won't help — this is a physical link issue.",
+                        ],
                         details={
                             "serial": cam_info.serial,
                             "link_throughput_bytes_per_sec": cam_info.link_throughput_bytes_per_sec,

--- a/multi_camera/acquisition/health.py
+++ b/multi_camera/acquisition/health.py
@@ -66,6 +66,7 @@ class CameraReachability(BaseModel):
     expected: bool
     ip: str | None = None
     link_speed_mbps: int | None = None
+    link_throughput_bytes_per_sec: int | None = None
     locked_by_other_process: bool = False
     last_error: str | None = None
 
@@ -408,6 +409,12 @@ class DetectedCamera(BaseModel):
     serial: str
     ip: str | None = None
     link_speed_mbps: int | None = None
+    # Camera's negotiated outbound throughput cap. Auto-set from link speed at
+    # Init time, so a value much lower than other cameras' is the strongest
+    # available signal that the camera fell back to a slower link (e.g. 100 Mbps
+    # on a degraded cable). Only readable from an Init'd device, so the bare
+    # PySpin enumerator path leaves this None.
+    link_throughput_bytes_per_sec: int | None = None
 
 
 class RecorderLike(Protocol):
@@ -439,7 +446,14 @@ def _snapshot_from_recorder(cam: Any) -> DetectedCamera | None:
         if isinstance(link_speed, int) and link_speed > 0
         else None
     )
-    return DetectedCamera(serial=str(serial), ip=ip, link_speed_mbps=link_mbps)
+    throughput = _read_camera_attribute(cam, "DeviceLinkThroughputLimit")
+    throughput_int = int(throughput) if isinstance(throughput, int) else None
+    return DetectedCamera(
+        serial=str(serial),
+        ip=ip,
+        link_speed_mbps=link_mbps,
+        link_throughput_bytes_per_sec=throughput_int,
+    )
 
 
 def _int_to_ipv4(value: int) -> str | None:
@@ -619,6 +633,9 @@ def check_camera_reachability(
                 expected=serial in expected_set,
                 ip=cam.ip if cam else None,
                 link_speed_mbps=cam.link_speed_mbps if cam else None,
+                link_throughput_bytes_per_sec=(
+                    cam.link_throughput_bytes_per_sec if cam else None
+                ),
             )
         )
 
@@ -685,6 +702,45 @@ def check_camera_reachability(
                         details={
                             "serial": cam_info.serial,
                             "link_speed_mbps": cam_info.link_speed_mbps,
+                        },
+                    )
+                )
+
+    # Throughput-outlier detector: catches the case where GevDeviceLinkSpeed
+    # reports 1000 (camera firmware bug) but DeviceLinkThroughputLimit reveals
+    # the link is actually 100 Mbps. Fires when one camera's throughput is
+    # < 50% of the median across detected cameras.
+    throughputs = [
+        c.link_throughput_bytes_per_sec
+        for c in cameras
+        if c.detected and c.link_throughput_bytes_per_sec is not None
+    ]
+    if len(throughputs) >= 3:
+        sorted_t = sorted(throughputs)
+        median_t = sorted_t[len(sorted_t) // 2]
+        outlier_threshold = median_t // 2
+        for cam_info in cameras:
+            if (
+                cam_info.detected
+                and cam_info.link_throughput_bytes_per_sec is not None
+                and cam_info.link_throughput_bytes_per_sec < outlier_threshold
+            ):
+                cam_mbps = cam_info.link_throughput_bytes_per_sec * 8 // 1_000_000
+                median_mbps = median_t * 8 // 1_000_000
+                findings.append(
+                    Finding(
+                        level="warn",
+                        code="camera_throughput_outlier",
+                        message=(
+                            f"Camera {cam_info.serial} link throughput is "
+                            f"~{cam_mbps} Mbps vs median ~{median_mbps} Mbps "
+                            f"across the rig — likely stuck at 100 Mbps. "
+                            f"Try unplug/replug the camera's cable."
+                        ),
+                        details={
+                            "serial": cam_info.serial,
+                            "link_throughput_bytes_per_sec": cam_info.link_throughput_bytes_per_sec,
+                            "median_throughput_bytes_per_sec": median_t,
                         },
                     )
                 )

--- a/multi_camera/backend/fastapi.py
+++ b/multi_camera/backend/fastapi.py
@@ -1123,6 +1123,54 @@ async def reset_cameras():
     return {"status": "success"}
 
 
+@api_router.post("/cameras/{serial}/restore_defaults")
+async def restore_camera_defaults(serial: str):
+    """Restore one camera to factory defaults via UserSetLoad, then re-init
+    the system so every camera picks up the saved config cleanly. Recovery
+    path for the 'one camera latched a bad feature value
+    (DeviceLinkThroughputLimit, LineMode, etc.) that survives soft restart'
+    case — equivalent to SpinView's 'Restore Factory Defaults' followed by
+    reconfigure.
+
+    Returns 409 if recording, 404 if the serial isn't currently in cams.
+    """
+    state: GlobalState = get_global_state()
+    if state.recording_status == "Recording":
+        raise HTTPException(
+            status_code=409,
+            detail="Cannot restore camera defaults while a recording is active.",
+        )
+
+    saved_config = getattr(state.acquisition, "config_file", None)
+
+    broadcast_event(
+        event_type="session_insight",
+        level="warn",
+        code="restore_defaults_started",
+        message=f"Restoring factory defaults on camera {serial}…",
+    )
+
+    try:
+        await run_in_threadpool(
+            state.acquisition.restore_camera_defaults, serial
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
+    state.acquisition.reset()
+    if saved_config:
+        await state.acquisition.configure_cameras(saved_config)
+
+    broadcast_event(
+        event_type="session_insight",
+        level="ok",
+        code="restore_defaults_complete",
+        message=f"Camera {serial} restored to factory defaults and re-configured.",
+    )
+
+    return {"status": "success", "serial": serial, "config": saved_config}
+
+
 @api_router.post("/restart_acquisition")
 async def restart_acquisition():
     """Tear down the PySpin system and reinitialize from the saved config.

--- a/multi_camera/backend/fastapi.py
+++ b/multi_camera/backend/fastapi.py
@@ -872,6 +872,13 @@ async def new_trial(data: NewTrialData, db: Session = Depends(db_dependency)):
     def receive_frames_wrapper(frames):
         loop.create_task(receive_frames(frames))
 
+    # Flip status synchronously before scheduling the acquisition thread, so
+    # recovery endpoints (restart/restore/exclude) immediately see the system
+    # as busy. Otherwise this handler returns 200 before start_acquisition's
+    # set_status("Recording") runs on the worker, leaving a window where a
+    # follow-up Restart click would tear down PySpin mid-BeginAcquisition.
+    state.recording_status = "Starting"
+
     # run acquisition in a separate thread
     acquisition_coroutine = run_in_threadpool(
         state.acquisition.start_acquisition,
@@ -906,6 +913,11 @@ async def new_trial(data: NewTrialData, db: Session = Depends(db_dependency)):
         except Exception as e:
             import traceback
             acquisition_logger.error(f"Trial failed: {e}", exc_info=True)
+            # If start_acquisition raised before its set_status("Recording")
+            # ran, status is still "Starting" — clear it so recovery
+            # endpoints aren't blocked.
+            if state.recording_status == "Starting":
+                state.recording_status = "Idle"
             broadcast_event(
                 event_type="error",
                 level="error",
@@ -1102,6 +1114,14 @@ async def get_current_config() -> str:
     return os.path.split(config)[-1]
 
 
+# States during which recovery endpoints (restart / restore / exclude) must
+# refuse to act. "Starting" exists to close the race between new_trial
+# returning 200 and FlirRecorder.start_acquisition flipping the status to
+# "Recording" on its worker thread — without it, a fast click on
+# "Restart acquisition" could tear down PySpin mid-BeginAcquisition.
+_BUSY_RECORDING_STATES = frozenset({"Starting", "Recording"})
+
+
 async def _refresh_health_after_configure() -> None:
     """Force a health re-check after a camera reconfigure so the operator
     immediately sees post-init state (link speeds, throughput, missing
@@ -1119,6 +1139,45 @@ async def _refresh_health_after_configure() -> None:
         code="post_configure_refresh",
         message="Health report updated after camera reconfigure.",
     )
+
+
+async def _reset_and_configure(saved_config: str | None, action: str) -> None:
+    """Tear down PySpin and reconfigure from saved_config. If reconfigure
+    fails the system is left with no cams Init'd; broadcast an error
+    envelope with recovery instructions so the operator sees it in the
+    diagnostics-tab finding list rather than just a small red div under
+    the button. Re-raises so the calling endpoint returns 500.
+
+    `action` is the operator-facing verb (e.g. "Restart") used in the
+    error message.
+    """
+    state: GlobalState = get_global_state()
+    # Camera close is per-camera over a threadpool inside FlirRecorder; with
+    # 8+ cameras it can stall the asyncio event loop for seconds, blocking
+    # the very websocket fanout that just queued the "started" envelope.
+    await run_in_threadpool(state.acquisition.reset)
+    if saved_config is None:
+        return
+    try:
+        await state.acquisition.configure_cameras(saved_config)
+    except Exception as e:  # noqa: BLE001
+        acquisition_logger.error(
+            f"{action}: configure_cameras failed after reset: {e}", exc_info=True
+        )
+        broadcast_event(
+            event_type="session_insight",
+            level="error",
+            code="reconfigure_failed",
+            message=f"{action} failed: cameras did not come back up ({e}).",
+            details={
+                "remediation": [
+                    "Click 'Restart acquisition' to retry.",
+                    "If it fails again, power-cycle the camera switch and retry.",
+                    "If the issue persists, check that all cameras are powered and connected.",
+                ],
+            },
+        )
+        raise
 
 
 @api_router.post("/current_config")
@@ -1148,7 +1207,7 @@ async def _set_camera_excluded(serial: str, excluded: bool) -> dict:
     reconfigure so the change takes effect. Returns the new exclusion list.
     """
     state: GlobalState = get_global_state()
-    if state.recording_status == "Recording":
+    if state.recording_status in _BUSY_RECORDING_STATES:
         raise HTTPException(
             status_code=409,
             detail="Cannot change camera exclusion while a recording is active.",
@@ -1169,9 +1228,7 @@ async def _set_camera_excluded(serial: str, excluded: bool) -> dict:
         message=f"{action} camera {serial}; reconfiguring…",
     )
 
-    state.acquisition.reset()
-    if saved_config:
-        await state.acquisition.configure_cameras(saved_config)
+    await _reset_and_configure(saved_config, action=action)
 
     await _refresh_health_after_configure()
 
@@ -1217,7 +1274,7 @@ async def restore_camera_defaults(serial: str):
     Returns 409 if recording, 404 if the serial isn't currently in cams.
     """
     state: GlobalState = get_global_state()
-    if state.recording_status == "Recording":
+    if state.recording_status in _BUSY_RECORDING_STATES:
         raise HTTPException(
             status_code=409,
             detail="Cannot restore camera defaults while a recording is active.",
@@ -1239,9 +1296,7 @@ async def restore_camera_defaults(serial: str):
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
 
-    state.acquisition.reset()
-    if saved_config:
-        await state.acquisition.configure_cameras(saved_config)
+    await _reset_and_configure(saved_config, action="Restore defaults")
 
     await _refresh_health_after_configure()
 
@@ -1267,7 +1322,7 @@ async def restart_acquisition():
     Returns 409 while a recording is active.
     """
     state: GlobalState = get_global_state()
-    if state.recording_status == "Recording":
+    if state.recording_status in _BUSY_RECORDING_STATES:
         raise HTTPException(
             status_code=409,
             detail="Cannot restart acquisition while a recording is active.",
@@ -1283,9 +1338,7 @@ async def restart_acquisition():
         message="Restarting acquisition system…",
     )
 
-    state.acquisition.reset()
-    if saved_config:
-        await state.acquisition.configure_cameras(saved_config)
+    await _reset_and_configure(saved_config, action="Restart")
 
     await _refresh_health_after_configure()
 

--- a/multi_camera/backend/fastapi.py
+++ b/multi_camera/backend/fastapi.py
@@ -1123,6 +1123,48 @@ async def reset_cameras():
     return {"status": "success"}
 
 
+@api_router.post("/restart_acquisition")
+async def restart_acquisition():
+    """Tear down the PySpin system and reinitialize from the saved config.
+
+    Distinct from /reset_cameras (which power-cycles each camera via
+    DeviceReset) — this only re-creates the software stack and re-runs
+    the PTP sync setup in configure_cameras. Recovery path for the
+    timestamp-spread > 1.0 / drifted-PTP case.
+
+    Returns 409 while a recording is active.
+    """
+    state: GlobalState = get_global_state()
+    if state.recording_status == "Recording":
+        raise HTTPException(
+            status_code=409,
+            detail="Cannot restart acquisition while a recording is active.",
+        )
+
+    # config_file gets cleared by close(); capture before reset().
+    saved_config = getattr(state.acquisition, "config_file", None)
+
+    broadcast_event(
+        event_type="session_insight",
+        level="warn",
+        code="restart_started",
+        message="Restarting acquisition system…",
+    )
+
+    state.acquisition.reset()
+    if saved_config:
+        await state.acquisition.configure_cameras(saved_config)
+
+    broadcast_event(
+        event_type="session_insight",
+        level="ok",
+        code="restart_complete",
+        message="Acquisition system restarted.",
+    )
+
+    return {"status": "success", "config": saved_config}
+
+
 # create an endpoint that exposes the camera statuses
 @api_router.get("/camera_status")
 async def get_camera_status() -> List[CameraStatus]:

--- a/multi_camera/backend/fastapi.py
+++ b/multi_camera/backend/fastapi.py
@@ -390,7 +390,7 @@ async def lifespan(app: FastAPI):
             # is also slow. Camera-specific issues during recording are
             # surfaced via the recorder's diagnostics_callback instead. DHCP
             # and host-network checks still run.
-            skip_camera_enumeration=(state.recording_status == "Recording"),
+            skip_camera_enumeration=(state.recording_status in _BUSY_RECORDING_STATES),
         ),
         on_poll=_on_idle_health_poll,
         logger=acquisition_logger,

--- a/multi_camera/backend/fastapi.py
+++ b/multi_camera/backend/fastapi.py
@@ -1143,6 +1143,68 @@ async def reset_cameras():
     return {"status": "success"}
 
 
+async def _set_camera_excluded(serial: str, excluded: bool) -> dict:
+    """Add/remove a camera from the operator-excluded set, then full
+    reconfigure so the change takes effect. Returns the new exclusion list.
+    """
+    state: GlobalState = get_global_state()
+    if state.recording_status == "Recording":
+        raise HTTPException(
+            status_code=409,
+            detail="Cannot change camera exclusion while a recording is active.",
+        )
+    saved_config = getattr(state.acquisition, "config_file", None)
+    current = set(getattr(state.acquisition, "excluded_serials", set()))
+    if excluded:
+        current.add(str(serial))
+    else:
+        current.discard(str(serial))
+    state.acquisition.set_excluded_serials(current)
+
+    action = "Excluded" if excluded else "Included"
+    broadcast_event(
+        event_type="session_insight",
+        level="warn" if excluded else "ok",
+        code=("camera_excluded" if excluded else "camera_included"),
+        message=f"{action} camera {serial}; reconfiguring…",
+    )
+
+    state.acquisition.reset()
+    if saved_config:
+        await state.acquisition.configure_cameras(saved_config)
+
+    await _refresh_health_after_configure()
+
+    return {
+        "status": "success",
+        "serial": serial,
+        "excluded": excluded,
+        "excluded_serials": sorted(current),
+    }
+
+
+@api_router.post("/cameras/{serial}/exclude")
+async def exclude_camera(serial: str):
+    """Remove a camera from this session's recordings without editing the
+    YAML config. Recovery path for one bad camera that's holding up the
+    rest of the rig (e.g. stuck-link case from the throughput-outlier
+    finding). Excluded cameras are not Init'd, do not appear in the
+    camera_status table, and are skipped by configure_cameras until
+    re-included via /cameras/{serial}/include or until the system restarts.
+
+    Returns 409 while a recording is active.
+    """
+    return await _set_camera_excluded(serial, excluded=True)
+
+
+@api_router.post("/cameras/{serial}/include")
+async def include_camera(serial: str):
+    """Re-add an operator-excluded camera back into the recording set
+    and reconfigure. Returns 409 while a recording is active.
+    """
+    return await _set_camera_excluded(serial, excluded=False)
+
+
 @api_router.post("/cameras/{serial}/restore_defaults")
 async def restore_camera_defaults(serial: str):
     """Restore one camera to factory defaults via UserSetLoad, then re-init

--- a/multi_camera/backend/fastapi.py
+++ b/multi_camera/backend/fastapi.py
@@ -1102,6 +1102,25 @@ async def get_current_config() -> str:
     return os.path.split(config)[-1]
 
 
+async def _refresh_health_after_configure() -> None:
+    """Force a health re-check after a camera reconfigure so the operator
+    immediately sees post-init state (link speeds, throughput, missing
+    cameras) without waiting for the next idle poll. Broadcasts the new
+    report so the GUI re-fetches.
+    """
+    try:
+        report = await _get_health_report(force_refresh=True)
+    except Exception as e:  # noqa: BLE001
+        acquisition_logger.warning(f"Post-configure health refresh failed: {e}")
+        return
+    broadcast_event(
+        event_type="health_report",
+        level=report.overall,
+        code="post_configure_refresh",
+        message="Health report updated after camera reconfigure.",
+    )
+
+
 @api_router.post("/current_config")
 async def update_config(config: ConfigFileData):
     print("Received config: ", config.config)
@@ -1112,6 +1131,7 @@ async def update_config(config: ConfigFileData):
         await state.acquisition.configure_cameras(
             os.path.join(CONFIG_PATH, config.config)
         )
+    await _refresh_health_after_configure()
     return {"status": "success", "config": config.config}
 
 
@@ -1161,6 +1181,8 @@ async def restore_camera_defaults(serial: str):
     if saved_config:
         await state.acquisition.configure_cameras(saved_config)
 
+    await _refresh_health_after_configure()
+
     broadcast_event(
         event_type="session_insight",
         level="ok",
@@ -1202,6 +1224,8 @@ async def restart_acquisition():
     state.acquisition.reset()
     if saved_config:
         await state.acquisition.configure_cameras(saved_config)
+
+    await _refresh_health_after_configure()
 
     broadcast_event(
         event_type="session_insight",

--- a/tests/acquisition/test_diagnostics_manager.py
+++ b/tests/acquisition/test_diagnostics_manager.py
@@ -1,13 +1,9 @@
-"""Tests for ``DiagnosticsManager`` — the WS fan-out used by PR 2's diagnostic
-envelope channel (``/api/v1/ws/diagnostics``).
+"""Tests for ``DiagnosticsManager`` — the WS fan-out behind
+``/api/v1/ws/diagnostics``.
 
-Failure modes the tests cover, all of which broke the v2 implementation that
-shared a single connection list with the recording-status WS:
-
-- Per-connection lock serializes concurrent broadcasts
-- A failing send_json drops the connection instead of leaving a stale entry
-- A dead connection does not block other connections from receiving
-- Disconnect clears the per-connection lock entry (no leak)
+Covers: per-connection lock serializes concurrent broadcasts, a failing
+send_json drops the connection, a dead connection doesn't block others,
+disconnect clears the per-connection lock entry.
 """
 
 from __future__ import annotations

--- a/tests/acquisition/test_health_cameras.py
+++ b/tests/acquisition/test_health_cameras.py
@@ -179,6 +179,60 @@ class TestEnumeratorPath:
         assert report.severity == "error"
 
 
+class TestThroughputOutlier:
+    def test_one_camera_throttled_fires_outlier_finding(self) -> None:
+        """Catches the 100 Mbps stuck-link case where GevDeviceLinkSpeed may
+        misreport but DeviceLinkThroughputLimit is accurate."""
+
+        def fake_enum() -> list[DetectedCamera]:
+            return [
+                DetectedCamera(serial="A", link_speed_mbps=1000, link_throughput_bytes_per_sec=92_000_000),
+                DetectedCamera(serial="B", link_speed_mbps=1000, link_throughput_bytes_per_sec=92_000_000),
+                DetectedCamera(serial="C", link_speed_mbps=1000, link_throughput_bytes_per_sec=92_000_000),
+                DetectedCamera(serial="D", link_speed_mbps=1000, link_throughput_bytes_per_sec=12_000_000),
+            ]
+
+        report = check_camera_reachability(
+            expected_serials=["A", "B", "C", "D"],
+            recorder=None,
+            enumerator=fake_enum,
+        )
+        outliers = [f for f in report.findings if f.code == "camera_throughput_outlier"]
+        assert len(outliers) == 1
+        assert "D" in outliers[0].message
+        assert outliers[0].details["serial"] == "D"
+
+    def test_uniform_throughput_no_outlier(self) -> None:
+        def fake_enum() -> list[DetectedCamera]:
+            return [
+                DetectedCamera(serial=str(i), link_speed_mbps=1000, link_throughput_bytes_per_sec=92_000_000)
+                for i in range(4)
+            ]
+
+        report = check_camera_reachability(
+            expected_serials=[str(i) for i in range(4)],
+            recorder=None,
+            enumerator=fake_enum,
+        )
+        assert not any(f.code == "camera_throughput_outlier" for f in report.findings)
+
+    def test_below_three_cameras_skips_detector(self) -> None:
+        """Median is meaningless with only 1-2 samples — don't fire."""
+
+        def fake_enum() -> list[DetectedCamera]:
+            return [
+                DetectedCamera(serial="A", link_throughput_bytes_per_sec=92_000_000),
+                DetectedCamera(serial="B", link_throughput_bytes_per_sec=12_000_000),
+            ]
+
+        report = check_camera_reachability(
+            expected_serials=["A", "B"],
+            recorder=None,
+            enumerator=fake_enum,
+        )
+        assert not any(f.code == "camera_throughput_outlier" for f in report.findings)
+
+
 class TestShortCircuit:
     def test_no_recorder_no_expected_short_circuits(self) -> None:
         """When nothing is configured, skip PySpin enumeration entirely."""

--- a/tests/acquisition/test_restart_acquisition.py
+++ b/tests/acquisition/test_restart_acquisition.py
@@ -65,6 +65,7 @@ class StubRecorder:
         self.cams: list[Any] = []
         self.calls: list[Any] = []
         self.known_serials: list[str] = []
+        self.excluded_serials: set[str] = set()
 
     def __call__(self, *args, **kwargs):
         return self
@@ -89,12 +90,7 @@ class StubRecorder:
             raise ValueError(f"Camera {serial} not found")
         self.calls.append(("restore_camera_defaults", serial))
 
-    def __post_init_excluded(self):
-        if not hasattr(self, "excluded_serials"):
-            self.excluded_serials = set()
-
     def set_excluded_serials(self, serials):
-        self.__post_init_excluded()
         self.excluded_serials = {str(s) for s in serials}
         self.calls.append(("set_excluded_serials", sorted(self.excluded_serials)))
 
@@ -158,7 +154,7 @@ def test_restore_defaults_returns_404_for_unknown_serial(configured_backend) -> 
         r = client.post("/api/v1/cameras/99999999/restore_defaults")
     assert r.status_code == 404
     # No reset/reconfigure when the target serial isn't recognized.
-    assert all(c[0] != "reset" for c in stub.calls if isinstance(c, str) is False) or "reset" not in stub.calls
+    assert "reset" not in stub.calls
 
 
 def test_restore_defaults_returns_409_while_recording(configured_backend) -> None:
@@ -173,7 +169,6 @@ def test_restore_defaults_returns_409_while_recording(configured_backend) -> Non
 
 def test_exclude_camera_sets_then_reconfigures(configured_backend) -> None:
     state, stub = configured_backend
-    stub.excluded_serials = set()
     saved_config = stub.config_file
     with TestClient(backend.app) as client:
         r = client.post("/api/v1/cameras/23280538/exclude")

--- a/tests/acquisition/test_restart_acquisition.py
+++ b/tests/acquisition/test_restart_acquisition.py
@@ -64,6 +64,7 @@ class StubRecorder:
         self.camera_config: dict[str, Any] = {"camera-info": {}}
         self.cams: list[Any] = []
         self.calls: list[Any] = []
+        self.known_serials: list[str] = []
 
     def __call__(self, *args, **kwargs):
         return self
@@ -82,6 +83,11 @@ class StubRecorder:
 
     def close(self):
         return None
+
+    def restore_camera_defaults(self, serial: str) -> None:
+        if serial not in self.known_serials:
+            raise ValueError(f"Camera {serial} not found")
+        self.calls.append(("restore_camera_defaults", serial))
 
 
 @pytest.fixture
@@ -114,6 +120,44 @@ def test_restart_returns_409_while_recording(configured_backend) -> None:
     state.recording_status = "Recording"
     with TestClient(backend.app) as client:
         r = client.post("/api/v1/restart_acquisition")
+    assert r.status_code == 409
+    assert stub.calls == []
+
+
+def test_restore_defaults_runs_then_reinits(configured_backend) -> None:
+    state, stub = configured_backend
+    stub.known_serials = ["23280538", "20150962"]
+    saved_config = stub.config_file
+    with TestClient(backend.app) as client:
+        r = client.post("/api/v1/cameras/23280538/restore_defaults")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "success"
+    assert body["serial"] == "23280538"
+    # Order: per-camera restore first, then full reset, then reconfigure.
+    assert stub.calls == [
+        ("restore_camera_defaults", "23280538"),
+        "reset",
+        ("configure_cameras", saved_config),
+    ]
+
+
+def test_restore_defaults_returns_404_for_unknown_serial(configured_backend) -> None:
+    state, stub = configured_backend
+    stub.known_serials = ["20150962"]
+    with TestClient(backend.app) as client:
+        r = client.post("/api/v1/cameras/99999999/restore_defaults")
+    assert r.status_code == 404
+    # No reset/reconfigure when the target serial isn't recognized.
+    assert all(c[0] != "reset" for c in stub.calls if isinstance(c, str) is False) or "reset" not in stub.calls
+
+
+def test_restore_defaults_returns_409_while_recording(configured_backend) -> None:
+    state, stub = configured_backend
+    stub.known_serials = ["23280538"]
+    state.recording_status = "Recording"
+    with TestClient(backend.app) as client:
+        r = client.post("/api/v1/cameras/23280538/restore_defaults")
     assert r.status_code == 409
     assert stub.calls == []
 

--- a/tests/acquisition/test_restart_acquisition.py
+++ b/tests/acquisition/test_restart_acquisition.py
@@ -89,6 +89,15 @@ class StubRecorder:
             raise ValueError(f"Camera {serial} not found")
         self.calls.append(("restore_camera_defaults", serial))
 
+    def __post_init_excluded(self):
+        if not hasattr(self, "excluded_serials"):
+            self.excluded_serials = set()
+
+    def set_excluded_serials(self, serials):
+        self.__post_init_excluded()
+        self.excluded_serials = {str(s) for s in serials}
+        self.calls.append(("set_excluded_serials", sorted(self.excluded_serials)))
+
 
 @pytest.fixture
 def configured_backend(monkeypatch: pytest.MonkeyPatch):
@@ -158,6 +167,44 @@ def test_restore_defaults_returns_409_while_recording(configured_backend) -> Non
     state.recording_status = "Recording"
     with TestClient(backend.app) as client:
         r = client.post("/api/v1/cameras/23280538/restore_defaults")
+    assert r.status_code == 409
+    assert stub.calls == []
+
+
+def test_exclude_camera_sets_then_reconfigures(configured_backend) -> None:
+    state, stub = configured_backend
+    stub.excluded_serials = set()
+    saved_config = stub.config_file
+    with TestClient(backend.app) as client:
+        r = client.post("/api/v1/cameras/23280538/exclude")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["excluded"] is True
+    assert body["excluded_serials"] == ["23280538"]
+    # Order: set the exclusion, then reset, then configure_cameras.
+    assert stub.calls == [
+        ("set_excluded_serials", ["23280538"]),
+        "reset",
+        ("configure_cameras", saved_config),
+    ]
+
+
+def test_include_camera_clears_exclusion(configured_backend) -> None:
+    state, stub = configured_backend
+    stub.excluded_serials = {"23280538", "20150962"}
+    with TestClient(backend.app) as client:
+        r = client.post("/api/v1/cameras/23280538/include")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["excluded"] is False
+    assert body["excluded_serials"] == ["20150962"]
+
+
+def test_exclude_returns_409_while_recording(configured_backend) -> None:
+    state, stub = configured_backend
+    state.recording_status = "Recording"
+    with TestClient(backend.app) as client:
+        r = client.post("/api/v1/cameras/23280538/exclude")
     assert r.status_code == 409
     assert stub.calls == []
 

--- a/tests/acquisition/test_restart_acquisition.py
+++ b/tests/acquisition/test_restart_acquisition.py
@@ -1,0 +1,134 @@
+"""Integration test for the /api/v1/restart_acquisition endpoint.
+
+Uses FastAPI's TestClient with a stub recorder. Verifies:
+- reset() runs first, then configure_cameras with the saved config_file
+- 409 is returned (and recorder is untouched) while recording
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+
+import pytest
+
+
+def _install_pyspin_stubs() -> None:
+    for name in ("PySpin", "simple_pyspin"):
+        if name in sys.modules:
+            continue
+        stub = types.ModuleType(name)
+        if name == "simple_pyspin":
+
+            class _Camera:
+                def __init__(self, *args, **kwargs):
+                    raise RuntimeError("PySpin stub")
+
+            stub.Camera = _Camera  # type: ignore[attr-defined]
+            stub._SYSTEM = None  # type: ignore[attr-defined]
+            stub.list_cameras = lambda: []  # type: ignore[attr-defined]
+        sys.modules[name] = stub
+
+
+_install_pyspin_stubs()
+
+
+def _import_backend():
+    import os
+    import unittest.mock as _mock
+
+    real_listdir = os.listdir
+
+    def safe_listdir(path):
+        if str(path).startswith("/configs"):
+            return []
+        return real_listdir(path)
+
+    os.makedirs("data", exist_ok=True)
+    with _mock.patch("os.listdir", side_effect=safe_listdir):
+        from fastapi.testclient import TestClient as _TestClient
+        from multi_camera.backend import fastapi as _backend
+    return _TestClient, _backend
+
+
+try:
+    TestClient, backend = _import_backend()
+except Exception as exc:  # pragma: no cover
+    pytest.skip(f"Backend not importable: {exc}", allow_module_level=True)
+
+
+class StubRecorder:
+    def __init__(self, config_file: str = "/configs/test.yaml"):
+        self.config_file = config_file
+        self.camera_config: dict[str, Any] = {"camera-info": {}}
+        self.cams: list[Any] = []
+        self.calls: list[Any] = []
+
+    def __call__(self, *args, **kwargs):
+        return self
+
+    def reset(self):
+        self.calls.append("reset")
+        # The real FlirRecorder.close() (called from reset()) clears config_file.
+        self.config_file = None
+
+    async def configure_cameras(self, config_file=None, **kwargs):
+        self.calls.append(("configure_cameras", config_file))
+        self.config_file = config_file
+
+    async def get_camera_status(self):
+        return []
+
+    def close(self):
+        return None
+
+
+@pytest.fixture
+def configured_backend(monkeypatch: pytest.MonkeyPatch):
+    stub = StubRecorder()
+    monkeypatch.setattr(backend, "FlirRecorder", lambda *a, **kw: stub)
+    monkeypatch.setattr(backend, "synchronize_to_datajoint", lambda *a, **kw: None)
+    state = backend.get_global_state()
+    state.recording_status = "Idle"
+    state.acquisition = stub
+    yield state, stub
+
+
+def test_restart_when_idle_resets_then_reconfigures(configured_backend) -> None:
+    state, stub = configured_backend
+    saved_config = stub.config_file
+    with TestClient(backend.app) as client:
+        r = client.post("/api/v1/restart_acquisition")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "success"
+    assert body["config"] == saved_config
+    # reset() ran first, then configure_cameras with the saved path.
+    assert stub.calls[0] == "reset"
+    assert stub.calls[1] == ("configure_cameras", saved_config)
+
+
+def test_restart_returns_409_while_recording(configured_backend) -> None:
+    state, stub = configured_backend
+    state.recording_status = "Recording"
+    with TestClient(backend.app) as client:
+        r = client.post("/api/v1/restart_acquisition")
+    assert r.status_code == 409
+    assert stub.calls == []
+
+
+def test_restart_without_saved_config_skips_configure(monkeypatch) -> None:
+    """If the recorder has no config_file (e.g. never configured), restart
+    still tears down PySpin but skips the configure call."""
+    stub = StubRecorder(config_file=None)
+    monkeypatch.setattr(backend, "FlirRecorder", lambda *a, **kw: stub)
+    monkeypatch.setattr(backend, "synchronize_to_datajoint", lambda *a, **kw: None)
+    state = backend.get_global_state()
+    state.recording_status = "Idle"
+    state.acquisition = stub
+
+    with TestClient(backend.app) as client:
+        r = client.post("/api/v1/restart_acquisition")
+    assert r.status_code == 200
+    assert stub.calls == ["reset"]


### PR DESCRIPTION
## Summary                                                                                                                                   
                                                            
  Operator-facing recovery actions and live link-quality diagnostics on top of PR 2's envelope channel.
                                                                                                                                               
  ## What's new                                                                                                                                
  
  **Recovery actions in the GUI (no SpinView, no docker restart):**                                                                            
                                                            
  - **Restart acquisition** button on the Diagnostics tab - `reset()` + reconfigure from the saved config. Recovery path for PTP drift / timestamp-spread > 1.0 / generally needing to redo PySpin init without bouncing the container.
  - **Restore defaults** button per camera in the camera-status table - loads the `Default` UserSet via explicit PySpin `CCommandPtr.Execute()` (not `simple_pyspin` attribute syntax, which silently no-ops on Command nodes) and pins it as the boot UserSet. Clears latched feature state (`DeviceLinkThroughputLimit`, etc.) without a power-cycle.
  - **Exclude / Include** camera per row in the Diagnostics tab — skips a camera in `configure_cameras` without editing the YAML config. Lets the operator record from N–1 cameras when one is misbehaving, then re-include later. The filtered config gets a different `camera_config_hash`, so DataJoint correctly tracks it as a distinct setup.
                                                                                                                                               
  All four recovery endpoints (`/restart_acquisition`, `/cameras/{serial}/restore_defaults`, `/cameras/{serial}/exclude`,                      
  `/cameras/{serial}/include`) return 409 while recording. Frontend disables the buttons during recording.
                                                                                                                                               
  **Link-quality diagnostics:**                             

  - Per-camera **link throughput** (`DeviceLinkThroughputLimit`) read from the recorder snapshot and surfaced as a table column on the Diagnostics tab.
  - **Throughput-outlier detector** — fires `camera_throughput_outlier` at `error` level when one camera's throughput is < 50% of the median across ≥3 detected cameras. Direct response to a real 100 Mbps stuck-link case (serial 23280538) that `GevDeviceLinkSpeed` mis-reported as 1 Gbps but `DeviceLinkThroughputLimit` revealed.
  - **Structured remediation** — `Finding.remediation: list[str] | None`. Banner stays terse; the diagnostics tab renders the steps as a numbered list. Used by the throughput-outlier and reconfigure-failed findings.                                                               
  
  **Backend correctness fixes (from code review):**                                                                                            
                                                            
  - TOCTOU on `recording_status` — `new_trial` flips status to `"Starting"` synchronously before scheduling `start_acquisition`; recovery endpoints gate on `_BUSY_RECORDING_STATES = {"Starting", "Recording"}`. Closes the ~50ms window where a fast double-click could tear down PySpin mid-`BeginAcquisition`.                                                                                                               
  - Event-loop blocking — `state.acquisition.reset()` now goes through `run_in_threadpool` via the new `_reset_and_configure` helper. With 8+ cameras the per-camera close loop could otherwise stall the websocket fanout for seconds.                                                    
  - Unrecoverable half-state — if `configure_cameras` raises after `reset()`, `_reset_and_configure` broadcasts a `reconfigure_failed` session_insight with structured remediation steps so the operator sees it in the diagnostics finding list                                                  
  - Idle poller extension — `skip_camera_enumeration` now triggers on `"Starting"` too, matching the busy-states set.                          
                                                                                                                                               
  ## Test plan
                                                                                                                                               
  - [x] Unit tests: 135 pass (9 new in `test_restart_acquisition.py`, 3 in `TestThroughputOutlier`)
  - [x] Laptop: Restart acquisition button — reset + reconfigure clean, 409 while recording                                                    
  - [x] Laptop: Restore defaults — confirmed `DeviceLinkThroughputLimit` before/after logging is correct via explicit `CCommandPtr.Execute()`
  - [x] Laptop: Exclude camera → reconfigure runs without it → GUI marks `excluded` → Include puts it back                                     
  - [x] Laptop: Throughput-outlier detector caught the real 100 Mbps stuck-link case end-to-end (red banner + structured remediation visible in
   Diagnostics tab)                                                                                                                            
  - [x] Laptop: Buttons disabled during recording (frontend gate)