### PR TITLE
Feature/aruco calibration integration v2

### DIFF
--- a/multi_camera/analysis/aruco.py
+++ b/multi_camera/analysis/aruco.py
@@ -212,12 +212,21 @@ def detect_markers_multi_camera(
     dictionary_id: int = cv2.aruco.DICT_4X4_250,
     frame_step: int = 1,
     max_workers: int | None = 4,
+    cv2_threads_per_worker: int = 1,
 ) -> dict[str, CameraDetectionResult]:
     """Run ArUco detection across multiple synchronized camera videos in parallel.
 
     ``expected_ids=None`` returns every marker the detector finds — appropriate
     for generic detection where the protocol isn't yet known.
+
+    ``cv2_threads_per_worker`` caps OpenCV's internal TBB threading per detect
+    call. Without it, each ``cv2.aruco.detectMarkers`` call fans out across
+    every CPU and the outer ``max_workers`` pool stops being a meaningful
+    concurrency limit. Effective core count ≈ ``max_workers * cv2_threads_per_worker``.
+    Set to 0 to keep OpenCV's default (= all cores).
     """
+    if cv2_threads_per_worker > 0:
+        cv2.setNumThreads(cv2_threads_per_worker)
 
     def _process_camera(cam_name: str, video_path: str) -> tuple[str, CameraDetectionResult]:
         detector = create_aruco_detector(dictionary_id)

