### PR TITLE
Fix/main ws broadcast cross thread

### DIFF
--- a/multi_camera/backend/fastapi.py
+++ b/multi_camera/backend/fastapi.py
@@ -308,6 +308,7 @@ def broadcast_event(
     except RuntimeError:
         asyncio.run_coroutine_threadsafe(coro, loop)
 
+
 RECORDING_BASE = "data"
 CONFIG_PATH = "/configs/"
 DEFAULT_CONFIG = os.path.join(CONFIG_PATH, "cotton_lab_config_20230620.yaml")
@@ -352,7 +353,6 @@ def get_disk_space_info(path: str) -> Dict:
         }
 
 
-
 print(CONFIG_PATH)
 config_files = os.listdir(CONFIG_PATH)
 print(config_files)
@@ -363,7 +363,7 @@ print([""] + [f for f in config_files if f.endswith(".yaml")])
 # print(socket.getfqdn())
 
 
-loop = asyncio.get_event_loop()
+loop: asyncio.AbstractEventLoop | None = None
 
 
 def receive_status(status, progress=None):
@@ -405,6 +405,14 @@ def _expected_serials(recorder: FlirRecorder | None) -> list[str]:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    # Bind the module-level loop to the loop uvicorn actually runs.
+    # receive_status() and broadcast_event() dispatch worker-thread
+    # broadcasts via run_coroutine_threadsafe(coro, loop); if loop is
+    # the import-time loop instead of uvicorn's, the coroutine is
+    # scheduled on a loop that never runs and the broadcast is dropped.
+    global loop
+    loop = asyncio.get_running_loop()
+
     state: GlobalState = get_global_state()
 
     # Perform startup tasks