--- a/multi_camera/analysis/aruco.py
+++ b/multi_camera/analysis/aruco.py
@@ -1,0 +1,514 @@
+"""Generic ArUco marker detection in multi-camera videos.
+
+Detection / triangulation primitives used by calibration-time ArUco workflows.
+Protocol-specific interpretation (e.g. walkway goalposts) lives downstream
+(see gait_analytics for the 10MWT walkway interpretation).
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+from dataclasses import dataclass
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+
+def aruco_dictionary_name(dictionary_id: int) -> str:
+    """Return the cv2.aruco predefined-dictionary name for an integer ID.
+
+    cv2.aruco exposes constants like ``cv2.aruco.DICT_4X4_250`` whose values are
+    plain integers; there's no built-in inverse lookup. This walks the module
+    once and returns the first matching ``DICT_*`` attribute name. Falls back
+    to ``"DICT_UNKNOWN_{n}"`` if the id doesn't match a known constant.
+    """
+    for attr in dir(cv2.aruco):
+        if attr.startswith("DICT_") and getattr(cv2.aruco, attr) == dictionary_id:
+            return attr
+    return f"DICT_UNKNOWN_{dictionary_id}"
+
+
+@dataclass
+class MarkerDetection:
+    marker_id: int
+    corners: np.ndarray
+    center: np.ndarray
+
+
+@dataclass
+class FrameDetections:
+    frame_idx: int
+    detections: list[MarkerDetection]
+
+
+@dataclass
+class CameraDetectionResult:
+    camera_name: str
+    video_path: str
+    total_frames: int
+    fps: float
+    width: int
+    height: int
+    frame_detections: list[FrameDetections]
+
+    def detection_rate(self, marker_id: int) -> float:
+        frames_processed = len(self.frame_detections)
+        if frames_processed == 0:
+            return 0.0
+        frames_with_marker = sum(
+            1 for fd in self.frame_detections if any(d.marker_id == marker_id for d in fd.detections)
+        )
+        return frames_with_marker / frames_processed
+
+    def to_dict(self) -> dict:
+        return {
+            "camera_name": self.camera_name,
+            "video_path": self.video_path,
+            "total_frames": self.total_frames,
+            "fps": self.fps,
+            "width": self.width,
+            "height": self.height,
+            "frame_detections": [
+                {
+                    "frame_idx": fd.frame_idx,
+                    "detections": [
+                        {"marker_id": d.marker_id, "corners": d.corners, "center": d.center} for d in fd.detections
+                    ],
+                }
+                for fd in self.frame_detections
+            ],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "CameraDetectionResult":
+        return cls(
+            camera_name=data["camera_name"],
+            video_path=data["video_path"],
+            total_frames=data["total_frames"],
+            fps=data["fps"],
+            width=data["width"],
+            height=data["height"],
+            frame_detections=[
+                FrameDetections(
+                    frame_idx=fd["frame_idx"],
+                    detections=[
+                        MarkerDetection(marker_id=d["marker_id"], corners=d["corners"], center=d["center"])
+                        for d in fd["detections"]
+                    ],
+                )
+                for fd in data["frame_detections"]
+            ],
+        )
+
+
+def create_aruco_detector(
+    dictionary_id: int = cv2.aruco.DICT_4X4_250,
+    aggressive: bool = True,
+) -> cv2.aruco.ArucoDetector:
+    dictionary = cv2.aruco.getPredefinedDictionary(dictionary_id)
+    parameters = cv2.aruco.DetectorParameters()
+    if aggressive:
+        # Smaller adaptive threshold windows help detect small/distant markers
+        parameters.adaptiveThreshWinSizeMin = 3
+        parameters.adaptiveThreshWinSizeMax = 53
+        parameters.adaptiveThreshWinSizeStep = 4
+        # Lower perimeter threshold to detect markers that appear small at oblique angles
+        parameters.minMarkerPerimeterRate = 0.01
+        # More bits per cell for perspective-distorted markers viewed at grazing angles
+        parameters.perspectiveRemovePixelPerCell = 8
+        # Allow more error bits for partially occluded or glare-affected markers
+        parameters.maxErroneousBitsInBorderRate = 0.5
+        # Subpixel corner refinement
+        parameters.cornerRefinementMethod = cv2.aruco.CORNER_REFINE_SUBPIX
+    return cv2.aruco.ArucoDetector(dictionary, parameters)
+
+
+def detect_markers_in_frame(
+    frame: np.ndarray,
+    detector: cv2.aruco.ArucoDetector,
+    expected_ids: set[int] | None = None,
+) -> list[MarkerDetection]:
+    """Detect ArUco markers in a frame.
+
+    If ``expected_ids`` is provided, only markers with matching IDs are returned;
+    pass ``None`` to return every marker the detector finds.
+    """
+    lab = cv2.cvtColor(frame, cv2.COLOR_BGR2LAB)
+    lab[:, :, 0] = cv2.createCLAHE(clipLimit=3.0, tileGridSize=(8, 8)).apply(lab[:, :, 0])
+    enhanced = cv2.cvtColor(lab, cv2.COLOR_LAB2BGR)
+
+    corners, ids, _ = detector.detectMarkers(enhanced)
+    detections: list[MarkerDetection] = []
+
+    if ids is not None:
+        for i, marker_id in enumerate(ids.flatten()):
+            mid = int(marker_id)
+            if expected_ids is None or mid in expected_ids:
+                corner_pts = corners[i][0]
+                center = np.mean(corner_pts, axis=0)
+                detections.append(MarkerDetection(marker_id=mid, corners=corner_pts, center=center))
+
+    return detections
+
+
+def get_marker_centers_by_frame(
+    result: CameraDetectionResult,
+    marker_id: int,
+) -> dict[int, np.ndarray]:
+    centers: dict[int, np.ndarray] = {}
+    for fd in result.frame_detections:
+        for det in fd.detections:
+            if det.marker_id == marker_id:
+                centers[fd.frame_idx] = det.center
+                break
+    return centers
+
+
+def detect_markers_in_video(
+    video_path: str,
+    detector: cv2.aruco.ArucoDetector,
+    expected_ids: list[int] | None = None,
+    camera_name: str = "",
+    frame_step: int = 1,
+) -> CameraDetectionResult:
+    cap = cv2.VideoCapture(video_path)
+    total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+    fps = cap.get(cv2.CAP_PROP_FPS)
+    width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+    height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+
+    expected_set = set(expected_ids) if expected_ids is not None else None
+    frame_detections: list[FrameDetections] = []
+
+    frame_idx = 0
+    while frame_idx < total_frames:
+        if frame_step > 1:
+            cap.set(cv2.CAP_PROP_POS_FRAMES, frame_idx)
+        ret, frame = cap.read()
+        if not ret or frame is None:
+            break
+
+        detections = detect_markers_in_frame(frame, detector, expected_set)
+        frame_detections.append(FrameDetections(frame_idx=frame_idx, detections=detections))
+        frame_idx += frame_step
+
+    cap.release()
+
+    return CameraDetectionResult(
+        camera_name=camera_name,
+        video_path=video_path,
+        total_frames=total_frames,
+        fps=fps,
+        width=width,
+        height=height,
+        frame_detections=frame_detections,
+    )
+
+
+def detect_markers_multi_camera(
+    video_paths: dict[str, str],
+    expected_ids: list[int] | None = None,
+    dictionary_id: int = cv2.aruco.DICT_4X4_250,
+    frame_step: int = 1,
+    max_workers: int | None = 4,
+) -> dict[str, CameraDetectionResult]:
+    """Run ArUco detection across multiple synchronized camera videos in parallel.
+
+    ``expected_ids=None`` returns every marker the detector finds — appropriate
+    for generic detection where the protocol isn't yet known.
+    """
+
+    def _process_camera(cam_name: str, video_path: str) -> tuple[str, CameraDetectionResult]:
+        detector = create_aruco_detector(dictionary_id)
+        result = detect_markers_in_video(
+            video_path, detector, expected_ids, camera_name=cam_name, frame_step=frame_step
+        )
+        return cam_name, result
+
+    results: dict[str, CameraDetectionResult] = {}
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = {executor.submit(_process_camera, name, path): name for name, path in video_paths.items()}
+        for future in concurrent.futures.as_completed(futures):
+            cam_name, result = future.result()
+            results[cam_name] = result
+
+    return results
+
+
+def triangulate_detected_markers_detailed(
+    detection_results: dict[str, CameraDetectionResult],
+    cgroup,
+    marker_ids: list[int] | None = None,
+    min_cameras: int = 2,
+) -> dict[int, dict]:
+    """Triangulate per-marker 3D positions and per-marker spatial spread.
+
+    Returns ``{marker_id: {"position": median_xyz_mm,
+                           "spread_mm": float,
+                           "n_frames": int}}``.
+
+    ``spread_mm`` is the median Euclidean distance from each per-frame
+    triangulation to the consensus median position — a robust scalar measure of
+    how stable the marker's triangulated location is across frames. Physically
+    fixed markers have low spread (a few mm, dominated by detection noise);
+    moving or transient markers have high spread.
+
+    ``cgroup`` is an aniposelib ``CameraGroup`` constructed from the calibration.
+    If ``marker_ids`` is ``None``, every marker ID seen in any camera is
+    triangulated. Markers seen by fewer than ``min_cameras`` on every frame are
+    omitted from the result.
+    """
+    camera_names = sorted(detection_results.keys())
+    num_cams = len(camera_names)
+
+    if marker_ids is None:
+        seen: set[int] = set()
+        for result in detection_results.values():
+            for fd in result.frame_detections:
+                for d in fd.detections:
+                    seen.add(d.marker_id)
+        marker_ids = sorted(seen)
+
+    out: dict[int, dict] = {}
+
+    for marker_id in marker_ids:
+        cam_frame_centers: list[dict[int, np.ndarray]] = []
+        for cam_name in camera_names:
+            centers = get_marker_centers_by_frame(detection_results[cam_name], marker_id)
+            cam_frame_centers.append(centers)
+
+        all_frames: set[int] = set()
+        for centers in cam_frame_centers:
+            all_frames.update(centers.keys())
+
+        valid_frames = []
+        for frame_idx in sorted(all_frames):
+            n_visible = sum(1 for centers in cam_frame_centers if frame_idx in centers)
+            if n_visible >= min_cameras:
+                valid_frames.append(frame_idx)
+
+        if not valid_frames:
+            continue
+
+        pts2d = np.full((num_cams, len(valid_frames), 2), np.nan, dtype=np.float64)
+        for fi, frame_idx in enumerate(valid_frames):
+            for cam_i, centers in enumerate(cam_frame_centers):
+                if frame_idx in centers:
+                    pts2d[cam_i, fi, :] = centers[frame_idx]
+
+        pts3d = cgroup.triangulate(pts2d)  # (N, 3)
+        median_pos = np.median(pts3d, axis=0)
+        # Median absolute deviation from the consensus position — robust to outliers
+        spread_mm = float(np.median(np.linalg.norm(pts3d - median_pos, axis=1)))
+        out[marker_id] = {
+            "position": median_pos,
+            "spread_mm": spread_mm,
+            "n_frames": len(valid_frames),
+        }
+
+    return out
+
+
+def triangulate_detected_markers(
+    detection_results: dict[str, CameraDetectionResult],
+    cgroup,
+    marker_ids: list[int] | None = None,
+    min_cameras: int = 2,
+) -> dict[int, np.ndarray]:
+    """Position-only convenience wrapper around ``triangulate_detected_markers_detailed``.
+
+    Returns ``{marker_id: median_xyz_mm}``.
+    """
+    detailed = triangulate_detected_markers_detailed(
+        detection_results, cgroup, marker_ids=marker_ids, min_cameras=min_cameras
+    )
+    return {mid: info["position"] for mid, info in detailed.items()}
+
+
+def positions_converged(
+    prev: dict[int, np.ndarray],
+    current: dict[int, np.ndarray],
+    threshold_mm: float,
+) -> bool:
+    """Check if all marker positions shifted less than threshold between iterations."""
+    if not prev:
+        return False
+    for marker_id, pos in current.items():
+        if marker_id not in prev:
+            return False
+        if np.linalg.norm(pos - prev[marker_id]) >= threshold_mm:
+            return False
+    return True
+
+
+def discover_camera_videos(video_base: str, video_dir: str) -> dict[str, str]:
+    """Find all per-camera videos for a given recording base.
+
+    Returns a mapping from camera serial → full path. Filenames are expected
+    in the format ``{video_base}.{camera_serial}.mp4``.
+    """
+    video_dir_path = Path(video_dir)
+    pattern = f"{video_base}.*.mp4"
+    found: dict[str, str] = {}
+
+    for path in sorted(video_dir_path.glob(pattern)):
+        filename = path.name
+        # Extract serial: everything between base. and .mp4
+        suffix = filename[len(video_base) + 1 : -4]  # strip "{base}." prefix and ".mp4" suffix
+        if suffix:
+            found[suffix] = str(path)
+
+    return found
+
+
+def draw_aruco_overlay(
+    frame: np.ndarray,
+    detections: list[MarkerDetection],
+    color_for_id: dict[int, tuple[int, int, int]] | None = None,
+) -> np.ndarray:
+    """Draw detected ArUco markers on a frame.
+
+    ``color_for_id`` optionally maps marker_id → BGR color. Markers without
+    a mapping are drawn white.
+    """
+    color_for_id = color_for_id or {}
+    _, w = frame.shape[:2]
+    scale = max(1, w / 640)
+
+    for det in detections:
+        color = color_for_id.get(det.marker_id, (255, 255, 255))
+
+        corners_int = det.corners.astype(int)
+        center = det.center.astype(int)
+
+        padding_factor = 0.5
+        padded = center + (corners_int - center) * (1 + padding_factor)
+        padded = padded.astype(int)
+
+        cv2.polylines(
+            frame,
+            [padded],
+            isClosed=True,
+            color=color,
+            thickness=max(1, int(3 * scale)),
+        )
+
+        font_scale = 2.0 * scale
+        thickness = max(2, int(3 * scale))
+        text = str(det.marker_id)
+        text_size = cv2.getTextSize(text, cv2.FONT_HERSHEY_SIMPLEX, font_scale, thickness)[0]
+        text_pos = (
+            int(center[0] - text_size[0] / 2),
+            int(center[1] + text_size[1] / 2),
+        )
+        cv2.putText(
+            frame,
+            text,
+            text_pos,
+            cv2.FONT_HERSHEY_SIMPLEX,
+            font_scale,
+            color,
+            thickness,
+        )
+
+    return frame
+
+
+def make_aruco_grid_video(
+    video_paths: dict[str, str],
+    results: dict[str, CameraDetectionResult],
+    output_path: str,
+    color_for_id: dict[int, tuple[int, int, int]] | None = None,
+    downsample: int = 2,
+    n_cols: int = 5,
+) -> str:
+    """Render a grid video showing all cameras side-by-side with detection overlays."""
+    camera_names = sorted(video_paths.keys())
+    caps = {name: cv2.VideoCapture(video_paths[name]) for name in camera_names}
+
+    first_result = results[camera_names[0]]
+    total_frames = min(r.total_frames for r in results.values())
+    fps = first_result.fps
+
+    sample_width = int(first_result.width / downsample)
+    sample_height = int(first_result.height / downsample)
+
+    # Build detection lookup: camera -> frame_idx -> list[MarkerDetection]
+    detection_lookup: dict[str, dict[int, list[MarkerDetection]]] = {}
+    for cam_name, result in results.items():
+        cam_lookup: dict[int, list[MarkerDetection]] = {}
+        for fd in result.frame_detections:
+            cam_lookup[fd.frame_idx] = fd.detections
+        detection_lookup[cam_name] = cam_lookup
+
+    def images_to_grid(images: list[np.ndarray], n_cols: int = n_cols) -> np.ndarray:
+        n_rows = int(np.ceil(len(images) / n_cols))
+        grid = np.zeros(
+            (n_rows * images[0].shape[0], n_cols * images[0].shape[1], 3),
+            dtype=np.uint8,
+        )
+        for i, img in enumerate(images):
+            row = i // n_cols
+            col = i % n_cols
+            grid[
+                row * img.shape[0] : (row + 1) * img.shape[0],
+                col * img.shape[1] : (col + 1) * img.shape[1],
+                :,
+            ] = img
+        return grid
+
+    # Compute grid dimensions for VideoWriter
+    actual_cols = min(n_cols, len(camera_names))
+    n_rows = int(np.ceil(len(camera_names) / actual_cols))
+    grid_width = actual_cols * sample_width
+    grid_height = n_rows * sample_height
+
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+    writer = cv2.VideoWriter(output_path, fourcc, fps, (grid_width, grid_height))
+
+    label_scale = max(0.3, sample_width / 640)
+    label_thickness = max(1, int(label_scale * 2))
+
+    for frame_idx in range(total_frames):
+        frames: list[np.ndarray] = []
+        for cam_name in camera_names:
+            ret, frame = caps[cam_name].read()
+            if not ret or frame is None:
+                frame = np.zeros((sample_height, sample_width, 3), dtype=np.uint8)
+            else:
+                frame = cv2.resize(frame, (sample_width, sample_height))
+
+            detections = detection_lookup.get(cam_name, {}).get(frame_idx, [])
+            if detections:
+                # Scale detections to match downsampled frame
+                scaled_detections = []
+                for d in detections:
+                    scale_factor = 1.0 / downsample
+                    scaled = MarkerDetection(
+                        marker_id=d.marker_id,
+                        corners=d.corners * scale_factor,
+                        center=d.center * scale_factor,
+                    )
+                    scaled_detections.append(scaled)
+                frame = draw_aruco_overlay(frame, scaled_detections, color_for_id)
+
+            cv2.putText(
+                frame,
+                cam_name,
+                (5, int(20 * label_scale + 10)),
+                cv2.FONT_HERSHEY_SIMPLEX,
+                label_scale,
+                (255, 255, 255),
+                label_thickness,
+            )
+            frames.append(frame)
+
+        grid = images_to_grid(frames, n_cols=actual_cols)
+        writer.write(grid)
+
+    writer.release()
+    for cap in caps.values():
+        cap.release()
+
+    return output_path

--- a/multi_camera/analysis/aruco.py
+++ b/multi_camera/analysis/aruco.py
@@ -212,7 +212,7 @@ def detect_markers_multi_camera(
     dictionary_id: int = cv2.aruco.DICT_4X4_250,
     frame_step: int = 1,
     max_workers: int | None = 4,
-    cv2_threads_per_worker: int = 1,
+    cv2_threads_per_worker: int | None = 1,
 ) -> dict[str, CameraDetectionResult]:
     """Run ArUco detection across multiple synchronized camera videos in parallel.
 
@@ -223,9 +223,13 @@ def detect_markers_multi_camera(
     call. Without it, each ``cv2.aruco.detectMarkers`` call fans out across
     every CPU and the outer ``max_workers`` pool stops being a meaningful
     concurrency limit. Effective core count ≈ ``max_workers * cv2_threads_per_worker``.
-    Set to 0 to keep OpenCV's default (= all cores).
+    The previous global value is restored on return so unrelated cv2 work in
+    the same process is unaffected. Pass ``None`` to leave OpenCV's thread
+    setting untouched.
     """
-    if cv2_threads_per_worker > 0:
+    prev_cv2_threads: int | None = None
+    if cv2_threads_per_worker is not None:
+        prev_cv2_threads = cv2.getNumThreads()
         cv2.setNumThreads(cv2_threads_per_worker)
 
     def _process_camera(cam_name: str, video_path: str) -> tuple[str, CameraDetectionResult]:
@@ -235,14 +239,17 @@ def detect_markers_multi_camera(
         )
         return cam_name, result
 
-    results: dict[str, CameraDetectionResult] = {}
-    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
-        futures = {executor.submit(_process_camera, name, path): name for name, path in video_paths.items()}
-        for future in concurrent.futures.as_completed(futures):
-            cam_name, result = future.result()
-            results[cam_name] = result
-
-    return results
+    try:
+        results: dict[str, CameraDetectionResult] = {}
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = {executor.submit(_process_camera, name, path): name for name, path in video_paths.items()}
+            for future in concurrent.futures.as_completed(futures):
+                cam_name, result = future.result()
+                results[cam_name] = result
+        return results
+    finally:
+        if prev_cv2_threads is not None:
+            cv2.setNumThreads(prev_cv2_threads)
 
 
 def triangulate_detected_markers_detailed(

--- a/multi_camera/analysis/aruco.py
+++ b/multi_camera/analysis/aruco.py
@@ -1,9 +1,4 @@
-"""Generic ArUco marker detection in multi-camera videos.
-
-Detection / triangulation primitives used by calibration-time ArUco workflows.
-Protocol-specific interpretation (e.g. walkway goalposts) lives downstream
-(see gait_analytics for the 10MWT walkway interpretation).
-"""
+"""Generic ArUco marker detection and triangulation in multi-camera videos."""
 
 from __future__ import annotations
 
@@ -216,8 +211,7 @@ def detect_markers_multi_camera(
 ) -> dict[str, CameraDetectionResult]:
     """Run ArUco detection across multiple synchronized camera videos in parallel.
 
-    ``expected_ids=None`` returns every marker the detector finds — appropriate
-    for generic detection where the protocol isn't yet known.
+    ``expected_ids=None`` returns every marker the detector finds.
 
     ``cv2_threads_per_worker`` caps OpenCV's internal TBB threading per detect
     call. Without it, each ``cv2.aruco.detectMarkers`` call fans out across

--- a/multi_camera/analysis/aruco.py
+++ b/multi_camera/analysis/aruco.py
@@ -123,15 +123,23 @@ def detect_markers_in_frame(
     frame: np.ndarray,
     detector: cv2.aruco.ArucoDetector,
     expected_ids: set[int] | None = None,
+    clahe: cv2.CLAHE | None = None,
 ) -> list[MarkerDetection]:
     """Detect ArUco markers in a frame.
 
     If ``expected_ids`` is provided, only markers with matching IDs are returned;
     pass ``None`` to return every marker the detector finds.
+
+    ``clahe`` is a reusable CLAHE object — pass one in to avoid the allocator
+    cost of building a new one per frame. Pass ``None`` to skip CLAHE entirely
+    (appropriate for well-lit calibration footage).
     """
-    lab = cv2.cvtColor(frame, cv2.COLOR_BGR2LAB)
-    lab[:, :, 0] = cv2.createCLAHE(clipLimit=3.0, tileGridSize=(8, 8)).apply(lab[:, :, 0])
-    enhanced = cv2.cvtColor(lab, cv2.COLOR_LAB2BGR)
+    if clahe is not None:
+        lab = cv2.cvtColor(frame, cv2.COLOR_BGR2LAB)
+        lab[:, :, 0] = clahe.apply(lab[:, :, 0])
+        enhanced = cv2.cvtColor(lab, cv2.COLOR_LAB2BGR)
+    else:
+        enhanced = frame
 
     corners, ids, _ = detector.detectMarkers(enhanced)
     detections: list[MarkerDetection] = []
@@ -166,6 +174,7 @@ def detect_markers_in_video(
     expected_ids: list[int] | None = None,
     camera_name: str = "",
     frame_step: int = 1,
+    use_clahe: bool = True,
 ) -> CameraDetectionResult:
     cap = cv2.VideoCapture(video_path)
     total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
@@ -175,17 +184,26 @@ def detect_markers_in_video(
 
     expected_set = set(expected_ids) if expected_ids is not None else None
     frame_detections: list[FrameDetections] = []
+    # Build CLAHE once per video — it's a stateless reusable, allocating per
+    # frame is wasted work. ``None`` skips CLAHE entirely.
+    clahe = cv2.createCLAHE(clipLimit=3.0, tileGridSize=(8, 8)) if use_clahe else None
 
     frame_idx = 0
     while frame_idx < total_frames:
-        if frame_step > 1:
-            cap.set(cv2.CAP_PROP_POS_FRAMES, frame_idx)
+        # cap.read() decodes the current frame; cap.grab() advances without
+        # decoding, which is the right way to skip on H.264 — calling
+        # cap.set(CAP_PROP_POS_FRAMES, ...) forces a keyframe seek per step
+        # and is dramatically slower for moderate frame_step values.
         ret, frame = cap.read()
         if not ret or frame is None:
             break
 
-        detections = detect_markers_in_frame(frame, detector, expected_set)
+        detections = detect_markers_in_frame(frame, detector, expected_set, clahe=clahe)
         frame_detections.append(FrameDetections(frame_idx=frame_idx, detections=detections))
+
+        for _ in range(frame_step - 1):
+            if not cap.grab():
+                break
         frame_idx += frame_step
 
     cap.release()
@@ -217,9 +235,11 @@ def detect_markers_multi_camera(
     call. Without it, each ``cv2.aruco.detectMarkers`` call fans out across
     every CPU and the outer ``max_workers`` pool stops being a meaningful
     concurrency limit. Effective core count ≈ ``max_workers * cv2_threads_per_worker``.
-    The previous global value is restored on return so unrelated cv2 work in
-    the same process is unaffected. Pass ``None`` to leave OpenCV's thread
-    setting untouched.
+    The previous global value is restored on return, so subsequent cv2 work
+    in the same process is unaffected — note this is a process-global setting
+    while we hold it, so concurrent unrelated cv2 work in other threads shares
+    the cap until this function returns. Pass ``None`` to leave OpenCV's
+    thread setting untouched.
     """
     prev_cv2_threads: int | None = None
     if cv2_threads_per_worker is not None:
@@ -308,13 +328,20 @@ def triangulate_detected_markers_detailed(
                     pts2d[cam_i, fi, :] = centers[frame_idx]
 
         pts3d = cgroup.triangulate(pts2d)  # (N, 3)
-        median_pos = np.median(pts3d, axis=0)
+        # Drop any rows where triangulation failed (degenerate geometry, all
+        # cameras too coplanar, etc.). nan-medians silently propagate NaN and
+        # make spread_mm "nan" in the QA report.
+        finite_rows = np.all(np.isfinite(pts3d), axis=1)
+        pts3d_finite = pts3d[finite_rows]
+        if len(pts3d_finite) == 0:
+            continue
+        median_pos = np.median(pts3d_finite, axis=0)
         # Median absolute deviation from the consensus position — robust to outliers
-        spread_mm = float(np.median(np.linalg.norm(pts3d - median_pos, axis=1)))
+        spread_mm = float(np.median(np.linalg.norm(pts3d_finite - median_pos, axis=1)))
         out[marker_id] = {
             "position": median_pos,
             "spread_mm": spread_mm,
-            "n_frames": len(valid_frames),
+            "n_frames": int(len(pts3d_finite)),
         }
 
     return out
@@ -383,7 +410,7 @@ def draw_aruco_overlay(
     a mapping are drawn white.
     """
     color_for_id = color_for_id or {}
-    _, w = frame.shape[:2]
+    w = frame.shape[1]
     scale = max(1, w / 640)
 
     for det in detections:
@@ -452,15 +479,15 @@ def make_aruco_grid_video(
             cam_lookup[fd.frame_idx] = fd.detections
         detection_lookup[cam_name] = cam_lookup
 
-    def images_to_grid(images: list[np.ndarray], n_cols: int = n_cols) -> np.ndarray:
-        n_rows = int(np.ceil(len(images) / n_cols))
+    def images_to_grid(images: list[np.ndarray], cols: int) -> np.ndarray:
+        rows = int(np.ceil(len(images) / cols))
         grid = np.zeros(
-            (n_rows * images[0].shape[0], n_cols * images[0].shape[1], 3),
+            (rows * images[0].shape[0], cols * images[0].shape[1], 3),
             dtype=np.uint8,
         )
         for i, img in enumerate(images):
-            row = i // n_cols
-            col = i % n_cols
+            row = i // cols
+            col = i % cols
             grid[
                 row * img.shape[0] : (row + 1) * img.shape[0],
                 col * img.shape[1] : (col + 1) * img.shape[1],
@@ -514,7 +541,7 @@ def make_aruco_grid_video(
             )
             frames.append(frame)
 
-        grid = images_to_grid(frames, n_cols=actual_cols)
+        grid = images_to_grid(frames, cols=actual_cols)
         writer.write(grid)
 
     writer.release()

--- a/multi_camera/analysis/calibration.py
+++ b/multi_camera/analysis/calibration.py
@@ -381,12 +381,15 @@ def run_AniposeLib_calibration(vid_base = None, charuco="charuco", checkerboard_
         config_hash = hashlib.md5(''.join(original_cam_ids).encode('utf-8')).hexdigest()[:10]
         print(f"Using generated config hash: {config_hash}")
 
-    # Convert timestamp string to datetime object
-    try:
-        trial_timestamp = vid_base[len("calibration_"):]
-        cal_timestamp = datetime.strptime(trial_timestamp, "%Y%m%d_%H%M%S")
-    except ValueError:
-        print(f"Warning: Could not parse vid_base {vid_base}")
+    # Convert timestamp string to datetime object. Fail fast on malformed
+    # basenames — silently warning leaves cal_timestamp unbound and produces
+    # a NameError two lines below, which masks the real cause.
+    if not vid_base.startswith("calibration_"):
+        raise ValueError(
+            f"Calibration video basename must start with 'calibration_', got {vid_base!r}"
+        )
+    trial_timestamp = vid_base[len("calibration_"):]
+    cal_timestamp = datetime.strptime(trial_timestamp, "%Y%m%d_%H%M%S")
     # Create the database entry
     entry = {
         "cal_timestamp": cal_timestamp,

--- a/multi_camera/analysis/calibration.py
+++ b/multi_camera/analysis/calibration.py
@@ -67,6 +67,147 @@ def run_calibration_APL(
     #db insert
 
 
+def run_calibration_and_insert(
+    vid_base,
+    *,
+    trial_video_project=None,
+    comment=None,
+    force_high_error=False,
+    **calibration_kwargs,
+):
+    """Run a calibration and insert all linked rows in one transaction.
+
+    Inserts into:
+      - ``Calibration`` (the computed parameters)
+      - ``Video`` (one row per camera, attaches the .mp4 to the localattach store)
+      - ``MultiCameraCalibration`` (session-level metadata, only for the
+        legacy/no-prior-push path; normally already there from push-to-DataJoint)
+      - ``CalibrationVideos`` (link rows: MultiCameraCalibration ↔ Video)
+
+    Calibration videos live under ``video_project="{trial_video_project}_CALIBRATION"``,
+    a dedicated per-project namespace that keeps them out of pose-pipeline analyses
+    while remaining trivially queryable per-project. Normally the calibration's
+    ``MultiCameraCalibration`` row already exists (push-to-DataJoint creates it),
+    so this function reads ``video_project`` from there. ``trial_video_project``
+    only needs to be passed for the legacy/no-prior-push path.
+
+    ArUco detection is gated by ``MultiCameraCalibration.comment`` containing the
+    substring ``"aruco"`` (see ``CalibrationArucoDetection.key_source``). For the
+    legacy/no-prior-push path, pass ``comment="...aruco..."`` to opt in.
+
+    Args:
+        vid_base: full path to the calibration video set, *without* the
+            ``.{serial}.mp4`` suffix. e.g. ``/mnt/.../calibration_20260312_151801``.
+        trial_video_project: trial-side ``video_project`` string for the session
+            this calibration belongs to. Only required when no ``MultiCameraCalibration``
+            row exists yet for this calibration (legacy / no-prior-push case).
+        comment: comment to record on the ``MultiCameraCalibration`` row when
+            this function inserts it (legacy/no-prior-push path only). If a row
+            already exists from push-to-DataJoint, its comment is preserved.
+        force_high_error: if True, suppress the reprojection-error guard. If False
+            (default) and reprojection_error > 0.3, raise rather than insert.
+        **calibration_kwargs: forwarded to ``run_calibration_APL``.
+
+    Returns:
+        ``cal_key`` dict ``{cal_timestamp, camera_config_hash}`` for chaining
+        downstream populate() calls.
+    """
+    import datajoint as dj
+
+    from multi_camera.datajoint.calibrate_cameras import Calibration
+    from multi_camera.datajoint.multi_camera_dj import (
+        CalibrationVideos,
+        MultiCameraCalibration,
+        calibration_video_project,
+    )
+    from pose_pipeline import Video
+
+    entry, board = run_calibration_APL(vid_base, **calibration_kwargs)
+
+    if np.isnan(entry["reprojection_error"]):
+        raise RuntimeError(f"Calibration failed (NaN reprojection_error): {entry}")
+    if entry["reprojection_error"] > 0.3 and not force_high_error:
+        raise RuntimeError(
+            f"Reprojection error {entry['reprojection_error']:.4f} > 0.3. "
+            "Pass force_high_error=True to insert anyway."
+        )
+
+    cal_key = {
+        "cal_timestamp": entry["cal_timestamp"],
+        "camera_config_hash": entry["camera_config_hash"],
+    }
+
+    # Resolve calibration video_project from the MultiCameraCalibration row that
+    # push_to_datajoint inserted. If absent (legacy / no prior push), derive from
+    # trial_video_project kwarg.
+    existing_capture = (MultiCameraCalibration & cal_key).fetch(as_dict=True)
+    if existing_capture:
+        cal_video_project = existing_capture[0]["video_project"]
+    else:
+        if trial_video_project is None:
+            raise RuntimeError(
+                f"No MultiCameraCalibration row for {cal_key} and no "
+                "trial_video_project= passed. Either push the session to DataJoint "
+                "first (recommended) or pass trial_video_project= explicitly."
+            )
+        cal_video_project = calibration_video_project(trial_video_project)
+
+    # Discover per-camera videos (mirrors run_AniposeLib_calibration's discovery)
+    vid_path, vid_basename = os.path.split(vid_base)
+    vids = sorted(glob.glob(os.path.join(vid_path, f"{vid_basename}.*.mp4")))
+    if not vids:
+        raise FileNotFoundError(f"No videos matching {vid_basename}.*.mp4 in {vid_path}")
+
+    discovered_serials = []
+    video_rows = []
+    cal_video_rows = []
+    for v in vids:
+        filename_no_ext = os.path.splitext(os.path.basename(v))[0]
+        serial = filename_no_ext.rsplit(".", 1)[-1]
+        discovered_serials.append(serial)
+        video_rows.append(
+            {
+                "video_project": cal_video_project,
+                "filename": filename_no_ext,
+                "video": v,
+                "start_time": entry["cal_timestamp"],
+            }
+        )
+        cal_video_rows.append(
+            {
+                **cal_key,
+                "video_project": cal_video_project,
+                "filename": filename_no_ext,
+            }
+        )
+
+    # Consistency check between videos discovered here and what calibration used
+    if set(discovered_serials) != set(entry["camera_names"]):
+        raise RuntimeError(
+            f"Camera mismatch: videos discovered {sorted(discovered_serials)} but "
+            f"calibration used {sorted(entry['camera_names'])}. "
+            "Refusing to insert inconsistent state."
+        )
+
+    # MultiCameraCalibration is normally inserted at push-to-DataJoint time. For
+    # legacy data (calibrations being added through this notebook path without a
+    # prior push) we create the row here so CalibrationVideos's FK resolves.
+    capture_row = {
+        **cal_key,
+        "video_project": cal_video_project,
+        "video_base_filename": vid_basename,
+        "comment": comment or "",
+    }
+
+    with dj.conn().transaction:
+        Calibration.insert1(entry)
+        Video.insert(video_rows, skip_duplicates=True)
+        MultiCameraCalibration.insert1(capture_row, skip_duplicates=True)
+        CalibrationVideos.insert(cal_video_rows, skip_duplicates=True)
+
+    return cal_key
+
+
 def relevel_calibration(
         entry,
         releveling_type = "stroller",

--- a/multi_camera/analysis/calibration.py
+++ b/multi_camera/analysis/calibration.py
@@ -109,8 +109,7 @@ def run_calibration_and_insert(
         **calibration_kwargs: forwarded to ``run_calibration_APL``.
 
     Returns:
-        ``cal_key`` dict ``{cal_timestamp, camera_config_hash}`` for chaining
-        downstream populate() calls.
+        ``cal_key`` dict ``{cal_timestamp, camera_config_hash}``.
     """
     import datajoint as dj
 

--- a/multi_camera/backend/recording_db.py
+++ b/multi_camera/backend/recording_db.py
@@ -467,6 +467,118 @@ def check_datajoint_external_mounted(mount_path, sentinel_file_name=".multi_cam_
 
     print("External drive mounted and sentinel file found.")
 
+def _is_calibration_comment(comment: Optional[str]) -> bool:
+    """A recording is a calibration if its comment contains 'calibration' or 'charuco'.
+
+    Substring match (not exact) so tag-style comments like 'charuco+aruco' are
+    still recognized.
+    """
+    if not comment:
+        return False
+    return "calibration" in comment or "charuco" in comment
+
+
+def _push_calibration_videos(
+    filenames_and_comments: List[Tuple[str, str]],
+    trial_video_project: str,
+) -> None:
+    """Insert calibration videos and per-recording metadata into DataJoint.
+
+    Calibration videos for trial project ``X`` live under ``video_project="{X}_CALIBRATION"``
+    in the Video table. The dedicated suffix keeps them out of pose-pipeline
+    analyses that filter on the trial project, while remaining trivially
+    queryable per-project.
+
+    For each calibration recording:
+      - Inserts one Video row per camera.
+      - Inserts a MultiCameraCalibration row carrying the SQLite comment forward
+        so CalibrationArucoDetection.populate() can gate off the substring "aruco".
+      - Inserts one CalibrationVideos row per camera linking the new Video rows
+        to the MultiCameraCalibration session.
+
+    All inserts use skip_duplicates=True so this is idempotent. Does NOT insert
+    the Calibration row — that requires the calibration computation, which
+    still lives in the notebook.
+    """
+    import glob
+    import json
+
+    from multi_camera.datajoint.multi_camera_dj import (
+        CalibrationVideos,
+        MultiCameraCalibration,
+        calibration_video_project,
+    )
+    from pose_pipeline import Video
+
+    cal_video_project = calibration_video_project(trial_video_project)
+
+    for cal_filename, comment in filenames_and_comments:
+        vid_path, vid_basename = os.path.split(cal_filename)
+        if not os.path.isdir(vid_path):
+            print(f"  [calibration] skipping {cal_filename}: directory not found")
+            continue
+
+        vids = sorted(glob.glob(os.path.join(vid_path, f"{vid_basename}.*.mp4")))
+        if not vids:
+            print(f"  [calibration] skipping {cal_filename}: no matching .mp4 files")
+            continue
+
+        # Parse timestamp from basename like "calibration_20260312_151801"
+        try:
+            ts_str = vid_basename.split("_", 1)[1]
+            cal_timestamp = datetime.strptime(ts_str, "%Y%m%d_%H%M%S")
+        except (IndexError, ValueError):
+            print(f"  [calibration] skipping {vid_basename}: cannot parse timestamp")
+            continue
+
+        # Read camera_config_hash from JSON sidecar (same source as run_calibration_APL)
+        json_file = os.path.join(vid_path, f"{vid_basename}.json")
+        if not os.path.exists(json_file):
+            print(f"  [calibration] skipping {vid_basename}: missing JSON sidecar")
+            continue
+        with open(json_file) as f:
+            sidecar = json.load(f)
+        camera_config_hash = sidecar.get("camera_config_hash")
+        if not camera_config_hash:
+            print(f"  [calibration] skipping {vid_basename}: no camera_config_hash in JSON")
+            continue
+
+        capture_key = {
+            "cal_timestamp": cal_timestamp,
+            "camera_config_hash": camera_config_hash,
+        }
+
+        video_rows = [
+            {
+                "video_project": cal_video_project,
+                "filename": os.path.splitext(os.path.basename(v))[0],
+                "video": v,
+                "start_time": cal_timestamp,
+            }
+            for v in vids
+        ]
+        cal_video_rows = [
+            {**capture_key, "video_project": cal_video_project, "filename": r["filename"]}
+            for r in video_rows
+        ]
+
+        Video.insert(video_rows, skip_duplicates=True)
+        MultiCameraCalibration.insert1(
+            {
+                **capture_key,
+                "video_project": cal_video_project,
+                "video_base_filename": vid_basename,
+                "comment": comment or "",
+            },
+            skip_duplicates=True,
+        )
+        CalibrationVideos.insert(cal_video_rows, skip_duplicates=True)
+        print(
+            f"  [calibration] inserted {len(video_rows)} videos + capture + linkage for "
+            f"{vid_basename} (comment={comment!r})"
+        )
+
+
 def push_to_datajoint(db: Session, participant_id: str, session_date: date, video_project: str):
     from multi_camera.datajoint.sessions import import_session
 
@@ -480,18 +592,25 @@ def push_to_datajoint(db: Session, participant_id: str, session_date: date, vide
     assert len(sessions) == 1, "Did not find exactly one session for this participant and date."
     recordings: List[RecordingOut] = sessions[0].recordings
 
-    # filter out the recordings that should not be processed and retain the
-    # filename and comment
-    recordings = [
-        (rec.filename, rec.comment) for rec in recordings if rec.should_process and rec.comment != "calibration" and rec.comment != "charuco"
+    # Split into trial recordings (push to DataJoint Recording chain) and calibration
+    # recordings (push raw videos only; Calibration computation still happens in the
+    # notebook via run_calibration_and_insert, which is idempotent on Video rows).
+    trial_recordings = [
+        (rec.filename, rec.comment)
+        for rec in recordings
+        if rec.should_process and not _is_calibration_comment(rec.comment)
+    ]
+    calibration_recordings = [
+        (rec.filename, rec.comment)
+        for rec in recordings
+        if rec.should_process and _is_calibration_comment(rec.comment)
     ]
 
-    print("Processing recordings: ", recordings)
+    print("Processing trial recordings: ", trial_recordings)
+    print("Processing calibration recordings: ", calibration_recordings)
 
     datajoint_external_path = get_datajoint_external_path()
     check_datajoint_external_mounted(datajoint_external_path)
-
-    # TODO: confirm calibration has been performed
 
     participant_id = normalize_participant_id(participant_id)
 
@@ -501,7 +620,13 @@ def push_to_datajoint(db: Session, participant_id: str, session_date: date, vide
     # Pass fin to import_session() once the DataJoint schema supports it. This is also
     # the layer where proper PHI access control should be enforced.
 
-    import_session(participant_id, session_date, video_project=video_project, recordings=recordings)
+    import_session(participant_id, session_date, video_project=video_project, recordings=trial_recordings)
+
+    # Calibration videos + recording metadata are pushed so they're queryable from DataJoint.
+    # Calibration computation still happens when the user runs run_calibration_and_insert
+    # from the notebook. Downstream ArUco detection auto-fires for any calibration whose
+    # MultiCameraCalibration.comment contains "aruco" (set in the acquisition GUI).
+    _push_calibration_videos(calibration_recordings, trial_video_project=video_project)
 
     synchronize_to_datajoint(db)
 

--- a/multi_camera/backend/recording_db.py
+++ b/multi_camera/backend/recording_db.py
@@ -503,6 +503,8 @@ def _push_calibration_videos(
     import glob
     import json
 
+    import datajoint as dj
+
     from multi_camera.datajoint.multi_camera_dj import (
         CalibrationVideos,
         MultiCameraCalibration,
@@ -562,17 +564,21 @@ def _push_calibration_videos(
             for r in video_rows
         ]
 
-        Video.insert(video_rows, skip_duplicates=True)
-        MultiCameraCalibration.insert1(
-            {
-                **capture_key,
-                "video_project": cal_video_project,
-                "video_base_filename": vid_basename,
-                "comment": comment or "",
-            },
-            skip_duplicates=True,
-        )
-        CalibrationVideos.insert(cal_video_rows, skip_duplicates=True)
+        # All three rows for one calibration go in a single transaction so a
+        # mid-sequence failure can't leave a Video row attached without its
+        # MultiCameraCalibration / CalibrationVideos linkage.
+        with dj.conn().transaction:
+            Video.insert(video_rows, skip_duplicates=True)
+            MultiCameraCalibration.insert1(
+                {
+                    **capture_key,
+                    "video_project": cal_video_project,
+                    "video_base_filename": vid_basename,
+                    "comment": comment or "",
+                },
+                skip_duplicates=True,
+            )
+            CalibrationVideos.insert(cal_video_rows, skip_duplicates=True)
         print(
             f"  [calibration] inserted {len(video_rows)} videos + capture + linkage for "
             f"{vid_basename} (comment={comment!r})"

--- a/multi_camera/backend/recording_db.py
+++ b/multi_camera/backend/recording_db.py
@@ -471,11 +471,13 @@ def _is_calibration_comment(comment: Optional[str]) -> bool:
     """A recording is a calibration if its comment contains 'calibration' or 'charuco'.
 
     Substring match (not exact) so tag-style comments like 'charuco+aruco' are
-    still recognized.
+    still recognized. Case-insensitive — operators type free-form comments and
+    "Calibration" or "ChArUco" must work the same as the lowercase form.
     """
     if not comment:
         return False
-    return "calibration" in comment or "charuco" in comment
+    lowered = comment.lower()
+    return "calibration" in lowered or "charuco" in lowered
 
 
 def _push_calibration_videos(
@@ -525,11 +527,16 @@ def _push_calibration_videos(
             print(f"  [calibration] skipping {cal_filename}: no matching .mp4 files")
             continue
 
-        # Parse timestamp from basename like "calibration_20260312_151801"
+        # Parse timestamp from basename like "calibration_20260312_151801".
+        # Mirror the strict prefix check from run_AniposeLib_calibration so
+        # accidental misnames (e.g. "session_20260312_...") don't slip through.
+        if not vid_basename.startswith("calibration_"):
+            print(f"  [calibration] skipping {vid_basename}: basename must start with 'calibration_'")
+            continue
         try:
-            ts_str = vid_basename.split("_", 1)[1]
+            ts_str = vid_basename[len("calibration_"):]
             cal_timestamp = datetime.strptime(ts_str, "%Y%m%d_%H%M%S")
-        except (IndexError, ValueError):
+        except ValueError:
             print(f"  [calibration] skipping {vid_basename}: cannot parse timestamp")
             continue
 

--- a/multi_camera/datajoint/aruco.py
+++ b/multi_camera/datajoint/aruco.py
@@ -42,7 +42,8 @@ class CalibrationArucoDetection(dj.Computed):
         # Only attempt detection on calibrations whose recording comment
         # mentions aruco markers — set in the acquisition GUI at record time
         # and propagated through MultiCameraCalibration on push to DataJoint.
-        return Calibration & (MultiCameraCalibration & 'comment LIKE "%aruco%"')
+        # LOWER(...) so operator-typed comments like "ChArUco" or "ArUco" match.
+        return Calibration & (MultiCameraCalibration & 'LOWER(comment) LIKE "%aruco%"')
 
     def make(self, key):
         from multi_camera.analysis.aruco import (

--- a/multi_camera/datajoint/aruco.py
+++ b/multi_camera/datajoint/aruco.py
@@ -1,15 +1,11 @@
 """ArUco-marker DataJoint tables for multi-camera calibration.
 
 ``CalibrationArucoDetection`` stores per-camera pixel detections of ArUco
-markers in the calibration videos. Detection is generic — every marker the
-detector finds is kept, no protocol-specific filtering. Detection
-auto-populates for any calibration whose recording comment contains the
-substring ``"aruco"`` (set in the acquisition GUI and propagated through
+markers in the calibration videos. Every marker the detector finds is kept;
+no marker-set filtering is applied at this layer. Detection auto-populates for
+any calibration whose recording comment contains the substring ``"aruco"``
+(set in the acquisition GUI and propagated through
 ``MultiCameraCalibration.comment``).
-
-Protocol-specific interpretation (e.g. 10MWT walkway goalposts) lives
-downstream in consumer packages, which own their own per-protocol flag tables
-keyed off ``Calibration``.
 """
 
 import cv2
@@ -90,8 +86,7 @@ class CalibrationArucoDetection(dj.Computed):
         # Triangulate every detected marker, recording per-marker spatial spread.
         # Stable markers (physically fixed) have low spread; transient markers
         # (e.g. someone walking past with a marker, equipment moving in/out of
-        # frame) have high spread. Downstream protocol-specific tables apply
-        # their own spread threshold over the markers they care about.
+        # frame) have high spread.
         detailed = triangulate_detected_markers_detailed(pixel_detections, cgroup)
 
         marker_ids_found = sorted(detailed.keys())

--- a/multi_camera/datajoint/aruco.py
+++ b/multi_camera/datajoint/aruco.py
@@ -1,0 +1,120 @@
+"""ArUco-marker DataJoint tables for multi-camera calibration.
+
+``CalibrationArucoDetection`` stores per-camera pixel detections of ArUco
+markers in the calibration videos. Detection is generic — every marker the
+detector finds is kept, no protocol-specific filtering. Detection
+auto-populates for any calibration whose recording comment contains the
+substring ``"aruco"`` (set in the acquisition GUI and propagated through
+``MultiCameraCalibration.comment``).
+
+Protocol-specific interpretation (e.g. 10MWT walkway goalposts) lives
+downstream in consumer packages, which own their own per-protocol flag tables
+keyed off ``Calibration``.
+"""
+
+import cv2
+import datajoint as dj
+
+from .calibrate_cameras import Calibration
+from .multi_camera_dj import CalibrationVideos, MultiCameraCalibration
+from pose_pipeline import Video
+
+schema = dj.schema("multicamera_tracking")
+
+
+DEFAULT_FRAME_STEP = 10
+DEFAULT_DICTIONARY_ID = cv2.aruco.DICT_4X4_250
+
+
+@schema
+class CalibrationArucoDetection(dj.Computed):
+    definition = """
+    # Per-camera pixel detections of ArUco markers in calibration videos
+    -> Calibration
+    ---
+    pixel_detections           : longblob    # dict[cam_name -> CameraDetectionResult.to_dict()]
+    num_markers_found          : int         # count of unique marker IDs detected
+    marker_ids_found           : longblob    # list[int] sorted
+    aruco_dictionary           : varchar(50) # cv2.aruco predefined-dict name, e.g. "DICT_4X4_250"
+    frame_step                 : int         # frames sampled (every Nth)
+    marker_position_spread_mm  : longblob    # dict[marker_id -> median absolute deviation (mm) of triangulated positions across frames]
+    marker_n_frames_detected   : longblob    # dict[marker_id -> int] frames each marker was triangulatable in (>= min_cameras visible)
+    """
+
+    @property
+    def key_source(self):
+        # Only attempt detection on calibrations whose recording comment
+        # mentions aruco markers — set in the acquisition GUI at record time
+        # and propagated through MultiCameraCalibration on push to DataJoint.
+        return Calibration & (MultiCameraCalibration & 'comment LIKE "%aruco%"')
+
+    def make(self, key):
+        from multi_camera.analysis.aruco import (
+            aruco_dictionary_name,
+            detect_markers_multi_camera,
+            triangulate_detected_markers_detailed,
+        )
+        from multi_camera.analysis.calibration import recreate_cgroup_from_entry
+
+        frame_step = DEFAULT_FRAME_STEP
+        dictionary_id = DEFAULT_DICTIONARY_ID
+        dictionary_name = aruco_dictionary_name(dictionary_id)
+
+        # Fetch per-camera video paths via CalibrationVideos → Video
+        video_query = (Video & (CalibrationVideos & key)).proj("video", "filename")
+        video_rows = video_query.fetch(as_dict=True)
+        if not video_rows:
+            raise FileNotFoundError(
+                f"No CalibrationVideos rows linked to {key} — push calibration videos first."
+            )
+
+        video_paths: dict[str, str] = {}
+        for row in video_rows:
+            # Filename is "{recording_base}.{camera_serial}" — last dot-segment is the serial
+            cam_serial = row["filename"].rsplit(".", 1)[-1]
+            video_paths[cam_serial] = row["video"]
+
+        cal_entry = (Calibration & key).fetch1()
+        cgroup = recreate_cgroup_from_entry(cal_entry)
+
+        print(f"[CalibrationArucoDetection] Detecting ArUco markers for {key}")
+        print(f"  {len(video_paths)} cameras, dictionary={dictionary_name}, frame_step={frame_step}")
+
+        pixel_detections = detect_markers_multi_camera(
+            video_paths,
+            expected_ids=None,  # generic: keep every marker the detector finds
+            dictionary_id=dictionary_id,
+            frame_step=frame_step,
+        )
+
+        # Triangulate every detected marker, recording per-marker spatial spread.
+        # Stable markers (physically fixed) have low spread; transient markers
+        # (e.g. someone walking past with a marker, equipment moving in/out of
+        # frame) have high spread. Downstream protocol-specific tables apply
+        # their own spread threshold over the markers they care about.
+        detailed = triangulate_detected_markers_detailed(pixel_detections, cgroup)
+
+        marker_ids_found = sorted(detailed.keys())
+        marker_position_spread_mm = {mid: info["spread_mm"] for mid, info in detailed.items()}
+        marker_n_frames_detected = {mid: info["n_frames"] for mid, info in detailed.items()}
+
+        print(f"  Found {len(marker_ids_found)} markers: {marker_ids_found}")
+        print(f"  Per-marker spatial spread (mm), worst → best:")
+        for mid, spread in sorted(marker_position_spread_mm.items(), key=lambda kv: -kv[1]):
+            n = marker_n_frames_detected[mid]
+            print(f"    Marker {mid:>4d}: spread={spread:7.2f}mm  (n_frames={n})")
+
+        serialized = {cam: result.to_dict() for cam, result in pixel_detections.items()}
+
+        self.insert1(
+            {
+                **key,
+                "pixel_detections": serialized,
+                "num_markers_found": len(marker_ids_found),
+                "marker_ids_found": marker_ids_found,
+                "aruco_dictionary": dictionary_name,
+                "frame_step": frame_step,
+                "marker_position_spread_mm": marker_position_spread_mm,
+                "marker_n_frames_detected": marker_n_frames_detected,
+            }
+        )

--- a/multi_camera/datajoint/multi_camera_dj.py
+++ b/multi_camera/datajoint/multi_camera_dj.py
@@ -7,6 +7,16 @@ from pose_pipeline import Video, VideoInfo, TopDownPerson, TopDownMethodLookup, 
 schema = dj.schema("multicamera_tracking")
 
 
+def calibration_video_project(trial_video_project: str) -> str:
+    """Derive the calibration-side video_project namespace from a trial-side one.
+
+    Calibration videos for project X live under ``"{X}_CALIBRATION"`` in the
+    Video table. Keeps calibrations out of pose-pipeline analyses that filter on
+    the trial project, while remaining trivially queryable per-project.
+    """
+    return f"{trial_video_project}_CALIBRATION"
+
+
 @schema
 class MultiCameraRecording(dj.Manual):
     definition = """
@@ -45,6 +55,28 @@ class CalibratedRecording(dj.Manual):
     # Match calibration to a recording
     -> MultiCameraRecording
     -> Calibration
+    """
+
+
+@schema
+class MultiCameraCalibration(dj.Manual):
+    definition = """
+    # Calibration recording session metadata (parallel to MultiCameraRecording for trials)
+    cal_timestamp : timestamp           # acquisition time, parsed from filename
+    camera_config_hash : varchar(50)
+    ---
+    video_project : varchar(50)
+    video_base_filename : varchar(100)  # e.g. "calibration_20260504_153438"
+    comment="" : varchar(255)           # comment from acquisition GUI
+    """
+
+
+@schema
+class CalibrationVideos(dj.Manual):
+    definition = """
+    # Per-camera videos that belong to a calibration recording session
+    -> MultiCameraCalibration
+    -> Video
     """
 
 


### PR DESCRIPTION
## Summary                                                                                                                                   
                                                                                                                                               
  Brings calibration videos into the DataJoint pipeline and adds an auto-populating ArUco detection layer for calibrations recorded with markers laid down.
                                                                                                                                               
  Previously, the GUI's "Push to DataJoint" filtered out anything whose comment contained "calibration" or "charuco", and downstream ArUco work had to be set up by hand from notebooks against grep-the-filesystem video paths. After this PR:                                                                                                                                          
                                                                                                                                               
  - Calibration recordings push into DataJoint alongside trial recordings, under a per-project `"{X}_CALIBRATION"` namespace in the `Video` table.                                                                          
  - A new `MultiCameraCalibration` capture-metadata table carries the GUI comment through, and a `CalibrationVideos` links MultiCameraCalibration and Video.                                                                 
  - A new `CalibrationArucoDetection` (`dj.Computed`) auto-runs detection + triangulation for any calibration whose `MultiCameraCalibration.comment` contains the substring `"aruco"`.                                                             
  - A new `run_calibration_and_insert(...)` entry-point ties the calibration math (`run_calibration_APL`) and DataJoint inserts together in one transaction.                                                                 
                                                                                                                                               
  ## What changes                                                                                                                              
                                                                                                                                               
  **New tables** (`multi_camera/datajoint/`):                                                                                                  
  - `MultiCameraCalibration` — `(cal_timestamp, camera_config_hash)` + `video_project`, `video_base_filename`, `comment`. Mirrors `MultiCameraRecording` for the calibration side.                                                                                             
  - `CalibrationVideos` — link table: `MultiCameraCalibration ↔ Video`.
  - `CalibrationArucoDetection` — `dj.Computed` keyed off `Calibration`. Stores per-camera `pixel_detections`, per-marker `spread_mm` +  `n_frames_detected`, the dictionary name, frame step. `key_source` restricted to comments containing `"aruco"`.                              
                                                                                                                                               
  **New module** (`multi_camera/analysis/aruco.py`):                                                                                           
  - Generic detection / triangulation primitives (`detect_markers_multi_camera`, `detect_markers_in_video`,
  `triangulate_detected_markers_detailed`, etc.) moved out of GaitAnalytics so MCT owns the detection layer. GA continues to re-export them for backwards compatibility on the consumer side.
  - `cv2_threads_per_worker` kwarg (default `1`) caps OpenCV's internal TBB threading per detect call so the outer `max_workers` is a meaningful concurrency limit instead of every detect call fanning across all cores.                                                          
   
  **New function** (`multi_camera/analysis/calibration.py`):                                                                                   
  - `run_calibration_and_insert(vid_base, ...)` — runs `run_calibration_APL`, validates reprojection error, then inserts `Calibration` +
  `Video` + `CalibrationVideos` (and `MultiCameraCalibration` for the legacy no-prior-push path) in a single transaction.                      
                                                            
  **Push flow** (`multi_camera/backend/recording_db.py`):                                                                                      
  - `_is_calibration_comment` substring-matches `"calibration"` / `"charuco"` so tag-style comments like `"charuco+aruco"` are still recognized  as calibrations.                                                                                                                            
  - `_push_calibration_videos` inserts the three per-calibration rows in a single transaction so a mid-sequence failure can't leave orphans.
                                                                                                                                               
  ## Migration                                                                                                                                 
                                                                                                                                               
  - Existing `Calibration` rows are untouched. They simply have no `CalibrationVideos` / `MultiCameraCalibration` / `CalibrationArucoDetection` entries, can be manually inserted if desired.
  - Re-running the GUI push on an already-pushed calibration is idempotent (every insert uses `skip_duplicates=True`); comment changes need to be made via raw SQL or by dropping + re-pushing.                                                                                             
   
  ## Test plan                                                                                                                                 
                                                            
  - [x] Fresh-session end-to-end on a recorded calibration with comment `"charuco+aruco"` — confirmed `Video` (per-camera) +  `MultiCameraCalibration` + `CalibrationVideos` rows appear after push.
  - [x] `CalibrationArucoDetection.populate()` auto-fires for the new row; pixel detections and per-marker spread stored correctly (stable markers <2mm, transient markers >100mm).                                                                                                     
  - [x] Retrofit path on 8 existing calibrations via notebook — same results as legacy.
  - [x] Downstream walkway interpretation (separate PR in GaitAnalytics) produces 10MWT metrics matching legacy.                                                                                                                         
  - [x] Confirmed `cv2.setNumThreads(...)` is scoped to `detect_markers_multi_camera` (snapshot + restore in `finally`) so unrelated cv2 work in the same process is unaffected.  