@@ -684,9 +692,7 @@ def _broadcast_new_session_insights() -> None:
             event_type="session_insight",
             level="warn",
             code=(
-                "trial_symptom_detected"
-                if is_per_trial
-                else "session_pattern_detected"
+                "trial_symptom_detected" if is_per_trial else "session_pattern_detected"
             ),
             message=insight,
             details={
@@ -719,7 +725,9 @@ async def stop_recording():
 
 
 @api_router.post("/session", response_model=Session)
-async def set_session(subject_id: str, fin: Optional[str] = None, db=Depends(db_dependency)) -> Session:
+async def set_session(
+    subject_id: str, fin: Optional[str] = None, db=Depends(db_dependency)
+) -> Session:
     """
     Create a new session directory for the participant
 
@@ -745,6 +753,7 @@ async def set_session(subject_id: str, fin: Optional[str] = None, db=Depends(db_
 
     if fin and fin.strip():
         from multi_camera.backend.recording_db import store_fin
+
         store_fin(db, participant_name=subject_id, fin=fin.strip())
         print(f"FIN stored for participant {subject_id}")
 
@@ -759,7 +768,14 @@ async def get_session() -> Session:
     return state.current_session
 
 
-ALLOWED_IMAGE_TYPES = {'image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/bmp', 'image/webp'}
+ALLOWED_IMAGE_TYPES = {
+    "image/jpeg",
+    "image/jpg",
+    "image/png",
+    "image/gif",
+    "image/bmp",
+    "image/webp",
+}
 MAX_UPLOAD_SIZE_MB = 25
 
 
@@ -780,7 +796,10 @@ async def upload_image(
     """
     state: GlobalState = get_global_state()
     if state.current_session is None:
-        raise HTTPException(status_code=404, detail="No active session. Create a session before uploading images.")
+        raise HTTPException(
+            status_code=404,
+            detail="No active session. Create a session before uploading images.",
+        )
 
     current_session = state.current_session
 
@@ -805,8 +824,8 @@ async def upload_image(
     timestamp = datetime.datetime.now()
     time_str = timestamp.strftime("%Y%m%d_%H%M%S")
     original_filename = file.filename or "uploaded_image.jpg"
-    safe_filename = re.sub(r'[^a-zA-Z0-9._-]', '_', os.path.basename(original_filename))
-    if not safe_filename or safe_filename.startswith('.'):
+    safe_filename = re.sub(r"[^a-zA-Z0-9._-]", "_", os.path.basename(original_filename))
+    if not safe_filename or safe_filename.startswith("."):
         safe_filename = "uploaded_image.jpg"
     saved_filename = f"{time_str}_{safe_filename}"
     saved_path = os.path.join(images_dir, saved_filename)
@@ -956,6 +975,7 @@ async def new_trial(data: NewTrialData, db: Session = Depends(db_dependency)):
             _broadcast_new_session_insights()
         except Exception as e:
             import traceback
+
             acquisition_logger.error(f"Trial failed: {e}", exc_info=True)
             # If start_acquisition raised before its set_status("Recording")
             # ran, status is still "Starting" — clear it so recovery
@@ -1334,9 +1354,7 @@ async def restore_camera_defaults(serial: str):
     )
 
     try:
-        await run_in_threadpool(
-            state.acquisition.restore_camera_defaults, serial
-        )
+        await run_in_threadpool(state.acquisition.restore_camera_defaults, serial)
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
 
@@ -1573,6 +1591,7 @@ async def receive_frames(frames):
 # @api_router.get("/video")
 async def video_endpoint():
     state: GlobalState = get_global_state()
+
     async def generate_frames():
         while True:
             # Wait for the next frame to become available

--- a/multi_camera/backend/fastapi.py
+++ b/multi_camera/backend/fastapi.py
@@ -132,21 +132,56 @@ def db_dependency():
 
 
 class ConnectionManager:
+    """WebSocket fan-out for ``/api/v1/ws`` (recording status + progress).
+
+    Per-connection ``asyncio.Lock`` serializes writes so a status broadcast
+    can't race the websockets library's keepalive ping on the same writer
+    (the ``AssertionError in _drain_helper`` failure mode that motivated
+    the same shape on :class:`DiagnosticsManager`). Failed sends drop the
+    offending connection instead of leaving stale entries that would block
+    the next broadcast.
+    """
+
     def __init__(self):
         self.active_connections: list[WebSocket] = []
+        self._locks: dict[WebSocket, asyncio.Lock] = {}
 
     async def connect(self, websocket: WebSocket):
         await websocket.accept()
-        logger.debug("Websocket connected")
         self.active_connections.append(websocket)
+        self._locks[websocket] = asyncio.Lock()
+        logger.debug("Websocket connected")
 
     def disconnect(self, websocket: WebSocket):
+        if websocket in self.active_connections:
+            self.active_connections.remove(websocket)
+        self._locks.pop(websocket, None)
         logger.debug("Websocket Disconnected")
-        self.active_connections.remove(websocket)
 
-    async def broadcast(self, message: str):
-        for connection in self.active_connections:
-            await connection.send_json(message)
+    async def _send_one(self, websocket: WebSocket, message: dict) -> bool:
+        lock = self._locks.get(websocket)
+        if lock is None:
+            return False
+        async with lock:
+            try:
+                await websocket.send_json(message)
+                return True
+            except Exception as e:  # noqa: BLE001
+                acquisition_logger.warning(
+                    f"Main WS send failed, dropping connection: {e}"
+                )
+                return False
+
+    async def broadcast(self, message: dict):
+        if not self.active_connections:
+            return
+        results = await asyncio.gather(
+            *(self._send_one(c, message) for c in list(self.active_connections)),
+            return_exceptions=False,
+        )
+        for connection, ok in zip(list(self.active_connections), results):
+            if not ok:
+                self.disconnect(connection)
 
 
 manager = ConnectionManager()
@@ -332,10 +367,15 @@ loop = asyncio.get_event_loop()
 
 
 def receive_status(status, progress=None):
-    """
-    Receive status updates from the acquisition system
+    """Receive status updates from the acquisition system.
 
-    This callback is running on a different thread so needs to be handled carefully.
+    Called from FlirRecorder worker threads (status callback) and from the
+    asyncio loop (during lifespan / async endpoints). Dispatch the
+    broadcast accordingly: ``loop.create_task`` is not thread-safe and
+    silently drops the broadcast when called from a worker thread, which
+    leaves the GUI's main WS subscriber unaware of state transitions
+    (Uninitialized → Idle → Recording → …) and forces a page reload to
+    recover.
     """
     global_state = get_global_state()
     global_state.recording_status = status
@@ -346,8 +386,12 @@ def receive_status(status, progress=None):
     else:
         acquisition_logger.info(f"Status: {status}")
 
-    # Put the status in the queue using asyncio from a synchronous function
-    loop.create_task(manager.broadcast(update))
+    coro = manager.broadcast(update)
+    try:
+        asyncio.get_running_loop()
+        asyncio.create_task(coro)
+    except RuntimeError:
+        asyncio.run_coroutine_threadsafe(coro, loop)
 
 
 def _expected_serials(recorder: FlirRecorder | None) -> list[str]:

--- a/multi_camera/backend/fastapi.py
+++ b/multi_camera/backend/fastapi.py
@@ -132,15 +132,9 @@ def db_dependency():
 
 
 class ConnectionManager:
-    """WebSocket fan-out for ``/api/v1/ws`` (recording status + progress).
-
-    Per-connection ``asyncio.Lock`` serializes writes so a status broadcast
-    can't race the websockets library's keepalive ping on the same writer
-    (the ``AssertionError in _drain_helper`` failure mode that motivated
-    the same shape on :class:`DiagnosticsManager`). Failed sends drop the
-    offending connection instead of leaving stale entries that would block
-    the next broadcast.
-    """
+    """WebSocket fan-out for ``/api/v1/ws``. Per-connection lock serializes
+    writes against the websockets keepalive ping; failed sends drop the
+    connection."""
 
     def __init__(self):
         self.active_connections: list[WebSocket] = []
@@ -367,16 +361,9 @@ loop: asyncio.AbstractEventLoop | None = None
 
 
 def receive_status(status, progress=None):
-    """Receive status updates from the acquisition system.
-
-    Called from FlirRecorder worker threads (status callback) and from the
-    asyncio loop (during lifespan / async endpoints). Dispatch the
-    broadcast accordingly: ``loop.create_task`` is not thread-safe and
-    silently drops the broadcast when called from a worker thread, which
-    leaves the GUI's main WS subscriber unaware of state transitions
-    (Uninitialized → Idle → Recording → …) and forces a page reload to
-    recover.
-    """
+    """Acquisition status callback. Invoked from both the asyncio loop and
+    FlirRecorder worker threads, so dispatch via ``run_coroutine_threadsafe``
+    when there is no running loop."""
     global_state = get_global_state()
     global_state.recording_status = status
 
@@ -405,11 +392,7 @@ def _expected_serials(recorder: FlirRecorder | None) -> list[str]:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    # Bind the module-level loop to the loop uvicorn actually runs.
-    # receive_status() and broadcast_event() dispatch worker-thread
-    # broadcasts via run_coroutine_threadsafe(coro, loop); if loop is
-    # the import-time loop instead of uvicorn's, the coroutine is
-    # scheduled on a loop that never runs and the broadcast is dropped.
+    # Bind module-level loop to uvicorn's; worker-thread broadcasts dispatch onto it.
     global loop
     loop = asyncio.get_running_loop()
 

--- a/tests/acquisition/test_main_ws_broadcast.py
+++ b/tests/acquisition/test_main_ws_broadcast.py
@@ -1,0 +1,293 @@
+"""Regression tests for the main ``/api/v1/ws`` broadcast path
+(``ConnectionManager`` + ``receive_status``).
+
+The bug: ``receive_status`` is invoked from FlirRecorder worker threads
+when the camera stack flips status (Uninitialized → Synchronizing → Idle
+→ Recording → …). The previous implementation used
+``loop.create_task(manager.broadcast(update))`` which is not thread-safe
+when ``loop`` is not the current thread's running loop — broadcasts
+silently failed to schedule, the GUI's ``/api/v1/ws`` subscriber never
+saw status updates, and operators had to reload the page to pull the
+new state via REST. Diagnostics events still arrived because
+``broadcast_event`` already used the loop-aware dispatch pattern.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import threading
+import types
+
+import pytest
+
+
+def _install_pyspin_stubs() -> None:
+    for name in ("PySpin", "simple_pyspin"):
+        if name in sys.modules:
+            continue
+        stub = types.ModuleType(name)
+        if name == "simple_pyspin":
+
+            class _Camera:
+                def __init__(self, *args, **kwargs):
+                    raise RuntimeError("PySpin stub")
+
+            stub.Camera = _Camera  # type: ignore[attr-defined]
+            stub._SYSTEM = None  # type: ignore[attr-defined]
+            stub.list_cameras = lambda: []  # type: ignore[attr-defined]
+        sys.modules[name] = stub
+
+
+_install_pyspin_stubs()
+
+
+def _import_backend():
+    import os
+    import unittest.mock as _mock
+
+    real_listdir = os.listdir
+
+    def safe_listdir(path):
+        if str(path).startswith("/configs"):
+            return []
+        return real_listdir(path)
+
+    os.makedirs("data", exist_ok=True)
+    with _mock.patch("os.listdir", side_effect=safe_listdir):
+        from multi_camera.backend import fastapi as _backend_fastapi
+    return _backend_fastapi
+
+
+try:
+    backend_fastapi = _import_backend()
+except Exception as exc:  # pragma: no cover
+    pytest.skip(f"Backend not importable: {exc}", allow_module_level=True)
+
+
+class FakeWebSocket:
+    """Minimal stand-in for ``starlette.websockets.WebSocket``."""
+
+    def __init__(self, name: str = "ws", fail_send: bool = False):
+        self.name = name
+        self.fail_send = fail_send
+        self.sent: list[dict] = []
+        self.accepted = False
+
+    async def accept(self) -> None:
+        self.accepted = True
+
+    async def send_json(self, message: dict) -> None:
+        if self.fail_send:
+            raise ConnectionError(f"{self.name} dead")
+        self.sent.append(message)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class TestConnectionManagerLifecycle:
+    def test_connect_accepts_and_registers_with_lock(self) -> None:
+        async def body():
+            mgr = backend_fastapi.ConnectionManager()
+            ws = FakeWebSocket()
+            await mgr.connect(ws)
+            assert ws.accepted is True
+            assert ws in mgr.active_connections
+            assert ws in mgr._locks
+
+        _run(body())
+
+    def test_disconnect_unregisters_and_drops_lock(self) -> None:
+        async def body():
+            mgr = backend_fastapi.ConnectionManager()
+            ws = FakeWebSocket()
+            await mgr.connect(ws)
+            mgr.disconnect(ws)
+            assert ws not in mgr.active_connections
+            assert ws not in mgr._locks
+
+        _run(body())
+
+    def test_disconnect_is_idempotent(self) -> None:
+        async def body():
+            mgr = backend_fastapi.ConnectionManager()
+            ws = FakeWebSocket()
+            await mgr.connect(ws)
+            mgr.disconnect(ws)
+            mgr.disconnect(ws)  # must not raise
+
+        _run(body())
+
+
+class TestConnectionManagerBroadcast:
+    def test_broadcast_reaches_all_connections(self) -> None:
+        async def body():
+            mgr = backend_fastapi.ConnectionManager()
+            ws_a = FakeWebSocket("a")
+            ws_b = FakeWebSocket("b")
+            await mgr.connect(ws_a)
+            await mgr.connect(ws_b)
+
+            update = {"status": "Idle"}
+            await mgr.broadcast(update)
+
+            assert ws_a.sent == [update]
+            assert ws_b.sent == [update]
+
+        _run(body())
+
+    def test_broadcast_with_no_connections_is_a_noop(self) -> None:
+        async def body():
+            mgr = backend_fastapi.ConnectionManager()
+            await mgr.broadcast({"status": "Idle"})
+
+        _run(body())
+
+    def test_dead_connection_is_dropped(self) -> None:
+        async def body():
+            mgr = backend_fastapi.ConnectionManager()
+            live = FakeWebSocket("live")
+            dead = FakeWebSocket("dead", fail_send=True)
+            await mgr.connect(live)
+            await mgr.connect(dead)
+
+            await mgr.broadcast({"status": "Idle"})
+
+            assert dead not in mgr.active_connections
+            assert dead not in mgr._locks
+            assert live in mgr.active_connections
+            assert len(live.sent) == 1
+
+        _run(body())
+
+    def test_per_connection_lock_serializes_concurrent_broadcasts(self) -> None:
+        """Two concurrent broadcasts to the same connection must not interleave.
+
+        Mirrors the same invariant ``DiagnosticsManager`` provides — a
+        status broadcast can't race the websockets keepalive ping on the
+        same writer.
+        """
+
+        async def body():
+            mgr = backend_fastapi.ConnectionManager()
+
+            in_flight = 0
+            max_in_flight = 0
+
+            class CountingWS(FakeWebSocket):
+                async def send_json(self, message: dict) -> None:
+                    nonlocal in_flight, max_in_flight
+                    in_flight += 1
+                    max_in_flight = max(max_in_flight, in_flight)
+                    await asyncio.sleep(0.01)
+                    in_flight -= 1
+                    self.sent.append(message)
+
+            ws = CountingWS("counted")
+            await mgr.connect(ws)
+
+            await asyncio.gather(
+                mgr.broadcast({"status": "A"}),
+                mgr.broadcast({"status": "B"}),
+                mgr.broadcast({"status": "C"}),
+            )
+
+            assert max_in_flight == 1, (
+                f"Expected serialized writes (max_in_flight=1), got {max_in_flight}"
+            )
+            assert len(ws.sent) == 3
+
+        _run(body())
+
+
+class TestReceiveStatusCrossThread:
+    """The original bug: receive_status fired from a worker thread silently
+    dropped the broadcast because ``loop.create_task`` is not thread-safe.
+    """
+
+    def test_status_callback_from_worker_thread_reaches_main_ws(self) -> None:
+        """Drive ``receive_status`` from a non-loop thread and verify the
+        update lands on a connected ``ConnectionManager`` client.
+        """
+
+        async def body():
+            # Capture the loop receive_status will dispatch onto when
+            # invoked from a worker thread.
+            backend_fastapi.loop = asyncio.get_running_loop()
+
+            ws = FakeWebSocket("recv-status")
+            await backend_fastapi.manager.connect(ws)
+
+            try:
+                done = threading.Event()
+
+                def fire_from_thread():
+                    backend_fastapi.receive_status("Synchronizing")
+                    done.set()
+
+                threading.Thread(target=fire_from_thread, daemon=True).start()
+
+                # Wait for the worker thread to schedule onto the loop,
+                # then yield repeatedly so the scheduled task runs.
+                assert done.wait(timeout=2.0), "receive_status did not return"
+                for _ in range(20):
+                    if ws.sent:
+                        break
+                    await asyncio.sleep(0.05)
+
+                assert ws.sent == [{"status": "Synchronizing"}], (
+                    f"receive_status broadcast did not reach the WS client; "
+                    f"got {ws.sent!r}. This is the cross-thread regression: "
+                    f"loop.create_task from a worker thread silently drops "
+                    f"the broadcast."
+                )
+            finally:
+                backend_fastapi.manager.disconnect(ws)
+
+        _run(body())
+
+    def test_status_callback_from_loop_thread_reaches_main_ws(self) -> None:
+        """Same call site, but invoked from inside the loop (lifespan
+        startup, async endpoints). Must also broadcast.
+        """
+
+        async def body():
+            backend_fastapi.loop = asyncio.get_running_loop()
+
+            ws = FakeWebSocket("recv-status-loop")
+            await backend_fastapi.manager.connect(ws)
+
+            try:
+                backend_fastapi.receive_status("Idle")
+                for _ in range(20):
+                    if ws.sent:
+                        break
+                    await asyncio.sleep(0.05)
+
+                assert ws.sent == [{"status": "Idle"}]
+            finally:
+                backend_fastapi.manager.disconnect(ws)
+
+        _run(body())
+
+    def test_progress_update_includes_progress_field(self) -> None:
+        async def body():
+            backend_fastapi.loop = asyncio.get_running_loop()
+
+            ws = FakeWebSocket("recv-progress")
+            await backend_fastapi.manager.connect(ws)
+
+            try:
+                backend_fastapi.receive_status("Recording", progress=0.42)
+                for _ in range(20):
+                    if ws.sent:
+                        break
+                    await asyncio.sleep(0.05)
+
+                assert ws.sent == [{"status": "Recording", "progress": 0.42}]
+            finally:
+                backend_fastapi.manager.disconnect(ws)
+
+        _run(body())

--- a/tests/acquisition/test_main_ws_broadcast.py
+++ b/tests/acquisition/test_main_ws_broadcast.py
@@ -291,3 +291,54 @@ class TestReceiveStatusCrossThread:
                 backend_fastapi.manager.disconnect(ws)
 
         _run(body())
+
+
+class TestLifespanCapturesRunningLoop:
+    """The follow-on bug found during field validation of the original fix.
+
+    Pre-fix, ``loop = asyncio.get_event_loop()`` ran at module import time —
+    before uvicorn started — so the captured loop was not the one uvicorn
+    ended up running. Worker-thread broadcasts hit
+    ``run_coroutine_threadsafe(coro, loop)`` and were silently dropped onto
+    a loop that never ran. Symptom on jc-compute02: ``Synchronized`` /
+    ``Idle`` transitions (fired from request-handler threads, dispatched
+    via the ``get_running_loop`` branch) reached the WS, but ``Recording``
+    and trailing ``Idle`` (fired from the FlirRecorder worker thread) did
+    not. ``lifespan()`` must re-bind module-level ``loop`` to the actual
+    running loop on startup.
+    """
+
+    def test_lifespan_rebinds_loop_to_running_loop(self) -> None:
+        import unittest.mock as _mock
+        from contextlib import ExitStack
+
+        from fastapi import FastAPI
+
+        backend_fastapi.loop = None
+
+        async def body():
+            with ExitStack() as stack:
+                stack.enter_context(
+                    _mock.patch.object(backend_fastapi, "FlirRecorder", autospec=True)
+                )
+                stack.enter_context(
+                    _mock.patch.object(
+                        backend_fastapi, "HealthIdlePoller", autospec=True
+                    )
+                )
+                stack.enter_context(
+                    _mock.patch.object(
+                        backend_fastapi, "get_db", return_value=_mock.MagicMock()
+                    )
+                )
+                stack.enter_context(
+                    _mock.patch.object(backend_fastapi, "synchronize_to_datajoint")
+                )
+                async with backend_fastapi.lifespan(FastAPI()):
+                    assert backend_fastapi.loop is asyncio.get_running_loop(), (
+                        "lifespan() did not re-bind module-level loop to the "
+                        "running loop; worker-thread broadcasts via "
+                        "run_coroutine_threadsafe will silently drop."
+                    )
+
+        _run(body())

--- a/tests/acquisition/test_main_ws_broadcast.py
+++ b/tests/acquisition/test_main_ws_broadcast.py
@@ -1,16 +1,5 @@
-"""Regression tests for the main ``/api/v1/ws`` broadcast path
-(``ConnectionManager`` + ``receive_status``).
-
-The bug: ``receive_status`` is invoked from FlirRecorder worker threads
-when the camera stack flips status (Uninitialized → Synchronizing → Idle
-→ Recording → …). The previous implementation used
-``loop.create_task(manager.broadcast(update))`` which is not thread-safe
-when ``loop`` is not the current thread's running loop — broadcasts
-silently failed to schedule, the GUI's ``/api/v1/ws`` subscriber never
-saw status updates, and operators had to reload the page to pull the
-new state via REST. Diagnostics events still arrived because
-``broadcast_event`` already used the loop-aware dispatch pattern.
-"""
+"""Tests for ``ConnectionManager``, ``receive_status``, and ``lifespan``'s
+loop binding on the ``/api/v1/ws`` broadcast path."""
 
 from __future__ import annotations
 
@@ -163,12 +152,7 @@ class TestConnectionManagerBroadcast:
         _run(body())
 
     def test_per_connection_lock_serializes_concurrent_broadcasts(self) -> None:
-        """Two concurrent broadcasts to the same connection must not interleave.
-
-        Mirrors the same invariant ``DiagnosticsManager`` provides — a
-        status broadcast can't race the websockets keepalive ping on the
-        same writer.
-        """
+        """Concurrent broadcasts to the same connection must not interleave."""
 
         async def body():
             mgr = backend_fastapi.ConnectionManager()
@@ -203,18 +187,11 @@ class TestConnectionManagerBroadcast:
 
 
 class TestReceiveStatusCrossThread:
-    """The original bug: receive_status fired from a worker thread silently
-    dropped the broadcast because ``loop.create_task`` is not thread-safe.
-    """
+    """``receive_status`` must broadcast whether invoked from the loop thread
+    or a worker thread."""
 
     def test_status_callback_from_worker_thread_reaches_main_ws(self) -> None:
-        """Drive ``receive_status`` from a non-loop thread and verify the
-        update lands on a connected ``ConnectionManager`` client.
-        """
-
         async def body():
-            # Capture the loop receive_status will dispatch onto when
-            # invoked from a worker thread.
             backend_fastapi.loop = asyncio.get_running_loop()
 
             ws = FakeWebSocket("recv-status")
@@ -229,30 +206,19 @@ class TestReceiveStatusCrossThread:
 
                 threading.Thread(target=fire_from_thread, daemon=True).start()
 
-                # Wait for the worker thread to schedule onto the loop,
-                # then yield repeatedly so the scheduled task runs.
                 assert done.wait(timeout=2.0), "receive_status did not return"
                 for _ in range(20):
                     if ws.sent:
                         break
                     await asyncio.sleep(0.05)
 
-                assert ws.sent == [{"status": "Synchronizing"}], (
-                    f"receive_status broadcast did not reach the WS client; "
-                    f"got {ws.sent!r}. This is the cross-thread regression: "
-                    f"loop.create_task from a worker thread silently drops "
-                    f"the broadcast."
-                )
+                assert ws.sent == [{"status": "Synchronizing"}]
             finally:
                 backend_fastapi.manager.disconnect(ws)
 
         _run(body())
 
     def test_status_callback_from_loop_thread_reaches_main_ws(self) -> None:
-        """Same call site, but invoked from inside the loop (lifespan
-        startup, async endpoints). Must also broadcast.
-        """
-
         async def body():
             backend_fastapi.loop = asyncio.get_running_loop()
 
@@ -294,19 +260,8 @@ class TestReceiveStatusCrossThread:
 
 
 class TestLifespanCapturesRunningLoop:
-    """The follow-on bug found during field validation of the original fix.
-
-    Pre-fix, ``loop = asyncio.get_event_loop()`` ran at module import time —
-    before uvicorn started — so the captured loop was not the one uvicorn
-    ended up running. Worker-thread broadcasts hit
-    ``run_coroutine_threadsafe(coro, loop)`` and were silently dropped onto
-    a loop that never ran. Symptom on jc-compute02: ``Synchronized`` /
-    ``Idle`` transitions (fired from request-handler threads, dispatched
-    via the ``get_running_loop`` branch) reached the WS, but ``Recording``
-    and trailing ``Idle`` (fired from the FlirRecorder worker thread) did
-    not. ``lifespan()`` must re-bind module-level ``loop`` to the actual
-    running loop on startup.
-    """
+    """``lifespan()`` must rebind module-level ``loop`` to the running loop so
+    ``run_coroutine_threadsafe`` from worker threads targets uvicorn's loop."""
 
     def test_lifespan_rebinds_loop_to_running_loop(self) -> None:
         import unittest.mock as _mock


### PR DESCRIPTION
- The acquisition GUI's recording-status indicator was getting stuck at "Uninitialized" with control buttons greyed out after selecting a camera config — the WS subscriber was not seeing state transitions (Synchronizing/Idle/Recording/Idle) and a page reload was the only way to recover.
- Root cause: `receive_status` fires from FlirRecorder worker threads but used `loop.create_task(...)` to schedule WS fan-out, which is not thread-safe and silently drops the task when called from a non-loop thread.
- Even after switching to `run_coroutine_threadsafe(coro, loop)`, the broadcast was still dropped during recording because the module-level `loop` was captured at import time, before uvicorn started its own loop, so the coroutine landed on a dead loop. Fixed by rebinding `loop` to `asyncio.get_running_loop()` inside `lifespan()`.
- Aligns `ConnectionManager` with `DiagnosticsManager`: per-connection `asyncio.Lock` to avoid racing the websockets keepalive ping, and drop dead connections on send failure instead of leaving stale entries.
