### PR TITLE
Fix/health poller skips during configure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # This is the build file for the docker. Note this should be run from the
 # parent directory for the necessary files to be available
 
-.PHONY: clean build run run-no-checks _docker-run run-mocap-test test test-matrix test-diagnostics validate-sync diag-recording diag-analyze health health-fix setup-env install-sudoers
+.PHONY: clean build run run-no-checks _docker-run run-mocap-test test test-matrix test-diagnostics validate-sync diag-recording diag-analyze health health-fix setup-env install-sudoers force-ip
 
 DIR := ${CURDIR}
 

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,14 @@ health-fix:
 	docker compose run --rm --entrypoint python3 test \
 		-m multi_camera.acquisition.health --remediate
 
+# Rescue cameras stuck on link-local 169.254.x.x by broadcasting a Spinnaker
+# ForceIP. Volatile: cameras revert to their previous IP config on next
+# power-cycle, so this is for unblocking the current session, not a
+# permanent fix. Pair with `make health` to confirm afterwards.
+force-ip:
+	docker compose run --rm --entrypoint python3 test \
+		/Mocap/scripts/acquisition/force_camera_ips.py
+
 # Install /etc/sudoers.d/mocap-acquisition so start_acquisition.sh's
 # auto-remediation path (MTU/rmem/DHCP) and `make health-fix` can run
 # without prompting for a password.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,7 @@ services:
       - ${DATAJOINT_EXTERNAL:-/mnt/datajoint_external}:/datajoint_external
       - ./tests:/Mocap/tests
       - ./tests/testdata:/Mocap/tests/testdata
+      - ./scripts:/Mocap/scripts
     network_mode: host
 
   reset:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -86,6 +86,8 @@ COPY datajoint_config.json /root/.datajoint_config.json
 
 COPY tests /Mocap/tests
 
+COPY scripts /Mocap/scripts
+
 RUN pip3 install pytest
 
 RUN pip install --upgrade numpy

--- a/frontend/acquisition/src/AcquisitionApi.js
+++ b/frontend/acquisition/src/AcquisitionApi.js
@@ -443,6 +443,19 @@ export const AcquisitionApi = (props) => {
         return response.data;
     };
 
+    const forceIpCamera = async (mac, ip, mask, gateway) => {
+        const body = {};
+        if (ip) body.ip = ip;
+        if (mask) body.mask = mask;
+        if (gateway) body.gateway = gateway;
+        const response = await axios.post(
+            `${API_BASE_URL}/cameras/${encodeURIComponent(mac)}/force_ip`,
+            body
+        );
+        await fetchHealth(true);
+        return response.data;
+    };
+
     /* Code for editing recording database */
 
     const getMatchingPriorRecordings = async (participant, filename) => {
@@ -565,6 +578,7 @@ export const AcquisitionApi = (props) => {
         restartAcquisition,
         restoreCameraDefaults,
         setCameraExcluded,
+        forceIpCamera,
         newSession,
         newTrial,
         previewVideo,

--- a/frontend/acquisition/src/AcquisitionApi.js
+++ b/frontend/acquisition/src/AcquisitionApi.js
@@ -21,6 +21,23 @@ const initialState = {
 
 export const AcquisitionState = createContext(initialState);
 
+// Mirrors backend `_BUSY_PYSPIN_STATES` in multi_camera/backend/fastapi.py.
+// Any recovery / reconfigure action the operator can trigger from the GUI
+// (Force IP, Exclude/Include, Restore defaults, Restart acquisition) is
+// refused by the backend in any of these states, so the corresponding
+// frontend buttons should disable to match — otherwise the operator clicks
+// and gets a 409 toast instead of an obviously-unavailable button.
+const BUSY_PYSPIN_STATES = [
+    'Configuring',
+    'Synchronizing',
+    'Synchronized',
+    'Starting',
+    'Recording',
+];
+
+export const isBusyPySpinState = (status) =>
+    BUSY_PYSPIN_STATES.includes(status);
+
 export const useEffectOnce = (effect) => {
 
     const destroyFunc = useRef();

--- a/frontend/acquisition/src/components/CameraStatusTable.js
+++ b/frontend/acquisition/src/components/CameraStatusTable.js
@@ -1,13 +1,13 @@
 import React, { useContext, useState } from 'react';
 import { Table, Button } from 'react-bootstrap';
 import Accordion from 'react-bootstrap/Accordion';
-import { AcquisitionState } from "../AcquisitionApi";
+import { AcquisitionState, isBusyPySpinState } from "../AcquisitionApi";
 
 const RestoreDefaultsButton = ({ serial }) => {
     const { restoreCameraDefaults, recordingSystemStatus } = useContext(AcquisitionState);
     const [busy, setBusy] = useState(false);
     const [error, setError] = useState(null);
-    const isRecording = recordingSystemStatus === 'Recording';
+    const isPySpinBusy = isBusyPySpinState(recordingSystemStatus);
 
     const handleClick = async () => {
         const ok = window.confirm(
@@ -31,10 +31,12 @@ const RestoreDefaultsButton = ({ serial }) => {
         <div>
             <Button
                 onClick={handleClick}
-                disabled={busy || isRecording}
+                disabled={busy || isPySpinBusy}
                 size="sm"
                 variant="outline-warning"
-                title={isRecording ? 'Stop the recording before restoring defaults' : 'Load factory UserSet on this camera and re-init'}
+                title={isPySpinBusy
+                    ? `Wait until the system is Idle (currently ${recordingSystemStatus})`
+                    : 'Load factory UserSet on this camera and re-init'}
             >
                 {busy ? 'Restoring…' : 'Restore defaults'}
             </Button>

--- a/frontend/acquisition/src/components/DiagnosticsPage.js
+++ b/frontend/acquisition/src/components/DiagnosticsPage.js
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect, useState } from 'react';
 import { Container, Card, Badge, Button, ListGroup, Accordion, Table } from 'react-bootstrap';
-import { AcquisitionState } from '../AcquisitionApi';
+import { AcquisitionState, isBusyPySpinState } from '../AcquisitionApi';
 
 const severityVariant = {
     ok: 'success',
@@ -335,7 +335,7 @@ const ExcludeCameraButton = ({ serial, excluded }) => {
     const { setCameraExcluded, recordingSystemStatus } = useContext(AcquisitionState);
     const [busy, setBusy] = useState(false);
     const [error, setError] = useState(null);
-    const isRecording = recordingSystemStatus === 'Recording';
+    const isPySpinBusy = isBusyPySpinState(recordingSystemStatus);
 
     const handleClick = async () => {
         const target = !excluded;
@@ -363,10 +363,12 @@ const ExcludeCameraButton = ({ serial, excluded }) => {
         <div>
             <Button
                 onClick={handleClick}
-                disabled={busy || isRecording}
+                disabled={busy || isPySpinBusy}
                 size="sm"
                 variant={excluded ? 'outline-success' : 'outline-secondary'}
-                title={isRecording ? 'Stop the recording first' : (excluded ? 'Re-include this camera in the recording' : 'Skip this camera in this session')}
+                title={isPySpinBusy
+                    ? `Wait until the system is Idle (currently ${recordingSystemStatus})`
+                    : (excluded ? 'Re-include this camera in the recording' : 'Skip this camera in this session')}
             >
                 {busy ? '…' : (excluded ? 'Include' : 'Exclude')}
             </Button>
@@ -379,7 +381,7 @@ const ForceIpButton = ({ mac }) => {
     const { forceIpCamera, recordingSystemStatus } = useContext(AcquisitionState);
     const [busy, setBusy] = useState(false);
     const [error, setError] = useState(null);
-    const isRecording = recordingSystemStatus === 'Recording';
+    const isPySpinBusy = isBusyPySpinState(recordingSystemStatus);
 
     const handleClick = async () => {
         const ok = window.confirm(
@@ -403,10 +405,12 @@ const ForceIpButton = ({ mac }) => {
         <div>
             <Button
                 onClick={handleClick}
-                disabled={busy || isRecording}
+                disabled={busy || isPySpinBusy}
                 size="sm"
                 variant="outline-warning"
-                title={isRecording ? 'Stop the recording first' : 'Re-IP this camera onto the camera subnet'}
+                title={isPySpinBusy
+                    ? `Wait until the system is Idle (currently ${recordingSystemStatus})`
+                    : 'Re-IP this camera onto the camera subnet'}
             >
                 {busy ? '…' : 'Force IP'}
             </Button>
@@ -419,7 +423,7 @@ const RestartAcquisitionButton = () => {
     const { restartAcquisition, recordingSystemStatus } = useContext(AcquisitionState);
     const [busy, setBusy] = useState(false);
     const [error, setError] = useState(null);
-    const isRecording = recordingSystemStatus === 'Recording';
+    const isPySpinBusy = isBusyPySpinState(recordingSystemStatus);
 
     const handleClick = async () => {
         setBusy(true);
@@ -438,10 +442,12 @@ const RestartAcquisitionButton = () => {
         <div>
             <Button
                 onClick={handleClick}
-                disabled={busy || isRecording}
+                disabled={busy || isPySpinBusy}
                 size="sm"
                 variant="outline-warning"
-                title={isRecording ? 'Stop the recording before restarting' : 'Re-init PySpin and re-run PTP sync'}
+                title={isPySpinBusy
+                    ? `Wait until the system is Idle (currently ${recordingSystemStatus})`
+                    : 'Re-init PySpin and re-run PTP sync'}
             >
                 {busy ? 'Restarting…' : 'Restart acquisition'}
             </Button>

--- a/frontend/acquisition/src/components/DiagnosticsPage.js
+++ b/frontend/acquisition/src/components/DiagnosticsPage.js
@@ -85,6 +85,7 @@ const HostHealthPanel = () => {
     const dhcpFindings = (dhcp && dhcp.findings) || [];
     const cameraFindings = (cameras && cameras.findings) || [];
     const perCamera = (cameras && cameras.cameras) || [];
+    const wrongSubnet = (cameras && cameras.wrong_subnet) || [];
     const hostFindings = (host_network && host_network.findings) || [];
     const expectedList = (cameras && cameras.expected) || [];
     const detectedList = (cameras && cameras.detected) || [];
@@ -142,6 +143,32 @@ const HostHealthPanel = () => {
                                     <tr><td>Extra</td><td>{extraList.join(', ') || '—'}</td></tr>
                                 </tbody>
                             </Table>
+                            {wrongSubnet.length > 0 && (
+                                <Table size="sm" striped bordered className="mb-2">
+                                    <thead>
+                                        <tr>
+                                            <th colSpan={3}>Cameras on wrong subnet</th>
+                                            <th>Action</th>
+                                        </tr>
+                                        <tr>
+                                            <th>MAC</th>
+                                            <th>Current IP</th>
+                                            <th>Model</th>
+                                            <th></th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {wrongSubnet.map((c) => (
+                                            <tr key={c.mac}>
+                                                <td><code>{c.mac}</code></td>
+                                                <td>{c.current_ip || '—'}</td>
+                                                <td>{c.model || '—'}</td>
+                                                <td><ForceIpButton mac={c.mac} /></td>
+                                            </tr>
+                                        ))}
+                                    </tbody>
+                                </Table>
+                            )}
                             {perCamera.length > 0 && (
                                 <Table size="sm" striped bordered className="mb-2">
                                     <thead>
@@ -342,6 +369,46 @@ const ExcludeCameraButton = ({ serial, excluded }) => {
                 title={isRecording ? 'Stop the recording first' : (excluded ? 'Re-include this camera in the recording' : 'Skip this camera in this session')}
             >
                 {busy ? '…' : (excluded ? 'Include' : 'Exclude')}
+            </Button>
+            {error && <div className="text-danger small mt-1">{error}</div>}
+        </div>
+    );
+};
+
+const ForceIpButton = ({ mac }) => {
+    const { forceIpCamera, recordingSystemStatus } = useContext(AcquisitionState);
+    const [busy, setBusy] = useState(false);
+    const [error, setError] = useState(null);
+    const isRecording = recordingSystemStatus === 'Recording';
+
+    const handleClick = async () => {
+        const ok = window.confirm(
+            `Force-IP camera ${mac}? The system will auto-assign the next free address ` +
+            'on the camera subnet. The camera will take a few seconds to reappear.'
+        );
+        if (!ok) return;
+        setBusy(true);
+        setError(null);
+        try {
+            await forceIpCamera(mac);
+        } catch (e) {
+            const msg = (e && e.response && e.response.data && e.response.data.detail) || e.message;
+            setError(msg || 'Force IP failed.');
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    return (
+        <div>
+            <Button
+                onClick={handleClick}
+                disabled={busy || isRecording}
+                size="sm"
+                variant="outline-warning"
+                title={isRecording ? 'Stop the recording first' : 'Re-IP this camera onto the camera subnet'}
+            >
+                {busy ? '…' : 'Force IP'}
             </Button>
             {error && <div className="text-danger small mt-1">{error}</div>}
         </div>

--- a/multi_camera/acquisition/flir_recording_api.py
+++ b/multi_camera/acquisition/flir_recording_api.py
@@ -112,6 +112,125 @@ def _ipv4_to_int(ip: str) -> int:
     return (parts[0] << 24) | (parts[1] << 16) | (parts[2] << 8) | parts[3]
 
 
+def _enumerate_camera_ips(
+    system: "PySpin.SystemPtr",
+    subnet: "ipaddress.IPv4Network",
+) -> tuple[set[str], list[tuple[str, int, str]]]:
+    """Walk every interface + camera attached to ``system``, return
+    ``(on_subnet_ips_in_use, off_subnet_camera_list)`` where the second
+    is a list of ``(serial, mac_int, current_ip)`` tuples for cameras
+    whose IP is NOT in ``subnet``.
+
+    Read-only — never calls ``Camera.Init()``. Used by
+    :func:`FlirRecorder.force_camera_ip` (and by the CLI rescue script)
+    both up-front (to pick a free IP and find the target) and again
+    after settle (to verify the camera moved). Caller is responsible
+    for the lifetime of ``system``; this just borrows it.
+    """
+    in_use: set[str] = set()
+    off: list[tuple[str, int, str]] = []
+    iface_list = system.GetInterfaces()
+    try:
+        for iface_idx in range(iface_list.GetSize()):
+            iface = iface_list.GetByIndex(iface_idx)
+            cam_list = iface.GetCameras()
+            try:
+                for cam_idx in range(cam_list.GetSize()):
+                    cam = cam_list.GetByIndex(cam_idx)
+                    try:
+                        tl = cam.GetTLDeviceNodeMap()
+                        serial_node = PySpin.CStringPtr(
+                            tl.GetNode("DeviceSerialNumber")
+                        )
+                        if not (
+                            PySpin.IsAvailable(serial_node)
+                            and PySpin.IsReadable(serial_node)
+                        ):
+                            continue
+                        serial = serial_node.GetValue()
+                        ip_node = PySpin.CIntegerPtr(
+                            tl.GetNode("GevDeviceIPAddress")
+                        )
+                        if not (
+                            PySpin.IsAvailable(ip_node)
+                            and PySpin.IsReadable(ip_node)
+                        ):
+                            continue
+                        cur_ip = str(ipaddress.IPv4Address(ip_node.GetValue()))
+                        try:
+                            cur_ip_addr = ipaddress.IPv4Address(cur_ip)
+                        except (ValueError, ipaddress.AddressValueError):
+                            continue
+                        if cur_ip_addr in subnet:
+                            in_use.add(cur_ip)
+                            continue
+                        mac_int = PySpin.CIntegerPtr(
+                            tl.GetNode("GevDeviceMACAddress")
+                        ).GetValue()
+                        off.append((serial, mac_int, cur_ip))
+                    finally:
+                        del cam
+            finally:
+                cam_list.Clear()
+    finally:
+        iface_list.Clear()
+    return in_use, off
+
+
+def _force_one_camera_ip(
+    system: "PySpin.SystemPtr",
+    target_mac: int,
+    new_ip_int: int,
+    mask_int: int,
+    gateway_int: int,
+) -> bool:
+    """Re-enumerate ``system``, find the camera whose MAC matches
+    ``target_mac``, write ``GevDeviceForce*`` on its
+    ``GetTLDeviceNodeMap()``, and execute ``GevDeviceForceIP``. All
+    writes and the Execute happen inside one ``CameraPtr`` scope so
+    Spinnaker targets through the handle. Returns ``True`` if the
+    target was found (the packet was sent), ``False`` otherwise.
+
+    Caller is responsible for waiting + verifying the camera actually
+    moved — see :func:`_enumerate_camera_ips`.
+    """
+    iface_list = system.GetInterfaces()
+    try:
+        for iface_idx in range(iface_list.GetSize()):
+            iface = iface_list.GetByIndex(iface_idx)
+            cam_list = iface.GetCameras()
+            try:
+                for cam_idx in range(cam_list.GetSize()):
+                    cam = cam_list.GetByIndex(cam_idx)
+                    try:
+                        tl = cam.GetTLDeviceNodeMap()
+                        this_mac = PySpin.CIntegerPtr(
+                            tl.GetNode("GevDeviceMACAddress")
+                        ).GetValue()
+                        if this_mac != target_mac:
+                            continue
+                        PySpin.CIntegerPtr(
+                            tl.GetNode("GevDeviceForceIPAddress")
+                        ).SetValue(new_ip_int)
+                        PySpin.CIntegerPtr(
+                            tl.GetNode("GevDeviceForceSubnetMask")
+                        ).SetValue(mask_int)
+                        PySpin.CIntegerPtr(
+                            tl.GetNode("GevDeviceForceGateway")
+                        ).SetValue(gateway_int)
+                        PySpin.CCommandPtr(
+                            tl.GetNode("GevDeviceForceIP")
+                        ).Execute()
+                        return True
+                    finally:
+                        del cam
+            finally:
+                cam_list.Clear()
+    finally:
+        iface_list.Clear()
+    return False
+
+
 def init_camera(
     c: Camera,
     jumbo_packet: bool = True,
@@ -1977,7 +2096,7 @@ class FlirRecorder:
                     f"to override."
                 )
             mask_int = _ipv4_to_int(str(subnet.netmask))
-            in_use_ips, off_subnet = self._enumerate_camera_ips(subnet)
+            in_use_ips, off_subnet = _enumerate_camera_ips(self.system, subnet)
             target_off = [
                 (s, m, cur) for (s, m, cur) in off_subnet if m == target_mac_int
             ]
@@ -2006,8 +2125,8 @@ class FlirRecorder:
         new_ip_int = _ipv4_to_int(ip)
         gateway_int = _ipv4_to_int(gateway)
 
-        if not self._force_one_camera_ip(
-            target_mac_int, new_ip_int, mask_int, gateway_int
+        if not _force_one_camera_ip(
+            self.system, target_mac_int, new_ip_int, mask_int, gateway_int
         ):
             raise ValueError(
                 f"No camera with MAC {mac} found on re-enumeration"
@@ -2019,7 +2138,7 @@ class FlirRecorder:
         # verification when the operator overrode the subnet — we don't
         # know what "on-subnet" means in that case.
         if subnet is not None:
-            _, still_off = self._enumerate_camera_ips(subnet)
+            _, still_off = _enumerate_camera_ips(self.system, subnet)
             if target_mac_int in {m for _, m, _ in still_off}:
                 raise RuntimeError(
                     f"Camera {mac} still off-subnet {settle_seconds}s after "
@@ -2029,116 +2148,6 @@ class FlirRecorder:
                 )
 
         return {"mac": mac, "ip": ip}
-
-    def _enumerate_camera_ips(
-        self, subnet: "ipaddress.IPv4Network"
-    ) -> tuple[set[str], list[tuple[str, int, str]]]:
-        """Walk every interface + camera, return (on_subnet_ips_in_use,
-        off_subnet_camera_list_as_(serial, mac_int, current_ip)).
-
-        Read-only — never calls ``Camera.Init()``. Used by ``force_camera_ip``
-        both up-front (to pick a free IP and find the target) and again
-        after settle (to verify the camera moved).
-        """
-        in_use: set[str] = set()
-        off: list[tuple[str, int, str]] = []
-        iface_list = self.system.GetInterfaces()
-        try:
-            for iface_idx in range(iface_list.GetSize()):
-                iface = iface_list.GetByIndex(iface_idx)
-                cam_list = iface.GetCameras()
-                try:
-                    for cam_idx in range(cam_list.GetSize()):
-                        cam = cam_list.GetByIndex(cam_idx)
-                        try:
-                            tl = cam.GetTLDeviceNodeMap()
-                            serial_node = PySpin.CStringPtr(
-                                tl.GetNode("DeviceSerialNumber")
-                            )
-                            if not (
-                                PySpin.IsAvailable(serial_node)
-                                and PySpin.IsReadable(serial_node)
-                            ):
-                                continue
-                            serial = serial_node.GetValue()
-                            ip_node = PySpin.CIntegerPtr(
-                                tl.GetNode("GevDeviceIPAddress")
-                            )
-                            if not (
-                                PySpin.IsAvailable(ip_node)
-                                and PySpin.IsReadable(ip_node)
-                            ):
-                                continue
-                            cur_ip = str(
-                                ipaddress.IPv4Address(ip_node.GetValue())
-                            )
-                            try:
-                                cur_ip_addr = ipaddress.IPv4Address(cur_ip)
-                            except (ValueError, ipaddress.AddressValueError):
-                                continue
-                            if cur_ip_addr in subnet:
-                                in_use.add(cur_ip)
-                                continue
-                            mac_int = PySpin.CIntegerPtr(
-                                tl.GetNode("GevDeviceMACAddress")
-                            ).GetValue()
-                            off.append((serial, mac_int, cur_ip))
-                        finally:
-                            del cam
-                finally:
-                    cam_list.Clear()
-        finally:
-            iface_list.Clear()
-        return in_use, off
-
-    def _force_one_camera_ip(
-        self,
-        target_mac: int,
-        new_ip_int: int,
-        mask_int: int,
-        gateway_int: int,
-    ) -> bool:
-        """Re-enumerate, find the camera with matching MAC, write
-        ``GevDeviceForce*`` on its TLDeviceNodeMap, Execute. All writes and
-        the Execute happen inside one ``CameraPtr`` scope so Spinnaker
-        targets through the handle. Returns True if the target was found
-        and the packet was sent, False otherwise.
-        """
-        iface_list = self.system.GetInterfaces()
-        try:
-            for iface_idx in range(iface_list.GetSize()):
-                iface = iface_list.GetByIndex(iface_idx)
-                cam_list = iface.GetCameras()
-                try:
-                    for cam_idx in range(cam_list.GetSize()):
-                        cam = cam_list.GetByIndex(cam_idx)
-                        try:
-                            tl = cam.GetTLDeviceNodeMap()
-                            this_mac = PySpin.CIntegerPtr(
-                                tl.GetNode("GevDeviceMACAddress")
-                            ).GetValue()
-                            if this_mac != target_mac:
-                                continue
-                            PySpin.CIntegerPtr(
-                                tl.GetNode("GevDeviceForceIPAddress")
-                            ).SetValue(new_ip_int)
-                            PySpin.CIntegerPtr(
-                                tl.GetNode("GevDeviceForceSubnetMask")
-                            ).SetValue(mask_int)
-                            PySpin.CIntegerPtr(
-                                tl.GetNode("GevDeviceForceGateway")
-                            ).SetValue(gateway_int)
-                            PySpin.CCommandPtr(
-                                tl.GetNode("GevDeviceForceIP")
-                            ).Execute()
-                            return True
-                        finally:
-                            del cam
-                finally:
-                    cam_list.Clear()
-        finally:
-            iface_list.Clear()
-        return False
 
     async def reset_cameras(self):
         """Reset all the cameras and reopen the system"""

--- a/multi_camera/acquisition/flir_recording_api.py
+++ b/multi_camera/acquisition/flir_recording_api.py
@@ -788,6 +788,10 @@ class FlirRecorder:
             trigger (bool): Enable network synchronized triggering
         """
 
+        # Flip status before any PySpin work so HealthIdlePoller's skip
+        # predicate covers init_camera's enumeration race window.
+        self.set_status("Configuring")
+
         self.config_file = config_file
 
         iface_list = self.system.GetInterfaces()
@@ -1440,7 +1444,8 @@ class FlirRecorder:
                     error_counters["exceptions"] += 1
                     err_text = str(e)
                     throttled_print(
-                        "exceptions", f"{camera_serial}: Failed to get image — {err_text}"
+                        "exceptions",
+                        f"{camera_serial}: Failed to get image — {err_text}",
                     )
                     if "-1002" in err_text or "no longer valid" in err_text:
                         self._fire_diagnostic_once(
@@ -1881,9 +1886,7 @@ class FlirRecorder:
 
         load_cmd = PySpin.CCommandPtr(nodemap.GetNode("UserSetLoad"))
         if not PySpin.IsAvailable(load_cmd) or not PySpin.IsWritable(load_cmd):
-            raise RuntimeError(
-                f"Camera {serial}: UserSetLoad command not executable"
-            )
+            raise RuntimeError(f"Camera {serial}: UserSetLoad command not executable")
         load_cmd.Execute()
         print(f"[restore_defaults] camera {serial} UserSetLoad executed")
 
@@ -1893,7 +1896,9 @@ class FlirRecorder:
         user_default = PySpin.CEnumerationPtr(nodemap.GetNode("UserSetDefault"))
         if PySpin.IsAvailable(user_default) and PySpin.IsWritable(user_default):
             user_default_entry = user_default.GetEntryByName("Default")
-            if user_default_entry is not None and PySpin.IsAvailable(user_default_entry):
+            if user_default_entry is not None and PySpin.IsAvailable(
+                user_default_entry
+            ):
                 user_default.SetIntValue(user_default_entry.GetValue())
 
         after_throughput = _read_int("DeviceLinkThroughputLimit")

--- a/multi_camera/acquisition/flir_recording_api.py
+++ b/multi_camera/acquisition/flir_recording_api.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel
 import concurrent.futures
 import threading
 import asyncio
+import ipaddress
 import json
 import time
 import cv2
@@ -97,6 +98,18 @@ def select_interface(interface, cameras):
 
     # If there are no cameras on the interface, return None
     return retval
+
+
+def _mac_str_to_int(mac: str) -> int:
+    """``aa:bb:cc:dd:ee:ff`` → integer, matches PySpin's MAC node format."""
+    return int(mac.replace(":", "").replace("-", ""), 16)
+
+
+def _ipv4_to_int(ip: str) -> int:
+    parts = [int(p) for p in ip.split(".")]
+    if len(parts) != 4:
+        raise ValueError(f"Invalid IPv4 address: {ip}")
+    return (parts[0] << 24) | (parts[1] << 16) | (parts[2] << 8) | parts[3]
 
 
 def init_camera(
@@ -1907,6 +1920,225 @@ class FlirRecorder:
             f"DeviceLinkThroughputLimit after: {after_throughput} "
             f"(delta: {None if before_throughput is None or after_throughput is None else after_throughput - before_throughput})"
         )
+
+    def force_camera_ip(
+        self,
+        mac: str,
+        ip: str | None = None,
+        mask: str | None = None,
+        gateway: str = "0.0.0.0",
+        settle_seconds: float = 5.0,
+        start_octet: int = 240,
+    ) -> dict:
+        """Force a camera that's on the wrong subnet to a target IP.
+
+        Re-enumerates ``system.GetInterfaces()`` per ForceIP call so each
+        write happens through a fresh ``CameraPtr`` whose Spinnaker
+        internal "selected device" state is aligned with the target;
+        reusing handles across calls was the targeting bug that an earlier
+        revision of this method hit (NULL-pointer derefs and force packets
+        landing on the wrong camera).
+
+        If ``ip`` is None the target subnet is auto-detected from
+        ``$NETWORK_INTERFACE`` via SIOCGIFNETMASK and the first free IP at
+        or above ``start_octet`` is chosen. Otherwise ``ip`` / ``mask`` /
+        ``gateway`` are used verbatim — operator override path.
+
+        After the ForceIP packet is sent, waits ``settle_seconds`` and
+        re-enumerates to confirm the camera actually moved. Raises
+        ``RuntimeError`` if the camera is still off-subnet (firmware
+        refused, dormant GVCP, switch ARP staleness — usual fix is
+        ``sudo service isc-dhcp-server restart`` then retry).
+
+        Caller must guarantee no recording is in progress, and (per
+        operator policy today) we only run this in laptop deployment mode.
+        """
+        target_mac_int = _mac_str_to_int(mac)
+
+        # Resolve target subnet for the IP we're about to pick (or to verify
+        # an operator-supplied IP against). Operator override skips the
+        # auto-detect since they're telling us where to put the camera.
+        if ip is None:
+            interface = os.environ.get("NETWORK_INTERFACE")
+            if not interface:
+                raise RuntimeError(
+                    "Cannot auto-pick an IP: $NETWORK_INTERFACE not set. "
+                    "Pass an explicit ip=... or set NETWORK_INTERFACE."
+                )
+            # Local import to avoid a circular dep at module-load time
+            # (health imports nothing from flir_recording_api, but
+            # multi_camera.acquisition imports both).
+            from multi_camera.acquisition.health import _get_host_interface_network
+
+            subnet = _get_host_interface_network(interface)
+            if subnet is None:
+                raise RuntimeError(
+                    f"Could not detect subnet on {interface}; pass ip=... "
+                    f"to override."
+                )
+            mask_int = _ipv4_to_int(str(subnet.netmask))
+            in_use_ips, off_subnet = self._enumerate_camera_ips(subnet)
+            target_off = [
+                (s, m, cur) for (s, m, cur) in off_subnet if m == target_mac_int
+            ]
+            if not target_off:
+                raise ValueError(
+                    f"No off-subnet camera with MAC {mac} on any interface"
+                )
+            network_base = _ipv4_to_int(str(subnet.network_address))
+            new_ip = None
+            for octet in range(start_octet, 255):
+                candidate = str(ipaddress.IPv4Address(network_base + octet))
+                if candidate not in in_use_ips:
+                    new_ip = candidate
+                    break
+            if new_ip is None:
+                raise RuntimeError(
+                    f"No free IPs in {subnet} at or above .{start_octet}"
+                )
+            ip = new_ip
+        else:
+            if mask is None:
+                mask = "255.255.255.0"
+            subnet = None  # operator override; skip auto-verify against subnet
+            mask_int = _ipv4_to_int(mask)
+
+        new_ip_int = _ipv4_to_int(ip)
+        gateway_int = _ipv4_to_int(gateway)
+
+        if not self._force_one_camera_ip(
+            target_mac_int, new_ip_int, mask_int, gateway_int
+        ):
+            raise ValueError(
+                f"No camera with MAC {mac} found on re-enumeration"
+            )
+
+        time.sleep(settle_seconds)
+
+        # Verify the camera actually left the off-subnet list. Skip
+        # verification when the operator overrode the subnet — we don't
+        # know what "on-subnet" means in that case.
+        if subnet is not None:
+            _, still_off = self._enumerate_camera_ips(subnet)
+            if target_mac_int in {m for _, m, _ in still_off}:
+                raise RuntimeError(
+                    f"Camera {mac} still off-subnet {settle_seconds}s after "
+                    f"ForceIP. The camera is ignoring GVCP (stale switch ARP "
+                    f"or dormant state). Try `sudo service isc-dhcp-server "
+                    f"restart`, then retry; power-cycle as a last resort."
+                )
+
+        return {"mac": mac, "ip": ip}
+
+    def _enumerate_camera_ips(
+        self, subnet: "ipaddress.IPv4Network"
+    ) -> tuple[set[str], list[tuple[str, int, str]]]:
+        """Walk every interface + camera, return (on_subnet_ips_in_use,
+        off_subnet_camera_list_as_(serial, mac_int, current_ip)).
+
+        Read-only — never calls ``Camera.Init()``. Used by ``force_camera_ip``
+        both up-front (to pick a free IP and find the target) and again
+        after settle (to verify the camera moved).
+        """
+        in_use: set[str] = set()
+        off: list[tuple[str, int, str]] = []
+        iface_list = self.system.GetInterfaces()
+        try:
+            for iface_idx in range(iface_list.GetSize()):
+                iface = iface_list.GetByIndex(iface_idx)
+                cam_list = iface.GetCameras()
+                try:
+                    for cam_idx in range(cam_list.GetSize()):
+                        cam = cam_list.GetByIndex(cam_idx)
+                        try:
+                            tl = cam.GetTLDeviceNodeMap()
+                            serial_node = PySpin.CStringPtr(
+                                tl.GetNode("DeviceSerialNumber")
+                            )
+                            if not (
+                                PySpin.IsAvailable(serial_node)
+                                and PySpin.IsReadable(serial_node)
+                            ):
+                                continue
+                            serial = serial_node.GetValue()
+                            ip_node = PySpin.CIntegerPtr(
+                                tl.GetNode("GevDeviceIPAddress")
+                            )
+                            if not (
+                                PySpin.IsAvailable(ip_node)
+                                and PySpin.IsReadable(ip_node)
+                            ):
+                                continue
+                            cur_ip = str(
+                                ipaddress.IPv4Address(ip_node.GetValue())
+                            )
+                            try:
+                                cur_ip_addr = ipaddress.IPv4Address(cur_ip)
+                            except (ValueError, ipaddress.AddressValueError):
+                                continue
+                            if cur_ip_addr in subnet:
+                                in_use.add(cur_ip)
+                                continue
+                            mac_int = PySpin.CIntegerPtr(
+                                tl.GetNode("GevDeviceMACAddress")
+                            ).GetValue()
+                            off.append((serial, mac_int, cur_ip))
+                        finally:
+                            del cam
+                finally:
+                    cam_list.Clear()
+        finally:
+            iface_list.Clear()
+        return in_use, off
+
+    def _force_one_camera_ip(
+        self,
+        target_mac: int,
+        new_ip_int: int,
+        mask_int: int,
+        gateway_int: int,
+    ) -> bool:
+        """Re-enumerate, find the camera with matching MAC, write
+        ``GevDeviceForce*`` on its TLDeviceNodeMap, Execute. All writes and
+        the Execute happen inside one ``CameraPtr`` scope so Spinnaker
+        targets through the handle. Returns True if the target was found
+        and the packet was sent, False otherwise.
+        """
+        iface_list = self.system.GetInterfaces()
+        try:
+            for iface_idx in range(iface_list.GetSize()):
+                iface = iface_list.GetByIndex(iface_idx)
+                cam_list = iface.GetCameras()
+                try:
+                    for cam_idx in range(cam_list.GetSize()):
+                        cam = cam_list.GetByIndex(cam_idx)
+                        try:
+                            tl = cam.GetTLDeviceNodeMap()
+                            this_mac = PySpin.CIntegerPtr(
+                                tl.GetNode("GevDeviceMACAddress")
+                            ).GetValue()
+                            if this_mac != target_mac:
+                                continue
+                            PySpin.CIntegerPtr(
+                                tl.GetNode("GevDeviceForceIPAddress")
+                            ).SetValue(new_ip_int)
+                            PySpin.CIntegerPtr(
+                                tl.GetNode("GevDeviceForceSubnetMask")
+                            ).SetValue(mask_int)
+                            PySpin.CIntegerPtr(
+                                tl.GetNode("GevDeviceForceGateway")
+                            ).SetValue(gateway_int)
+                            PySpin.CCommandPtr(
+                                tl.GetNode("GevDeviceForceIP")
+                            ).Execute()
+                            return True
+                        finally:
+                            del cam
+                finally:
+                    cam_list.Clear()
+        finally:
+            iface_list.Clear()
+        return False
 
     async def reset_cameras(self):
         """Reset all the cameras and reopen the system"""

--- a/multi_camera/acquisition/health.py
+++ b/multi_camera/acquisition/health.py
@@ -234,6 +234,32 @@ def _parse_interface_ipv4(ip_addr_output: str) -> str | None:
     return match.group(1) if match else None
 
 
+def _get_host_interface_network(interface: str) -> ipaddress.IPv4Network | None:
+    """Return the interface's IPv4 network (e.g. 192.168.1.0/24) via ioctls.
+
+    Reads IP via SIOCGIFADDR and netmask via SIOCGIFNETMASK so the probe
+    works in containers without iproute2. Returns ``None`` when the
+    interface has no IPv4 assigned or ioctls are unsupported — caller
+    should skip the off-subnet camera check in that case.
+    """
+    try:
+        import fcntl
+        import socket
+        import struct
+
+        packed = struct.pack("256s", interface[:15].encode("ascii"))
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            ip_bytes = fcntl.ioctl(s.fileno(), 0x8915, packed)[20:24]  # SIOCGIFADDR
+            mask_bytes = fcntl.ioctl(s.fileno(), 0x891B, packed)[
+                20:24
+            ]  # SIOCGIFNETMASK
+        ip = socket.inet_ntoa(ip_bytes)
+        mask = socket.inet_ntoa(mask_bytes)
+        return ipaddress.IPv4Network(f"{ip}/{mask}", strict=False)
+    except (OSError, ValueError):
+        return None
+
+
 def _parse_lease_file(lease_file_text: str, now: datetime.datetime) -> int:
     """Count non-expired, non-abandoned DHCP leases in an isc-dhcp-server lease file.
 
@@ -595,6 +621,7 @@ def check_camera_reachability(
     include_unexpected: bool = False,
     enumerator: CameraEnumerator = _default_camera_enumerator,
     excluded_serials: set[str] | None = None,
+    host_interface_subnet: ipaddress.IPv4Network | None = None,
 ) -> CameraReachabilityReport:
     """Report which expected cameras are reachable right now.
 
@@ -800,6 +827,45 @@ def check_camera_reachability(
                         },
                     )
                 )
+
+    # GigE Vision discovery is link-local broadcast and crosses subnets, so a
+    # camera with a stale persistent IP or a link-local 169.254.x.x fallback
+    # still shows up in the enumerator. Init() over GVCP would then fail with
+    # "Spinnaker: Camera is on a wrong subnet. [-1015]" — flag it here so the
+    # operator finds out from `make health` instead of `make test`.
+    if host_interface_subnet is not None:
+        for cam_info in cameras:
+            if not cam_info.detected or cam_info.ip is None:
+                continue
+            try:
+                cam_ip = ipaddress.IPv4Address(cam_info.ip)
+            except (ValueError, ipaddress.AddressValueError):
+                continue
+            if cam_ip in host_interface_subnet:
+                continue
+            findings.append(
+                Finding(
+                    level="error",
+                    code="camera_off_subnet",
+                    message=(
+                        f"Camera {cam_info.serial} has IP {cam_info.ip}, not on "
+                        f"the host subnet {host_interface_subnet}. Init() will "
+                        f"fail with 'wrong subnet'."
+                    ),
+                    remediation=[
+                        "Run `python3 scripts/acquisition/force_camera_ips.py` "
+                        "inside the test container to ForceIP affected cameras.",
+                        "Power-cycle the camera so it re-requests a DHCP lease.",
+                        "If this happens repeatedly, the camera's DHCP request is "
+                        "racing the switch link-up; investigate dhcpd start order.",
+                    ],
+                    details={
+                        "serial": cam_info.serial,
+                        "camera_ip": cam_info.ip,
+                        "host_subnet": str(host_interface_subnet),
+                    },
+                )
+            )
 
     if not missing and expected:
         findings.append(
@@ -1044,6 +1110,9 @@ def run_health_check(
                 include_unexpected=include_unexpected_cameras,
                 enumerator=camera_enumerator or _default_camera_enumerator,
                 excluded_serials=excluded_serials,
+                host_interface_subnet=_get_host_interface_network(
+                    config.network_interface
+                ),
             )
         host_future = executor.submit(
             check_host_network,
@@ -1255,9 +1324,7 @@ def _default_sudo_runner(args: list[str], timeout_s: float = 5.0) -> tuple[str, 
     """
     cmd = ["sudo", "-n", *args]
     try:
-        result = subprocess.run(
-            cmd, capture_output=True, text=True, timeout=timeout_s
-        )
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout_s)
         return (result.stdout + result.stderr).strip(), result.returncode
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
         return f"command failed: {e}", -1

--- a/multi_camera/acquisition/health.py
+++ b/multi_camera/acquisition/health.py
@@ -552,6 +552,30 @@ CameraEnumerator = Callable[[], list[DetectedCamera]]
 WrongSubnetEnumerator = Callable[[], list[WrongSubnetCamera]]
 
 
+def _read_tl_string(node_map: Any, name: str) -> str | None:
+    try:
+        import PySpin  # type: ignore[import-untyped]
+
+        node = PySpin.CStringPtr(node_map.GetNode(name))
+        if PySpin.IsAvailable(node) and PySpin.IsReadable(node):
+            return node.GetValue()
+    except Exception:  # noqa: BLE001
+        return None
+    return None
+
+
+def _read_tl_int(node_map: Any, name: str) -> int | None:
+    try:
+        import PySpin  # type: ignore[import-untyped]
+
+        node = PySpin.CIntegerPtr(node_map.GetNode(name))
+        if PySpin.IsAvailable(node) and PySpin.IsReadable(node):
+            return int(node.GetValue())
+    except Exception:  # noqa: BLE001
+        return None
+    return None
+
+
 def _default_wrong_subnet_enumerator() -> list[WrongSubnetCamera]:
     """Enumerate cameras visible to the GigE interface(s) but on the wrong
     subnet. PySpin's TransportLayerInterface exposes these as "incompatible
@@ -619,6 +643,7 @@ def _default_wrong_subnet_enumerator() -> list[WrongSubnetCamera]:
         finally:
             iface_list.Clear()
     finally:
+        # Don't release the system — simple_pyspin caches a singleton instance.
         pass
 
     return found
@@ -673,30 +698,6 @@ def _default_camera_enumerator() -> list[DetectedCamera]:
         pass
 
     return detected
-
-
-def _read_tl_string(node_map: Any, name: str) -> str | None:
-    try:
-        import PySpin  # type: ignore[import-untyped]
-
-        node = PySpin.CStringPtr(node_map.GetNode(name))
-        if PySpin.IsAvailable(node) and PySpin.IsReadable(node):
-            return node.GetValue()
-    except Exception:  # noqa: BLE001
-        return None
-    return None
-
-
-def _read_tl_int(node_map: Any, name: str) -> int | None:
-    try:
-        import PySpin  # type: ignore[import-untyped]
-
-        node = PySpin.CIntegerPtr(node_map.GetNode(name))
-        if PySpin.IsAvailable(node) and PySpin.IsReadable(node):
-            return int(node.GetValue())
-    except Exception:  # noqa: BLE001
-        return None
-    return None
 
 
 def check_camera_reachability(

--- a/multi_camera/acquisition/health.py
+++ b/multi_camera/acquisition/health.py
@@ -79,6 +79,17 @@ class CameraReachability(BaseModel):
     last_error: str | None = None
 
 
+class WrongSubnetCamera(BaseModel):
+    """A camera visible to the GigE interface but unreachable because its
+    IP is outside the host's subnet. Identified by MAC because the serial
+    isn't readable without Init, and Init isn't possible while wrong-subnet.
+    """
+
+    mac: str
+    current_ip: str | None = None
+    model: str | None = None
+
+
 class CameraReachabilityReport(BaseModel):
     expected: list[str]
     detected: list[str]
@@ -86,6 +97,7 @@ class CameraReachabilityReport(BaseModel):
     extra: list[str]
     cameras: list[CameraReachability]
     enumerated: bool
+    wrong_subnet: list[WrongSubnetCamera] = Field(default_factory=list)
     findings: list[Finding] = Field(default_factory=list)
 
     @property
@@ -537,6 +549,79 @@ def _int_to_ipv4(value: int) -> str | None:
 
 
 CameraEnumerator = Callable[[], list[DetectedCamera]]
+WrongSubnetEnumerator = Callable[[], list[WrongSubnetCamera]]
+
+
+def _default_wrong_subnet_enumerator() -> list[WrongSubnetCamera]:
+    """Enumerate cameras visible to the GigE interface(s) but on the wrong
+    subnet. PySpin's TransportLayerInterface exposes these as "incompatible
+    devices" — readable via interface-level nodes without Init.
+    """
+    try:
+        import PySpin  # type: ignore[import-untyped]
+    except ImportError:
+        return []
+
+    found: list[WrongSubnetCamera] = []
+    system = PySpin.System.GetInstance()
+    try:
+        iface_list = system.GetInterfaces()
+        try:
+            for i in range(iface_list.GetSize()):
+                iface = iface_list.GetByIndex(i)
+                try:
+                    tl_node_map = iface.GetTLNodeMap()
+                    count_node = PySpin.CIntegerPtr(
+                        tl_node_map.GetNode("IncompatibleDeviceCount")
+                    )
+                    if not (
+                        PySpin.IsAvailable(count_node) and PySpin.IsReadable(count_node)
+                    ):
+                        continue
+                    count = count_node.GetValue()
+                    if count <= 0:
+                        continue
+                    selector = PySpin.CIntegerPtr(
+                        tl_node_map.GetNode("IncompatibleDeviceSelector")
+                    )
+                    if not (
+                        PySpin.IsAvailable(selector) and PySpin.IsWritable(selector)
+                    ):
+                        continue
+                    for idx in range(count):
+                        selector.SetValue(idx)
+                        mac_int = _read_tl_int(
+                            tl_node_map, "IncompatibleGevDeviceMACAddress"
+                        )
+                        ip_int = _read_tl_int(
+                            tl_node_map, "IncompatibleGevDeviceIPAddress"
+                        )
+                        model = _read_tl_string(
+                            tl_node_map, "IncompatibleDeviceModelName"
+                        )
+                        if mac_int is None:
+                            continue
+                        mac_hex = f"{mac_int:012x}"
+                        mac_str = ":".join(
+                            mac_hex[j : j + 2] for j in range(0, 12, 2)
+                        )
+                        found.append(
+                            WrongSubnetCamera(
+                                mac=mac_str,
+                                current_ip=_int_to_ipv4(ip_int)
+                                if ip_int is not None
+                                else None,
+                                model=model,
+                            )
+                        )
+                finally:
+                    del iface
+        finally:
+            iface_list.Clear()
+    finally:
+        pass
+
+    return found
 
 
 def _default_camera_enumerator() -> list[DetectedCamera]:
@@ -622,6 +707,7 @@ def check_camera_reachability(
     enumerator: CameraEnumerator = _default_camera_enumerator,
     excluded_serials: set[str] | None = None,
     host_interface_subnet: ipaddress.IPv4Network | None = None,
+    wrong_subnet_enumerator: WrongSubnetEnumerator | None = None,
 ) -> CameraReachabilityReport:
     """Report which expected cameras are reachable right now.
 
@@ -637,7 +723,46 @@ def check_camera_reachability(
     expected = [str(s) for s in expected_serials]
     recorder_has_cams = recorder is not None and bool(getattr(recorder, "cams", None))
 
+    # Wrong-subnet detection is independent of whether a config is loaded —
+    # the operator should see "camera X is on wrong subnet" even before
+    # they've selected anything, because that's the discoverability case.
+    wrong_subnet_findings: list[Finding] = []
+    wrong_subnet_list: list[WrongSubnetCamera] = []
+    if wrong_subnet_enumerator is not None:
+        try:
+            wrong_subnet_list = wrong_subnet_enumerator()
+        except Exception:  # noqa: BLE001
+            wrong_subnet_list = []
+        for cam in wrong_subnet_list:
+            wrong_subnet_findings.append(
+                Finding(
+                    level="error",
+                    code="camera_wrong_subnet",
+                    message=(
+                        f"Camera {cam.mac} is visible to the GigE interface but "
+                        f"on the wrong subnet (current IP {cam.current_ip or 'unknown'})."
+                    ),
+                    details={
+                        "mac": cam.mac,
+                        "current_ip": cam.current_ip,
+                        "model": cam.model,
+                    },
+                    remediation=[
+                        "Click 'Force IP' on this camera's row to re-IP it onto the camera subnet.",
+                        "If Force IP fails, run `make reset` to power-cycle the camera.",
+                    ],
+                )
+            )
+
     if not recorder_has_cams and not expected:
+        no_config_finding = Finding(
+            level="ok",
+            code="cameras_not_configured",
+            message=(
+                "No camera config loaded — select a config to enable "
+                "camera reachability checks."
+            ),
+        )
         return CameraReachabilityReport(
             expected=[],
             detected=[],
@@ -645,16 +770,8 @@ def check_camera_reachability(
             extra=[],
             cameras=[],
             enumerated=False,
-            findings=[
-                Finding(
-                    level="ok",
-                    code="cameras_not_configured",
-                    message=(
-                        "No camera config loaded — select a config to enable "
-                        "camera reachability checks."
-                    ),
-                )
-            ],
+            wrong_subnet=wrong_subnet_list,
+            findings=wrong_subnet_findings + [no_config_finding],
         )
 
     detected_cams: list[DetectedCamera] = []
@@ -876,6 +993,10 @@ def check_camera_reachability(
             )
         )
 
+    # Wrong-subnet findings were computed up front (before the
+    # not-configured early-return) so they always surface.
+    findings.extend(wrong_subnet_findings)
+
     if not findings:
         findings.append(
             Finding(
@@ -892,6 +1013,7 @@ def check_camera_reachability(
         extra=extra,
         cameras=cameras,
         enumerated=enumerated_fresh,
+        wrong_subnet=wrong_subnet_list,
         findings=findings,
     )
 
@@ -1060,6 +1182,7 @@ def run_health_check(
     skip_camera_enumeration: bool = False,
     ip_addr_runner: IpAddrRunner | None = None,
     camera_enumerator: CameraEnumerator | None = None,
+    wrong_subnet_enumerator: WrongSubnetEnumerator | None = None,
     now: datetime.datetime | None = None,
 ) -> HealthCheckReport:
     """Run DHCP + camera-reachability + host-network checks concurrently.
@@ -1112,6 +1235,9 @@ def run_health_check(
                 excluded_serials=excluded_serials,
                 host_interface_subnet=_get_host_interface_network(
                     config.network_interface
+                ),
+                wrong_subnet_enumerator=(
+                    wrong_subnet_enumerator or _default_wrong_subnet_enumerator
                 ),
             )
         host_future = executor.submit(
@@ -1431,6 +1557,8 @@ __all__ = [
     "RemediationReport",
     "Severity",
     "SudoRunner",
+    "WrongSubnetCamera",
+    "WrongSubnetEnumerator",
     "check_camera_reachability",
     "check_dhcp_server",
     "check_host_network",

--- a/multi_camera/backend/fastapi.py
+++ b/multi_camera/backend/fastapi.py
@@ -1161,18 +1161,14 @@ async def get_current_config() -> str:
     return os.path.split(config)[-1]
 
 
-# States during which recovery endpoints (restart / restore / exclude) must
-# refuse to act. "Starting" exists to close the race between new_trial
-# returning 200 and FlirRecorder.start_acquisition flipping the status to
-# "Recording" on its worker thread — without it, a fast click on
-# "Restart acquisition" could tear down PySpin mid-BeginAcquisition.
-_BUSY_RECORDING_STATES = frozenset({"Starting", "Recording"})
-
-
-# States during which HealthIdlePoller must skip PySpin GigE enumeration:
-# the recorder is either holding camera handles or actively writing to
-# camera registers (LineMode, DeviceLinkThroughputLimit, …), and a second
-# enumeration would race those writes → GenICam::AccessException.
+# States during which PySpin is in flight — either holding camera handles
+# or actively writing camera registers (LineMode, DeviceLinkThroughputLimit,
+# BeginAcquisition, …). Used by HealthIdlePoller to skip its GigE
+# enumeration (which would race those writes → GenICam::AccessException),
+# and by recovery endpoints (restart / restore / exclude) that must 409
+# instead of racing the in-flight operation. "Starting" closes the gap
+# between new_trial returning 200 and start_acquisition flipping to
+# "Recording" on its worker thread.
 _BUSY_PYSPIN_STATES = frozenset(
     {"Configuring", "Synchronizing", "Synchronized", "Starting", "Recording"}
 )
@@ -1218,9 +1214,6 @@ async def _reset_and_configure(saved_config: str | None, action: str) -> None:
     await run_in_threadpool(state.acquisition.reset)
     if saved_config is None:
         return
-    # Flip status before the configure so HealthIdlePoller skips its
-    # PySpin enumeration during init_camera (see _BUSY_PYSPIN_STATES).
-    state.acquisition.set_status("Configuring")
     try:
         await state.acquisition.configure_cameras(saved_config)
     except Exception as e:  # noqa: BLE001
@@ -1250,9 +1243,6 @@ async def update_config(config: ConfigFileData):
     if config.config == "":
         state.acquisition.reset()
     else:
-        # Flip status before the configure so HealthIdlePoller skips its
-        # PySpin enumeration during init_camera (see _BUSY_PYSPIN_STATES).
-        state.acquisition.set_status("Configuring")
         await state.acquisition.configure_cameras(
             os.path.join(CONFIG_PATH, config.config)
         )
@@ -1273,10 +1263,13 @@ async def _set_camera_excluded(serial: str, excluded: bool) -> dict:
     reconfigure so the change takes effect. Returns the new exclusion list.
     """
     state: GlobalState = get_global_state()
-    if state.recording_status in _BUSY_RECORDING_STATES:
+    if state.recording_status in _BUSY_PYSPIN_STATES:
         raise HTTPException(
             status_code=409,
-            detail="Cannot change camera exclusion while a recording is active.",
+            detail=(
+                "Cannot change camera exclusion while the system is busy "
+                f"(state: {state.recording_status})."
+            ),
         )
     saved_config = getattr(state.acquisition, "config_file", None)
     current = set(getattr(state.acquisition, "excluded_serials", set()))
@@ -1337,13 +1330,16 @@ async def restore_camera_defaults(serial: str):
     case — equivalent to SpinView's 'Restore Factory Defaults' followed by
     reconfigure.
 
-    Returns 409 if recording, 404 if the serial isn't currently in cams.
+    Returns 409 if the system is busy, 404 if the serial isn't currently in cams.
     """
     state: GlobalState = get_global_state()
-    if state.recording_status in _BUSY_RECORDING_STATES:
+    if state.recording_status in _BUSY_PYSPIN_STATES:
         raise HTTPException(
             status_code=409,
-            detail="Cannot restore camera defaults while a recording is active.",
+            detail=(
+                "Cannot restore camera defaults while the system is busy "
+                f"(state: {state.recording_status})."
+            ),
         )
 
     saved_config = getattr(state.acquisition, "config_file", None)
@@ -1383,13 +1379,16 @@ async def restart_acquisition():
     the PTP sync setup in configure_cameras. Recovery path for the
     timestamp-spread > 1.0 / drifted-PTP case.
 
-    Returns 409 while a recording is active.
+    Returns 409 while the system is busy (configuring, recording, etc.).
     """
     state: GlobalState = get_global_state()
-    if state.recording_status in _BUSY_RECORDING_STATES:
+    if state.recording_status in _BUSY_PYSPIN_STATES:
         raise HTTPException(
             status_code=409,
-            detail="Cannot restart acquisition while a recording is active.",
+            detail=(
+                "Cannot restart acquisition while the system is busy "
+                f"(state: {state.recording_status})."
+            ),
         )
 
     # config_file gets cleared by close(); capture before reset().

--- a/multi_camera/backend/fastapi.py
+++ b/multi_camera/backend/fastapi.py
@@ -420,12 +420,12 @@ async def lifespan(app: FastAPI):
             expected_serials=_expected_serials(state.acquisition),
             recorder=state.acquisition,
             recording_state=state.recording_status or "Idle",
-            # During an active recording the recorder owns the camera handles;
-            # PySpin GigE enumeration would race with the worker threads and
-            # is also slow. Camera-specific issues during recording are
-            # surfaced via the recorder's diagnostics_callback instead. DHCP
-            # and host-network checks still run.
-            skip_camera_enumeration=(state.recording_status in _BUSY_RECORDING_STATES),
+            # See _BUSY_PYSPIN_STATES: skip enumeration whenever the recorder
+            # is holding handles or writing camera registers. DHCP and
+            # host-network checks still run.
+            skip_camera_enumeration=_should_skip_camera_enumeration(
+                state.recording_status
+            ),
         ),
         on_poll=_on_idle_health_poll,
         logger=acquisition_logger,
@@ -1169,6 +1169,19 @@ async def get_current_config() -> str:
 _BUSY_RECORDING_STATES = frozenset({"Starting", "Recording"})
 
 
+# States during which HealthIdlePoller must skip PySpin GigE enumeration:
+# the recorder is either holding camera handles or actively writing to
+# camera registers (LineMode, DeviceLinkThroughputLimit, …), and a second
+# enumeration would race those writes → GenICam::AccessException.
+_BUSY_PYSPIN_STATES = frozenset(
+    {"Configuring", "Synchronizing", "Synchronized", "Starting", "Recording"}
+)
+
+
+def _should_skip_camera_enumeration(recording_status: str | None) -> bool:
+    return recording_status in _BUSY_PYSPIN_STATES
+
+
 async def _refresh_health_after_configure() -> None:
     """Force a health re-check after a camera reconfigure so the operator
     immediately sees post-init state (link speeds, throughput, missing
@@ -1205,6 +1218,9 @@ async def _reset_and_configure(saved_config: str | None, action: str) -> None:
     await run_in_threadpool(state.acquisition.reset)
     if saved_config is None:
         return
+    # Flip status before the configure so HealthIdlePoller skips its
+    # PySpin enumeration during init_camera (see _BUSY_PYSPIN_STATES).
+    state.acquisition.set_status("Configuring")
     try:
         await state.acquisition.configure_cameras(saved_config)
     except Exception as e:  # noqa: BLE001
@@ -1234,6 +1250,9 @@ async def update_config(config: ConfigFileData):
     if config.config == "":
         state.acquisition.reset()
     else:
+        # Flip status before the configure so HealthIdlePoller skips its
+        # PySpin enumeration during init_camera (see _BUSY_PYSPIN_STATES).
+        state.acquisition.set_status("Configuring")
         await state.acquisition.configure_cameras(
             os.path.join(CONFIG_PATH, config.config)
         )

--- a/multi_camera/backend/fastapi.py
+++ b/multi_camera/backend/fastapi.py
@@ -1370,6 +1370,99 @@ async def restore_camera_defaults(serial: str):
     return {"status": "success", "serial": serial, "config": saved_config}
 
 
+class ForceIpData(BaseModel):
+    ip: Optional[str] = None
+    mask: Optional[str] = None
+    gateway: Optional[str] = None
+
+
+@api_router.post("/cameras/{mac}/force_ip")
+async def force_camera_ip(mac: str, data: ForceIpData):
+    """Force a camera that's on the wrong subnet to a target IP via PySpin's
+    GigE Vision ForceIP. Identified by MAC because the serial isn't readable
+    until the camera is on a reachable subnet.
+
+    Body fields are optional. With no body, an IP is auto-picked from the
+    first free address at or above .240 on the host NIC's subnet. Pass
+    ``ip`` / ``mask`` / ``gateway`` to override.
+
+    Returns 409 in network mode (deferred — the operator owns the upstream
+    DHCP fix in that case), 409 if the system is busy (configuring,
+    recording, etc.), and 404 if no camera with that MAC is on the wrong
+    subnet right now.
+    """
+    state: GlobalState = get_global_state()
+    health_config = getattr(state, "health_config", None)
+    if health_config is not None and health_config.deployment_mode != "laptop":
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"Force IP is only available in laptop deployment mode "
+                f"(current: {health_config.deployment_mode}). In network "
+                f"mode, fix the upstream DHCP server so the camera receives "
+                f"a lease on its own subnet."
+            ),
+        )
+    if state.recording_status in _BUSY_PYSPIN_STATES:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"Cannot Force IP while the system is busy "
+                f"(status={state.recording_status})."
+            ),
+        )
+
+    broadcast_event(
+        event_type="session_insight",
+        level="warn",
+        code="force_ip_started",
+        message=f"Forcing IP on camera {mac}…",
+    )
+
+    kwargs: dict = {"mac": mac}
+    if data.ip is not None:
+        kwargs["ip"] = data.ip
+    if data.mask is not None:
+        kwargs["mask"] = data.mask
+    if data.gateway is not None:
+        kwargs["gateway"] = data.gateway
+
+    try:
+        result = await run_in_threadpool(
+            lambda: state.acquisition.force_camera_ip(**kwargs)
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except Exception as e:  # noqa: BLE001
+        broadcast_event(
+            event_type="session_insight",
+            level="error",
+            code="force_ip_failed",
+            message=f"Force IP on {mac} failed: {e}",
+            details={
+                "remediation": [
+                    "Check that the camera is on a directly-connected interface.",
+                    "Run `make reset` to power-cycle the camera.",
+                ],
+            },
+        )
+        raise HTTPException(status_code=500, detail=str(e))
+
+    await _refresh_health_after_configure()
+
+    broadcast_event(
+        event_type="session_insight",
+        level="ok",
+        code="force_ip_complete",
+        message=(
+            f"Camera {mac} is being re-IP'd; it should reappear in the "
+            "Diagnostics tab within a few seconds."
+        ),
+    )
+
+    return {"status": "success", **result}
+
+
 @api_router.post("/restart_acquisition")
 async def restart_acquisition():
     """Tear down the PySpin system and reinitialize from the saved config.

--- a/scripts/acquisition/force_camera_ips.py
+++ b/scripts/acquisition/force_camera_ips.py
@@ -38,11 +38,12 @@ import os
 import sys
 import time
 
+from multi_camera.acquisition.flir_recording_api import (
+    _ipv4_to_int,
+    _enumerate_camera_ips,
+    _force_one_camera_ip,
+)
 from multi_camera.acquisition.health import _get_host_interface_network
-
-
-def _ip_to_int(ip: str) -> int:
-    return int(ipaddress.IPv4Address(ip))
 
 
 def _int_to_ip(value: int) -> str:
@@ -133,114 +134,14 @@ def main() -> int:
             )
             return 3
 
-    mask_int = _ip_to_int(str(subnet.netmask))
+    mask_int = _ipv4_to_int(str(subnet.netmask))
     gateway_int = 0
-    network_base = _ip_to_int(str(subnet.network_address))
+    network_base = _ipv4_to_int(str(subnet.network_address))
     print(f"Target subnet: {subnet} (mask {subnet.netmask})")
 
     system = PySpin.System.GetInstance()
     try:
-
-        def enumerate_state() -> tuple[set[str], list[tuple[str, int, str]]]:
-            """Snapshot every camera's (serial, mac, current_ip) by walking
-            every interface. Returns (in_use_ips_on_subnet, off_subnet_list).
-            Re-runnable — used both up-front and again after each ForceIP to
-            verify the camera actually moved.
-            """
-            in_use: set[str] = set()
-            off: list[tuple[str, int, str]] = []
-            iface_list = system.GetInterfaces()
-            try:
-                for iface_idx in range(iface_list.GetSize()):
-                    iface = iface_list.GetByIndex(iface_idx)
-                    cam_list = iface.GetCameras()
-                    try:
-                        for cam_idx in range(cam_list.GetSize()):
-                            cam = cam_list.GetByIndex(cam_idx)
-                            try:
-                                tl = cam.GetTLDeviceNodeMap()
-                                serial_node = PySpin.CStringPtr(
-                                    tl.GetNode("DeviceSerialNumber")
-                                )
-                                if not (
-                                    PySpin.IsAvailable(serial_node)
-                                    and PySpin.IsReadable(serial_node)
-                                ):
-                                    continue
-                                serial = serial_node.GetValue()
-                                ip_node = PySpin.CIntegerPtr(
-                                    tl.GetNode("GevDeviceIPAddress")
-                                )
-                                if not (
-                                    PySpin.IsAvailable(ip_node)
-                                    and PySpin.IsReadable(ip_node)
-                                ):
-                                    continue
-                                cur_ip = _int_to_ip(ip_node.GetValue())
-                                try:
-                                    cur_ip_addr = ipaddress.IPv4Address(cur_ip)
-                                except (ValueError, ipaddress.AddressValueError):
-                                    continue
-                                if cur_ip_addr in subnet:
-                                    in_use.add(cur_ip)
-                                    continue
-                                mac_int = PySpin.CIntegerPtr(
-                                    tl.GetNode("GevDeviceMACAddress")
-                                ).GetValue()
-                                off.append((serial, mac_int, cur_ip))
-                            finally:
-                                del cam
-                    finally:
-                        cam_list.Clear()
-            finally:
-                iface_list.Clear()
-            return in_use, off
-
-        def force_one(target_mac: int, new_ip_int: int) -> bool:
-            """Re-enumerate, find the camera with the matching MAC, write
-            ``GevDeviceForce*`` on its TLDeviceNodeMap, and Execute. The
-            writes + Execute all happen inside one ``CameraPtr`` scope so
-            Spinnaker can target through the handle. Returns True if a
-            matching camera was found (the ForceIP packet was sent), False
-            otherwise. Caller verifies after waiting.
-            """
-            iface_list = system.GetInterfaces()
-            try:
-                for iface_idx in range(iface_list.GetSize()):
-                    iface = iface_list.GetByIndex(iface_idx)
-                    cam_list = iface.GetCameras()
-                    try:
-                        for cam_idx in range(cam_list.GetSize()):
-                            cam = cam_list.GetByIndex(cam_idx)
-                            try:
-                                tl = cam.GetTLDeviceNodeMap()
-                                this_mac = PySpin.CIntegerPtr(
-                                    tl.GetNode("GevDeviceMACAddress")
-                                ).GetValue()
-                                if this_mac != target_mac:
-                                    continue
-                                PySpin.CIntegerPtr(
-                                    tl.GetNode("GevDeviceForceIPAddress")
-                                ).SetValue(new_ip_int)
-                                PySpin.CIntegerPtr(
-                                    tl.GetNode("GevDeviceForceSubnetMask")
-                                ).SetValue(mask_int)
-                                PySpin.CIntegerPtr(
-                                    tl.GetNode("GevDeviceForceGateway")
-                                ).SetValue(gateway_int)
-                                PySpin.CCommandPtr(
-                                    tl.GetNode("GevDeviceForceIP")
-                                ).Execute()
-                                return True
-                            finally:
-                                del cam
-                    finally:
-                        cam_list.Clear()
-            finally:
-                iface_list.Clear()
-            return False
-
-        in_use_ips, off_subnet = enumerate_state()
+        in_use_ips, off_subnet = _enumerate_camera_ips(system, subnet)
         if not off_subnet:
             print("No cameras off-subnet — nothing to do.")
             return 0
@@ -258,13 +159,15 @@ def main() -> int:
         failures: list[str] = []
         for serial, mac_int, cur_ip in off_subnet:
             new_ip = next_free_ip()
-            new_ip_int = _ip_to_int(new_ip)
+            new_ip_int = _ipv4_to_int(new_ip)
             print(
                 f"{serial} (MAC {_mac_to_str(mac_int)}): {cur_ip} → "
                 f"{new_ip} (mask {subnet.netmask})"
             )
 
-            if not force_one(mac_int, new_ip_int):
+            if not _force_one_camera_ip(
+                system, mac_int, new_ip_int, mask_int, gateway_int
+            ):
                 print(
                     f"  ! No camera with MAC {_mac_to_str(mac_int)} found on "
                     f"re-enumeration; skipping.",
@@ -278,7 +181,7 @@ def main() -> int:
             # Verify: if this MAC still shows up in the off-subnet list after
             # the settle, the ForceIP didn't stick — surface the camera so
             # the operator can power-cycle it.
-            _, still_off = enumerate_state()
+            _, still_off = _enumerate_camera_ips(system, subnet)
             if mac_int in {m for _, m, _ in still_off}:
                 print(
                     f"  ! {serial} still off-subnet after {args.settle_seconds}s. "

--- a/scripts/acquisition/force_camera_ips.py
+++ b/scripts/acquisition/force_camera_ips.py
@@ -95,6 +95,23 @@ def main() -> int:
     )
     args = parser.parse_args()
 
+    # Gate to laptop deployment mode. In network mode the operator owns
+    # the upstream DHCP fix; this CLI's volatile ForceIP rescue would
+    # mask the real problem and require re-running on every camera
+    # power-cycle. Lift this gate once we've designed a deliberate
+    # network-mode ForceIP policy (target-subnet validation, lease-pool
+    # collision avoidance against the upstream DHCP server, etc.).
+    deployment_mode = os.environ.get("DEPLOYMENT_MODE", "laptop").strip().lower()
+    if deployment_mode != "laptop":
+        print(
+            f"Force IP is only available in laptop deployment mode "
+            f"(current DEPLOYMENT_MODE={deployment_mode!r}). In network "
+            f"mode, fix the upstream DHCP server so cameras receive leases "
+            f"on the correct subnet on their own.",
+            file=sys.stderr,
+        )
+        return 4
+
     try:
         import PySpin  # type: ignore[import-untyped]
     except ImportError:

--- a/scripts/acquisition/force_camera_ips.py
+++ b/scripts/acquisition/force_camera_ips.py
@@ -59,10 +59,10 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--interface",
-        default=os.environ.get("NETWORK_INTERFACE", "enp34s0"),
+        default=os.environ.get("NETWORK_INTERFACE"),
         help=(
             "Host NIC to auto-detect the target subnet from. "
-            "Defaults to $NETWORK_INTERFACE."
+            "Defaults to $NETWORK_INTERFACE; required if neither is set."
         ),
     )
     parser.add_argument(
@@ -95,6 +95,15 @@ def main() -> int:
         ),
     )
     args = parser.parse_args()
+
+    if not args.interface and not args.target_subnet:
+        print(
+            "No network interface specified. Pass --interface, set "
+            "$NETWORK_INTERFACE, or pass --target-subnet to override the "
+            "auto-detect path.",
+            file=sys.stderr,
+        )
+        return 5
 
     # Gate to laptop deployment mode. In network mode the operator owns
     # the upstream DHCP fix; this CLI's volatile ForceIP rescue would

--- a/scripts/acquisition/force_camera_ips.py
+++ b/scripts/acquisition/force_camera_ips.py
@@ -1,29 +1,44 @@
-"""Rescue cameras stuck on link-local 169.254.x.x via PySpin ForceIP.
+"""Rescue cameras stuck on a wrong subnet via Spinnaker ForceIP.
 
-When DHCP misses a camera at boot it falls back to link-local, which leaves
-``Init()`` failing with ``Spinnaker: Camera is on a wrong subnet. [-1015]``
-while ``make health`` still reports the camera as reachable (GVCP discovery
-is link-local broadcast and crosses subnets). This script broadcasts a
-``ForceIP`` GVCP command to each affected camera by MAC, assigning a fresh
-address in the target subnet. The change is volatile — on the next camera
-power-cycle DHCP runs again — so this is a runtime recovery, not a
-permanent fix.
+When DHCP misses a camera at boot it falls back to link-local 169.254.x.x,
+which leaves ``Init()`` failing with ``Spinnaker: Camera is on a wrong
+subnet. [-1015]`` while ``make health`` still reports the camera as
+reachable (GVCP discovery is link-local broadcast and crosses subnets).
+This script broadcasts a ``ForceIP`` GVCP command to each affected
+camera, assigning a fresh IP within the host NIC's subnet. The change is
+volatile — on the next camera power-cycle the camera renegotiates DHCP
+or falls back to its persistent IP — so this is a runtime recovery, not
+a permanent fix.
 
 Usage (inside the test container):
     docker compose run --rm --entrypoint python3 test \\
         /Mocap/scripts/acquisition/force_camera_ips.py
 
-By default rescues every camera whose current IP is in 169.254.0.0/16 and
-assigns it ``192.168.1.{200+offset}`` with mask 255.255.255.0. Override with
-``--target-subnet`` / ``--start-octet`` if your lab uses different ranges.
+By default the target subnet is auto-detected from the NIC named by
+``$NETWORK_INTERFACE`` (or ``--interface``) via ``SIOCGIFNETMASK``. New
+IPs are picked starting at ``--start-octet`` (default 240, chosen to sit
+above typical DHCP pools that run .10–.100) and skip any IP already
+held by another discovered camera so we never collide with a live
+lease. Targeting works by re-enumerating the camera list right before
+each ForceIP — that gives a fresh ``CameraPtr`` whose internal state
+points at exactly one device — then MAC-verifying the handle before
+writing ``GevDeviceForce*`` and executing ``GevDeviceForceIP`` on its
+own ``GetTLDeviceNodeMap``. After the configured settle delay the
+camera list is re-enumerated again to confirm the target actually
+moved onto the new subnet; cameras that don't move (firmware refused,
+camera offline, etc.) are reported so the operator can power-cycle
+them instead.
 """
 
 from __future__ import annotations
 
 import argparse
 import ipaddress
+import os
 import sys
 import time
+
+from multi_camera.acquisition.health import _get_host_interface_network
 
 
 def _ip_to_int(ip: str) -> int:
@@ -42,24 +57,41 @@ def _mac_to_str(mac_int: int) -> str:
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument(
+        "--interface",
+        default=os.environ.get("NETWORK_INTERFACE", "enp34s0"),
+        help=(
+            "Host NIC to auto-detect the target subnet from. "
+            "Defaults to $NETWORK_INTERFACE."
+        ),
+    )
+    parser.add_argument(
         "--target-subnet",
-        default="192.168.1.0/24",
-        help="Subnet to ForceIP cameras onto (default: 192.168.1.0/24).",
+        default=None,
+        help=(
+            "Override the auto-detected subnet (e.g. 192.168.1.0/24). "
+            "Use only if you know the host NIC's IP isn't on the same "
+            "subnet the cameras should join."
+        ),
     )
     parser.add_argument(
         "--start-octet",
         type=int,
-        default=200,
+        default=240,
         help=(
-            "Last octet to start assigning from (default: 200). Picked above "
-            "the DHCP pool so the forced IPs don't collide with leases."
+            "Last octet to start assigning from (default: 240). 240+ "
+            "sits above typical isc-dhcp-server pools that run .10–.100, "
+            "so forced IPs won't collide with a future DHCPACK."
         ),
     )
     parser.add_argument(
         "--settle-seconds",
         type=float,
-        default=2.0,
-        help="Pause after each ForceIP for the camera to apply (default: 2s).",
+        default=5.0,
+        help=(
+            "Pause after each ForceIP for the camera to apply the new "
+            "config (default: 5s). Shorter values can cause subsequent "
+            "ForceIP calls to target the still-reconfiguring camera."
+        ),
     )
     args = parser.parse_args()
 
@@ -72,86 +104,182 @@ def main() -> int:
         )
         return 2
 
-    subnet = ipaddress.IPv4Network(args.target_subnet)
+    if args.target_subnet:
+        subnet = ipaddress.IPv4Network(args.target_subnet)
+    else:
+        subnet = _get_host_interface_network(args.interface)
+        if subnet is None:
+            print(
+                f"Could not detect IPv4 subnet on interface {args.interface}. "
+                f"Pass --target-subnet to override.",
+                file=sys.stderr,
+            )
+            return 3
+
     mask_int = _ip_to_int(str(subnet.netmask))
-    gateway_int = 0  # no gateway
+    gateway_int = 0
+    network_base = _ip_to_int(str(subnet.network_address))
+    print(f"Target subnet: {subnet} (mask {subnet.netmask})")
 
     system = PySpin.System.GetInstance()
     try:
-        iface_list = system.GetInterfaces()
-        offset = 0
-        any_rescued = False
 
-        for i in range(iface_list.GetSize()):
-            iface = iface_list.GetByIndex(i)
-            iface_nodemap = iface.GetTLNodeMap()
-            cam_list = iface.GetCameras()
+        def enumerate_state() -> tuple[set[str], list[tuple[str, int, str]]]:
+            """Snapshot every camera's (serial, mac, current_ip) by walking
+            every interface. Returns (in_use_ips_on_subnet, off_subnet_list).
+            Re-runnable — used both up-front and again after each ForceIP to
+            verify the camera actually moved.
+            """
+            in_use: set[str] = set()
+            off: list[tuple[str, int, str]] = []
+            iface_list = system.GetInterfaces()
             try:
-                for j in range(cam_list.GetSize()):
-                    cam = cam_list.GetByIndex(j)
-                    tl = cam.GetTLDeviceNodeMap()
-
-                    serial = PySpin.CStringPtr(tl.GetNode("DeviceSerialNumber"))
-                    if not (PySpin.IsAvailable(serial) and PySpin.IsReadable(serial)):
-                        continue
-                    serial_str = serial.GetValue()
-
-                    cur_ip_node = PySpin.CIntegerPtr(tl.GetNode("GevDeviceIPAddress"))
-                    if not (
-                        PySpin.IsAvailable(cur_ip_node)
-                        and PySpin.IsReadable(cur_ip_node)
-                    ):
-                        continue
-                    cur_ip = _int_to_ip(cur_ip_node.GetValue())
-
-                    if not cur_ip.startswith("169.254."):
-                        print(
-                            f"{serial_str}: {cur_ip} — already on a routable subnet, skipping."
-                        )
-                        continue
-
-                    mac_node = PySpin.CIntegerPtr(tl.GetNode("GevDeviceMACAddress"))
-                    mac_int = mac_node.GetValue()
-
-                    new_ip_int = (
-                        _ip_to_int(str(subnet.network_address))
-                        + args.start_octet
-                        + offset
-                    )
-                    offset += 1
-                    new_ip = _int_to_ip(new_ip_int)
-
-                    print(
-                        f"{serial_str} (MAC {_mac_to_str(mac_int)}): "
-                        f"{cur_ip} → {new_ip} (mask {subnet.netmask})"
-                    )
-
-                    PySpin.CIntegerPtr(
-                        iface_nodemap.GetNode("GevDeviceMACAddress")
-                    ).SetValue(mac_int)
-                    PySpin.CIntegerPtr(
-                        iface_nodemap.GetNode("GevDeviceForceIPAddress")
-                    ).SetValue(new_ip_int)
-                    PySpin.CIntegerPtr(
-                        iface_nodemap.GetNode("GevDeviceForceSubnetMask")
-                    ).SetValue(mask_int)
-                    PySpin.CIntegerPtr(
-                        iface_nodemap.GetNode("GevDeviceForceGateway")
-                    ).SetValue(gateway_int)
-                    PySpin.CCommandPtr(
-                        iface_nodemap.GetNode("GevDeviceForceIP")
-                    ).Execute()
-
-                    time.sleep(args.settle_seconds)
-                    any_rescued = True
+                for iface_idx in range(iface_list.GetSize()):
+                    iface = iface_list.GetByIndex(iface_idx)
+                    cam_list = iface.GetCameras()
+                    try:
+                        for cam_idx in range(cam_list.GetSize()):
+                            cam = cam_list.GetByIndex(cam_idx)
+                            try:
+                                tl = cam.GetTLDeviceNodeMap()
+                                serial_node = PySpin.CStringPtr(
+                                    tl.GetNode("DeviceSerialNumber")
+                                )
+                                if not (
+                                    PySpin.IsAvailable(serial_node)
+                                    and PySpin.IsReadable(serial_node)
+                                ):
+                                    continue
+                                serial = serial_node.GetValue()
+                                ip_node = PySpin.CIntegerPtr(
+                                    tl.GetNode("GevDeviceIPAddress")
+                                )
+                                if not (
+                                    PySpin.IsAvailable(ip_node)
+                                    and PySpin.IsReadable(ip_node)
+                                ):
+                                    continue
+                                cur_ip = _int_to_ip(ip_node.GetValue())
+                                try:
+                                    cur_ip_addr = ipaddress.IPv4Address(cur_ip)
+                                except (ValueError, ipaddress.AddressValueError):
+                                    continue
+                                if cur_ip_addr in subnet:
+                                    in_use.add(cur_ip)
+                                    continue
+                                mac_int = PySpin.CIntegerPtr(
+                                    tl.GetNode("GevDeviceMACAddress")
+                                ).GetValue()
+                                off.append((serial, mac_int, cur_ip))
+                            finally:
+                                del cam
+                    finally:
+                        cam_list.Clear()
             finally:
-                cam_list.Clear()
+                iface_list.Clear()
+            return in_use, off
 
-        iface_list.Clear()
+        def force_one(target_mac: int, new_ip_int: int) -> bool:
+            """Re-enumerate, find the camera with the matching MAC, write
+            ``GevDeviceForce*`` on its TLDeviceNodeMap, and Execute. The
+            writes + Execute all happen inside one ``CameraPtr`` scope so
+            Spinnaker can target through the handle. Returns True if a
+            matching camera was found (the ForceIP packet was sent), False
+            otherwise. Caller verifies after waiting.
+            """
+            iface_list = system.GetInterfaces()
+            try:
+                for iface_idx in range(iface_list.GetSize()):
+                    iface = iface_list.GetByIndex(iface_idx)
+                    cam_list = iface.GetCameras()
+                    try:
+                        for cam_idx in range(cam_list.GetSize()):
+                            cam = cam_list.GetByIndex(cam_idx)
+                            try:
+                                tl = cam.GetTLDeviceNodeMap()
+                                this_mac = PySpin.CIntegerPtr(
+                                    tl.GetNode("GevDeviceMACAddress")
+                                ).GetValue()
+                                if this_mac != target_mac:
+                                    continue
+                                PySpin.CIntegerPtr(
+                                    tl.GetNode("GevDeviceForceIPAddress")
+                                ).SetValue(new_ip_int)
+                                PySpin.CIntegerPtr(
+                                    tl.GetNode("GevDeviceForceSubnetMask")
+                                ).SetValue(mask_int)
+                                PySpin.CIntegerPtr(
+                                    tl.GetNode("GevDeviceForceGateway")
+                                ).SetValue(gateway_int)
+                                PySpin.CCommandPtr(
+                                    tl.GetNode("GevDeviceForceIP")
+                                ).Execute()
+                                return True
+                            finally:
+                                del cam
+                    finally:
+                        cam_list.Clear()
+            finally:
+                iface_list.Clear()
+            return False
 
-        if not any_rescued:
-            print("No cameras on 169.254.x.x — nothing to do.")
+        in_use_ips, off_subnet = enumerate_state()
+        if not off_subnet:
+            print("No cameras off-subnet — nothing to do.")
             return 0
+
+        def next_free_ip() -> str:
+            for octet in range(args.start_octet, 255):
+                candidate = _int_to_ip(network_base + octet)
+                if candidate not in in_use_ips:
+                    in_use_ips.add(candidate)
+                    return candidate
+            raise RuntimeError(
+                f"No free IPs in {subnet} starting at .{args.start_octet}."
+            )
+
+        failures: list[str] = []
+        for serial, mac_int, cur_ip in off_subnet:
+            new_ip = next_free_ip()
+            new_ip_int = _ip_to_int(new_ip)
+            print(
+                f"{serial} (MAC {_mac_to_str(mac_int)}): {cur_ip} → "
+                f"{new_ip} (mask {subnet.netmask})"
+            )
+
+            if not force_one(mac_int, new_ip_int):
+                print(
+                    f"  ! No camera with MAC {_mac_to_str(mac_int)} found on "
+                    f"re-enumeration; skipping.",
+                    file=sys.stderr,
+                )
+                failures.append(serial)
+                continue
+
+            time.sleep(args.settle_seconds)
+
+            # Verify: if this MAC still shows up in the off-subnet list after
+            # the settle, the ForceIP didn't stick — surface the camera so
+            # the operator can power-cycle it.
+            _, still_off = enumerate_state()
+            if mac_int in {m for _, m, _ in still_off}:
+                print(
+                    f"  ! {serial} still off-subnet after {args.settle_seconds}s. "
+                    f"The camera is likely ignoring GVCP due to a stale "
+                    f"switch ARP entry or a dormant state. Try, in order:\n"
+                    f"      1. sudo service isc-dhcp-server restart  "
+                    f"(refreshes layer-2 traffic; usually wakes the camera)\n"
+                    f"      2. make force-ip  (retry)\n"
+                    f"      3. Power-cycle the camera as a last resort.",
+                    file=sys.stderr,
+                )
+                failures.append(serial)
+            else:
+                print(f"  ✓ {serial} on {subnet}")
+
+        if failures:
+            print(f"\nUnresolved: {', '.join(failures)}", file=sys.stderr)
+            return 1
         return 0
     finally:
         system.ReleaseInstance()

--- a/scripts/acquisition/force_camera_ips.py
+++ b/scripts/acquisition/force_camera_ips.py
@@ -1,0 +1,161 @@
+"""Rescue cameras stuck on link-local 169.254.x.x via PySpin ForceIP.
+
+When DHCP misses a camera at boot it falls back to link-local, which leaves
+``Init()`` failing with ``Spinnaker: Camera is on a wrong subnet. [-1015]``
+while ``make health`` still reports the camera as reachable (GVCP discovery
+is link-local broadcast and crosses subnets). This script broadcasts a
+``ForceIP`` GVCP command to each affected camera by MAC, assigning a fresh
+address in the target subnet. The change is volatile — on the next camera
+power-cycle DHCP runs again — so this is a runtime recovery, not a
+permanent fix.
+
+Usage (inside the test container):
+    docker compose run --rm --entrypoint python3 test \\
+        /Mocap/scripts/acquisition/force_camera_ips.py
+
+By default rescues every camera whose current IP is in 169.254.0.0/16 and
+assigns it ``192.168.1.{200+offset}`` with mask 255.255.255.0. Override with
+``--target-subnet`` / ``--start-octet`` if your lab uses different ranges.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ipaddress
+import sys
+import time
+
+
+def _ip_to_int(ip: str) -> int:
+    return int(ipaddress.IPv4Address(ip))
+
+
+def _int_to_ip(value: int) -> str:
+    return str(ipaddress.IPv4Address(value))
+
+
+def _mac_to_str(mac_int: int) -> str:
+    bs = mac_int.to_bytes(6, "big")
+    return ":".join(f"{b:02x}" for b in bs)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--target-subnet",
+        default="192.168.1.0/24",
+        help="Subnet to ForceIP cameras onto (default: 192.168.1.0/24).",
+    )
+    parser.add_argument(
+        "--start-octet",
+        type=int,
+        default=200,
+        help=(
+            "Last octet to start assigning from (default: 200). Picked above "
+            "the DHCP pool so the forced IPs don't collide with leases."
+        ),
+    )
+    parser.add_argument(
+        "--settle-seconds",
+        type=float,
+        default=2.0,
+        help="Pause after each ForceIP for the camera to apply (default: 2s).",
+    )
+    args = parser.parse_args()
+
+    try:
+        import PySpin  # type: ignore[import-untyped]
+    except ImportError:
+        print(
+            "PySpin not importable — run this inside the test container.",
+            file=sys.stderr,
+        )
+        return 2
+
+    subnet = ipaddress.IPv4Network(args.target_subnet)
+    mask_int = _ip_to_int(str(subnet.netmask))
+    gateway_int = 0  # no gateway
+
+    system = PySpin.System.GetInstance()
+    try:
+        iface_list = system.GetInterfaces()
+        offset = 0
+        any_rescued = False
+
+        for i in range(iface_list.GetSize()):
+            iface = iface_list.GetByIndex(i)
+            iface_nodemap = iface.GetTLNodeMap()
+            cam_list = iface.GetCameras()
+            try:
+                for j in range(cam_list.GetSize()):
+                    cam = cam_list.GetByIndex(j)
+                    tl = cam.GetTLDeviceNodeMap()
+
+                    serial = PySpin.CStringPtr(tl.GetNode("DeviceSerialNumber"))
+                    if not (PySpin.IsAvailable(serial) and PySpin.IsReadable(serial)):
+                        continue
+                    serial_str = serial.GetValue()
+
+                    cur_ip_node = PySpin.CIntegerPtr(tl.GetNode("GevDeviceIPAddress"))
+                    if not (
+                        PySpin.IsAvailable(cur_ip_node)
+                        and PySpin.IsReadable(cur_ip_node)
+                    ):
+                        continue
+                    cur_ip = _int_to_ip(cur_ip_node.GetValue())
+
+                    if not cur_ip.startswith("169.254."):
+                        print(
+                            f"{serial_str}: {cur_ip} — already on a routable subnet, skipping."
+                        )
+                        continue
+
+                    mac_node = PySpin.CIntegerPtr(tl.GetNode("GevDeviceMACAddress"))
+                    mac_int = mac_node.GetValue()
+
+                    new_ip_int = (
+                        _ip_to_int(str(subnet.network_address))
+                        + args.start_octet
+                        + offset
+                    )
+                    offset += 1
+                    new_ip = _int_to_ip(new_ip_int)
+
+                    print(
+                        f"{serial_str} (MAC {_mac_to_str(mac_int)}): "
+                        f"{cur_ip} → {new_ip} (mask {subnet.netmask})"
+                    )
+
+                    PySpin.CIntegerPtr(
+                        iface_nodemap.GetNode("GevDeviceMACAddress")
+                    ).SetValue(mac_int)
+                    PySpin.CIntegerPtr(
+                        iface_nodemap.GetNode("GevDeviceForceIPAddress")
+                    ).SetValue(new_ip_int)
+                    PySpin.CIntegerPtr(
+                        iface_nodemap.GetNode("GevDeviceForceSubnetMask")
+                    ).SetValue(mask_int)
+                    PySpin.CIntegerPtr(
+                        iface_nodemap.GetNode("GevDeviceForceGateway")
+                    ).SetValue(gateway_int)
+                    PySpin.CCommandPtr(
+                        iface_nodemap.GetNode("GevDeviceForceIP")
+                    ).Execute()
+
+                    time.sleep(args.settle_seconds)
+                    any_rescued = True
+            finally:
+                cam_list.Clear()
+
+        iface_list.Clear()
+
+        if not any_rescued:
+            print("No cameras on 169.254.x.x — nothing to do.")
+            return 0
+        return 0
+    finally:
+        system.ReleaseInstance()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/acquisition/test_force_ip_endpoint.py
+++ b/tests/acquisition/test_force_ip_endpoint.py
@@ -1,0 +1,228 @@
+"""Tests for ``POST /api/v1/cameras/{mac}/force_ip``.
+
+The endpoint is the GUI surface for the same operation
+``scripts/acquisition/force_camera_ips.py`` exposes from the CLI. Both
+gate to laptop deployment mode (the upstream DHCP problem in network
+mode wants a deliberate operator fix, not a volatile ForceIP). The
+endpoint also refuses while the system is in any PySpin-busy state to
+avoid racing ``configure_cameras`` or an active recording.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+import unittest.mock as mock
+
+import pytest
+
+
+def _install_pyspin_stubs() -> None:
+    for name in ("PySpin", "simple_pyspin"):
+        if name in sys.modules:
+            continue
+        stub = types.ModuleType(name)
+        if name == "simple_pyspin":
+
+            class _Camera:
+                def __init__(self, *args, **kwargs):
+                    raise RuntimeError("PySpin stub")
+
+            stub.Camera = _Camera  # type: ignore[attr-defined]
+            stub._SYSTEM = None  # type: ignore[attr-defined]
+            stub.list_cameras = lambda: []  # type: ignore[attr-defined]
+        sys.modules[name] = stub
+
+
+_install_pyspin_stubs()
+
+
+def _import_backend():
+    import os
+
+    real_listdir = os.listdir
+
+    def safe_listdir(path):
+        if str(path).startswith("/configs"):
+            return []
+        return real_listdir(path)
+
+    os.makedirs("data", exist_ok=True)
+    with mock.patch("os.listdir", side_effect=safe_listdir):
+        from multi_camera.backend import fastapi as _backend_fastapi
+    return _backend_fastapi
+
+
+try:
+    backend_fastapi = _import_backend()
+except Exception as exc:  # pragma: no cover
+    pytest.skip(f"Backend not importable: {exc}", allow_module_level=True)
+
+from multi_camera.acquisition.health import HealthConfig
+
+
+def _make_state(deployment_mode: str = "laptop", recording_status: str = "Idle"):
+    state = backend_fastapi.GlobalState()
+    state.health_config = HealthConfig(deployment_mode=deployment_mode)
+    state.recording_status = recording_status
+    state.acquisition = mock.MagicMock()
+    state.acquisition.force_camera_ip = mock.MagicMock(
+        return_value={"mac": "aa:bb:cc:dd:ee:ff", "ip": "192.168.1.240"}
+    )
+    return state
+
+
+def _call_endpoint(state, mac: str, body: dict | None = None):
+    """Drive the endpoint synchronously, returning either the result dict
+    or the raised HTTPException for assertion.
+    """
+    from fastapi import HTTPException
+
+    data = backend_fastapi.ForceIpData(**(body or {}))
+
+    async def body_coro():
+        with mock.patch.object(
+            backend_fastapi, "get_global_state", return_value=state
+        ), mock.patch.object(
+            backend_fastapi, "broadcast_event", new=mock.MagicMock()
+        ), mock.patch.object(
+            backend_fastapi,
+            "_refresh_health_after_configure",
+            new=mock.AsyncMock(),
+        ):
+            return await backend_fastapi.force_camera_ip(mac, data)
+
+    try:
+        return asyncio.run(body_coro()), None
+    except HTTPException as e:
+        return None, e
+
+
+class TestDeploymentModeGate:
+    """Network mode is deliberately unsupported today — the script and
+    endpoint both refuse so the operator doesn't paper over an upstream
+    DHCP issue with a volatile ForceIP that has to be re-run every
+    power-cycle.
+    """
+
+    def test_endpoint_refuses_in_network_mode(self) -> None:
+        state = _make_state(deployment_mode="network")
+        result, exc = _call_endpoint(state, "aa:bb:cc:dd:ee:ff")
+        assert result is None
+        assert exc is not None
+        assert exc.status_code == 409
+        assert "laptop" in exc.detail.lower()
+        assert "network" in exc.detail.lower()
+        # Must not have tried the force — gating is upstream of the call
+        state.acquisition.force_camera_ip.assert_not_called()
+
+    def test_endpoint_allows_in_laptop_mode(self) -> None:
+        state = _make_state(deployment_mode="laptop")
+        result, exc = _call_endpoint(state, "aa:bb:cc:dd:ee:ff")
+        assert exc is None
+        assert result == {
+            "status": "success",
+            "mac": "aa:bb:cc:dd:ee:ff",
+            "ip": "192.168.1.240",
+        }
+        state.acquisition.force_camera_ip.assert_called_once()
+
+    def test_endpoint_refuses_when_health_config_missing(self) -> None:
+        """If lifespan hasn't populated health_config the gate becomes
+        a no-op (default HealthConfig() has deployment_mode='laptop').
+        Verify that path still works rather than NameError-ing.
+        """
+        state = backend_fastapi.GlobalState()
+        state.recording_status = "Idle"
+        state.acquisition = mock.MagicMock()
+        state.acquisition.force_camera_ip = mock.MagicMock(
+            return_value={"mac": "aa", "ip": "192.168.1.240"}
+        )
+        # state.health_config = default HealthConfig() — laptop mode
+        result, exc = _call_endpoint(state, "aa")
+        assert exc is None
+        assert result["status"] == "success"
+
+
+class TestBusyStateGate:
+    """force_camera_ip touches PySpin and must not run while any other
+    PySpin-busy operation is in flight.
+    """
+
+    @pytest.mark.parametrize(
+        "status",
+        ["Configuring", "Synchronizing", "Synchronized", "Starting", "Recording"],
+    )
+    def test_endpoint_refuses_in_pyspin_busy_state(self, status: str) -> None:
+        state = _make_state(recording_status=status)
+        result, exc = _call_endpoint(state, "aa:bb:cc:dd:ee:ff")
+        assert result is None
+        assert exc is not None
+        assert exc.status_code == 409
+        assert status in exc.detail
+        state.acquisition.force_camera_ip.assert_not_called()
+
+    @pytest.mark.parametrize("status", ["Idle", "Uninitialized"])
+    def test_endpoint_proceeds_in_idle_or_uninitialized(self, status: str) -> None:
+        state = _make_state(recording_status=status)
+        result, exc = _call_endpoint(state, "aa:bb:cc:dd:ee:ff")
+        assert exc is None
+        assert result["status"] == "success"
+
+
+class TestForceCameraIpInvocation:
+    """The endpoint passes optional body fields through to
+    ``state.acquisition.force_camera_ip`` and converts exceptions into
+    the right HTTP status.
+    """
+
+    def test_no_body_passes_only_mac(self) -> None:
+        state = _make_state()
+        _, exc = _call_endpoint(state, "aa:bb:cc:dd:ee:ff", body={})
+        assert exc is None
+        kwargs = state.acquisition.force_camera_ip.call_args.kwargs
+        assert kwargs == {"mac": "aa:bb:cc:dd:ee:ff"}
+
+    def test_full_body_passes_all_fields(self) -> None:
+        state = _make_state()
+        _, exc = _call_endpoint(
+            state,
+            "aa:bb:cc:dd:ee:ff",
+            body={
+                "ip": "192.168.1.250",
+                "mask": "255.255.255.0",
+                "gateway": "192.168.1.1",
+            },
+        )
+        assert exc is None
+        kwargs = state.acquisition.force_camera_ip.call_args.kwargs
+        assert kwargs == {
+            "mac": "aa:bb:cc:dd:ee:ff",
+            "ip": "192.168.1.250",
+            "mask": "255.255.255.0",
+            "gateway": "192.168.1.1",
+        }
+
+    def test_value_error_becomes_404(self) -> None:
+        """force_camera_ip raises ValueError when no camera with the MAC
+        is currently off-subnet — surface as 404 so the operator can
+        retry after a discovery refresh.
+        """
+        state = _make_state()
+        state.acquisition.force_camera_ip.side_effect = ValueError(
+            "No off-subnet camera with MAC aa:bb:cc:dd:ee:ff on any interface"
+        )
+        _, exc = _call_endpoint(state, "aa:bb:cc:dd:ee:ff")
+        assert exc is not None
+        assert exc.status_code == 404
+
+    def test_other_exception_becomes_500(self) -> None:
+        state = _make_state()
+        state.acquisition.force_camera_ip.side_effect = RuntimeError(
+            "Camera ignored ForceIP, still off-subnet after 5s"
+        )
+        _, exc = _call_endpoint(state, "aa:bb:cc:dd:ee:ff")
+        assert exc is not None
+        assert exc.status_code == 500
+        assert "Camera ignored" in exc.detail

--- a/tests/acquisition/test_health_cameras.py
+++ b/tests/acquisition/test_health_cameras.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from multi_camera.acquisition.health import (
     DetectedCamera,
     HealthConfig,
+    WrongSubnetCamera,
     _int_to_ipv4,
     _snapshot_from_recorder,
     check_camera_reachability,
@@ -607,3 +608,77 @@ class TestCameraOffSubnet:
             host_interface_subnet=ipaddress.IPv4Network("192.168.1.0/24"),
         )
         assert report.severity == "error"
+
+
+class TestWrongSubnetDetection:
+    """``check_camera_reachability`` runs an optional ``wrong_subnet_enumerator``
+    that surfaces cameras visible to PySpin's TransportLayer as "incompatible"
+    — i.e. on a subnet PySpin's GVCP knows is unreachable. Distinct from the
+    ``TestCameraOffSubnet`` path which compares already-detected camera IPs
+    against the host NIC's subnet; this one finds cameras that don't appear
+    in the regular enumeration at all.
+    """
+
+    def test_wrong_subnet_camera_emits_finding(self) -> None:
+        def fake_enum() -> list[DetectedCamera]:
+            return []
+
+        def fake_wrong_subnet() -> list[WrongSubnetCamera]:
+            return [
+                WrongSubnetCamera(
+                    mac="aa:bb:cc:dd:ee:ff",
+                    current_ip="10.0.0.42",
+                    model="Blackfly S",
+                )
+            ]
+
+        report = check_camera_reachability(
+            expected_serials=[],
+            recorder=None,
+            enumerator=fake_enum,
+            wrong_subnet_enumerator=fake_wrong_subnet,
+        )
+
+        assert len(report.wrong_subnet) == 1
+        assert report.wrong_subnet[0].mac == "aa:bb:cc:dd:ee:ff"
+        wrong = [f for f in report.findings if f.code == "camera_wrong_subnet"]
+        assert len(wrong) == 1
+        assert wrong[0].level == "error"
+        assert wrong[0].remediation and any(
+            "Force IP" in s for s in wrong[0].remediation
+        )
+
+    def test_no_wrong_subnet_no_finding(self) -> None:
+        def fake_enum() -> list[DetectedCamera]:
+            return [DetectedCamera(serial="111", link_speed_mbps=1000)]
+
+        def fake_wrong_subnet() -> list[WrongSubnetCamera]:
+            return []
+
+        report = check_camera_reachability(
+            expected_serials=["111"],
+            recorder=None,
+            enumerator=fake_enum,
+            wrong_subnet_enumerator=fake_wrong_subnet,
+        )
+        assert report.wrong_subnet == []
+        assert not any(f.code == "camera_wrong_subnet" for f in report.findings)
+
+    def test_enumerator_raising_does_not_break_check(self) -> None:
+        """A failing wrong-subnet enumerator must not crash the rest of
+        the reachability check — fall back to empty list.
+        """
+
+        def fake_enum() -> list[DetectedCamera]:
+            return [DetectedCamera(serial="111", link_speed_mbps=1000)]
+
+        def boom() -> list[WrongSubnetCamera]:
+            raise RuntimeError("PySpin exploded")
+
+        report = check_camera_reachability(
+            expected_serials=["111"],
+            recorder=None,
+            enumerator=fake_enum,
+            wrong_subnet_enumerator=boom,
+        )
+        assert report.wrong_subnet == []

--- a/tests/acquisition/test_health_cameras.py
+++ b/tests/acquisition/test_health_cameras.py
@@ -187,10 +187,26 @@ class TestThroughputOutlier:
 
         def fake_enum() -> list[DetectedCamera]:
             return [
-                DetectedCamera(serial="A", link_speed_mbps=1000, link_throughput_bytes_per_sec=92_000_000),
-                DetectedCamera(serial="B", link_speed_mbps=1000, link_throughput_bytes_per_sec=92_000_000),
-                DetectedCamera(serial="C", link_speed_mbps=1000, link_throughput_bytes_per_sec=92_000_000),
-                DetectedCamera(serial="D", link_speed_mbps=1000, link_throughput_bytes_per_sec=12_000_000),
+                DetectedCamera(
+                    serial="A",
+                    link_speed_mbps=1000,
+                    link_throughput_bytes_per_sec=92_000_000,
+                ),
+                DetectedCamera(
+                    serial="B",
+                    link_speed_mbps=1000,
+                    link_throughput_bytes_per_sec=92_000_000,
+                ),
+                DetectedCamera(
+                    serial="C",
+                    link_speed_mbps=1000,
+                    link_throughput_bytes_per_sec=92_000_000,
+                ),
+                DetectedCamera(
+                    serial="D",
+                    link_speed_mbps=1000,
+                    link_throughput_bytes_per_sec=12_000_000,
+                ),
             ]
 
         report = check_camera_reachability(
@@ -206,7 +222,11 @@ class TestThroughputOutlier:
     def test_uniform_throughput_no_outlier(self) -> None:
         def fake_enum() -> list[DetectedCamera]:
             return [
-                DetectedCamera(serial=str(i), link_speed_mbps=1000, link_throughput_bytes_per_sec=92_000_000)
+                DetectedCamera(
+                    serial=str(i),
+                    link_speed_mbps=1000,
+                    link_throughput_bytes_per_sec=92_000_000,
+                )
                 for i in range(4)
             ]
 
@@ -412,7 +432,9 @@ class TestRunHealthCheck:
         assert elapsed < 0.2, f"run_health_check took {elapsed:.3f}s, expected <0.2s"
         assert report.cameras.enumerated is False
 
-    def test_skip_camera_enumeration_does_not_call_enumerator(self, tmp_path: Path) -> None:
+    def test_skip_camera_enumeration_does_not_call_enumerator(
+        self, tmp_path: Path
+    ) -> None:
         """During recording, run_health_check must skip the PySpin enum
         (recorder owns the handles) but still run DHCP / host-network checks.
         """
@@ -473,3 +495,115 @@ class TestHealthConfigFromEnv:
         cfg = HealthConfig.from_env({})
         assert cfg.deployment_mode == "laptop"
         assert cfg.network_interface == "enp5s0"
+
+
+class TestCameraOffSubnet:
+    """GigE Vision discovery is link-local broadcast and crosses subnets, so a
+    camera with a stale persistent IP or a 169.254.x.x link-local fallback
+    still enumerates. ``check_camera_reachability`` must flag these explicitly
+    — pre-fix, ``make health`` reported "all reachable" while ``Init()`` failed
+    with ``Spinnaker: Camera is on a wrong subnet. [-1015]``.
+    """
+
+    def test_off_subnet_camera_produces_error_finding(self) -> None:
+        import ipaddress
+
+        def fake_enum() -> list[DetectedCamera]:
+            return [
+                DetectedCamera(serial="111", ip="192.168.1.51"),
+                DetectedCamera(serial="222", ip="169.254.172.46"),
+            ]
+
+        report = check_camera_reachability(
+            expected_serials=["111", "222"],
+            recorder=None,
+            enumerator=fake_enum,
+            host_interface_subnet=ipaddress.IPv4Network("192.168.1.0/24"),
+        )
+        off_subnet = [f for f in report.findings if f.code == "camera_off_subnet"]
+        assert len(off_subnet) == 1
+        assert off_subnet[0].level == "error"
+        assert "222" in off_subnet[0].message
+        assert "169.254.172.46" in off_subnet[0].message
+        assert off_subnet[0].details["serial"] == "222"
+        assert off_subnet[0].details["host_subnet"] == "192.168.1.0/24"
+
+    def test_all_on_subnet_emits_no_off_subnet_finding(self) -> None:
+        import ipaddress
+
+        def fake_enum() -> list[DetectedCamera]:
+            return [
+                DetectedCamera(serial="111", ip="192.168.1.51"),
+                DetectedCamera(serial="222", ip="192.168.1.52"),
+            ]
+
+        report = check_camera_reachability(
+            expected_serials=["111", "222"],
+            recorder=None,
+            enumerator=fake_enum,
+            host_interface_subnet=ipaddress.IPv4Network("192.168.1.0/24"),
+        )
+        assert not any(f.code == "camera_off_subnet" for f in report.findings)
+
+    def test_unknown_subnet_skips_check(self) -> None:
+        def fake_enum() -> list[DetectedCamera]:
+            return [DetectedCamera(serial="111", ip="169.254.1.1")]
+
+        report = check_camera_reachability(
+            expected_serials=["111"],
+            recorder=None,
+            enumerator=fake_enum,
+            host_interface_subnet=None,
+        )
+        assert not any(f.code == "camera_off_subnet" for f in report.findings)
+
+    def test_camera_without_ip_is_skipped(self) -> None:
+        import ipaddress
+
+        def fake_enum() -> list[DetectedCamera]:
+            return [DetectedCamera(serial="111", ip=None)]
+
+        report = check_camera_reachability(
+            expected_serials=["111"],
+            recorder=None,
+            enumerator=fake_enum,
+            host_interface_subnet=ipaddress.IPv4Network("192.168.1.0/24"),
+        )
+        assert not any(f.code == "camera_off_subnet" for f in report.findings)
+
+    def test_multiple_off_subnet_each_get_their_own_finding(self) -> None:
+        import ipaddress
+
+        def fake_enum() -> list[DetectedCamera]:
+            return [
+                DetectedCamera(serial="aaa", ip="169.254.1.1"),
+                DetectedCamera(serial="bbb", ip="192.168.1.51"),
+                DetectedCamera(serial="ccc", ip="10.0.0.5"),
+            ]
+
+        report = check_camera_reachability(
+            expected_serials=["aaa", "bbb", "ccc"],
+            recorder=None,
+            enumerator=fake_enum,
+            host_interface_subnet=ipaddress.IPv4Network("192.168.1.0/24"),
+        )
+        off = sorted(
+            (f.details["serial"], f.details["camera_ip"])
+            for f in report.findings
+            if f.code == "camera_off_subnet"
+        )
+        assert off == [("aaa", "169.254.1.1"), ("ccc", "10.0.0.5")]
+
+    def test_severity_becomes_error_when_off_subnet_present(self) -> None:
+        import ipaddress
+
+        def fake_enum() -> list[DetectedCamera]:
+            return [DetectedCamera(serial="111", ip="169.254.1.1")]
+
+        report = check_camera_reachability(
+            expected_serials=["111"],
+            recorder=None,
+            enumerator=fake_enum,
+            host_interface_subnet=ipaddress.IPv4Network("192.168.1.0/24"),
+        )
+        assert report.severity == "error"

--- a/tests/acquisition/test_health_poller_busy_states.py
+++ b/tests/acquisition/test_health_poller_busy_states.py
@@ -1,0 +1,170 @@
+"""Tests for the health-poller busy-state predicate that skips PySpin GigE
+enumeration during configure / sync / recording, and for the ``Configuring``
+status flip that lets the predicate fire during ``configure_cameras``."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+import unittest.mock as mock
+
+import pytest
+
+
+def _install_pyspin_stubs() -> None:
+    for name in ("PySpin", "simple_pyspin"):
+        if name in sys.modules:
+            continue
+        stub = types.ModuleType(name)
+        if name == "simple_pyspin":
+
+            class _Camera:
+                def __init__(self, *args, **kwargs):
+                    raise RuntimeError("PySpin stub")
+
+            stub.Camera = _Camera  # type: ignore[attr-defined]
+            stub._SYSTEM = None  # type: ignore[attr-defined]
+            stub.list_cameras = lambda: []  # type: ignore[attr-defined]
+        sys.modules[name] = stub
+
+
+_install_pyspin_stubs()
+
+
+def _import_backend():
+    import os
+
+    real_listdir = os.listdir
+
+    def safe_listdir(path):
+        if str(path).startswith("/configs"):
+            return []
+        return real_listdir(path)
+
+    os.makedirs("data", exist_ok=True)
+    with mock.patch("os.listdir", side_effect=safe_listdir):
+        from multi_camera.backend import fastapi as _backend_fastapi
+    return _backend_fastapi
+
+
+try:
+    backend_fastapi = _import_backend()
+except Exception as exc:  # pragma: no cover
+    pytest.skip(f"Backend not importable: {exc}", allow_module_level=True)
+
+
+class TestShouldSkipCameraEnumeration:
+    """The poller must skip PySpin GigE enumeration whenever the recorder is
+    in a state that holds camera handles or runs PySpin writes — otherwise
+    enumeration races ``init_camera``'s ``LineMode``/``DeviceLinkThroughputLimit``
+    writes and raises ``GenICam::AccessException``."""
+
+    @pytest.mark.parametrize(
+        "status,expected",
+        [
+            ("Configuring", True),
+            ("Synchronizing", True),
+            ("Synchronized", True),
+            ("Starting", True),
+            ("Recording", True),
+            ("Idle", False),
+            ("Uninitialized", False),
+            ("Resetting", False),
+            (None, False),
+            ("", False),
+        ],
+    )
+    def test_skip_decision_per_status(self, status, expected) -> None:
+        assert backend_fastapi._should_skip_camera_enumeration(status) is expected
+
+    def test_pyspin_states_is_superset_of_recording_states(self) -> None:
+        assert backend_fastapi._BUSY_RECORDING_STATES.issubset(
+            backend_fastapi._BUSY_PYSPIN_STATES
+        )
+
+
+class TestConfigureCamerasFlipsToConfiguring:
+    """Both ``configure_cameras`` call sites must flip status to ``Configuring``
+    before awaiting the configure, so the poller skip predicate evaluates to
+    True during ``init_camera``'s PySpin enumeration."""
+
+    def test_update_config_sets_configuring_before_configure(self) -> None:
+        from fastapi import HTTPException  # noqa: F401  (matches endpoint impl)
+
+        recorder = mock.MagicMock()
+        recorder.config_file = None
+        call_order = []
+        recorder.set_status.side_effect = lambda s: call_order.append(("set_status", s))
+
+        async def fake_configure(*args, **kwargs):
+            call_order.append(("configure_cameras", args, kwargs))
+
+        recorder.configure_cameras = fake_configure
+
+        state = backend_fastapi.GlobalState()
+        state.acquisition = recorder
+
+        async def body():
+            with mock.patch.object(
+                backend_fastapi, "get_global_state", return_value=state
+            ), mock.patch.object(
+                backend_fastapi,
+                "_refresh_health_after_configure",
+                new=mock.AsyncMock(),
+            ):
+                cfg = backend_fastapi.ConfigFileData(config="cotton_lab.yaml")
+                await backend_fastapi.update_config(cfg)
+
+        asyncio.run(body())
+
+        statuses = [entry[1] for entry in call_order if entry[0] == "set_status"]
+        configure_idx = next(
+            i for i, entry in enumerate(call_order) if entry[0] == "configure_cameras"
+        )
+        set_status_idx = next(
+            i for i, entry in enumerate(call_order) if entry[0] == "set_status"
+        )
+        assert "Configuring" in statuses
+        assert set_status_idx < configure_idx, (
+            "set_status('Configuring') must run BEFORE configure_cameras to "
+            "cover the init_camera enumeration window."
+        )
+
+    def test_reset_and_configure_sets_configuring_before_configure(self) -> None:
+        recorder = mock.MagicMock()
+        call_order = []
+        recorder.set_status.side_effect = lambda s: call_order.append(("set_status", s))
+        recorder.reset.side_effect = lambda: call_order.append(("reset",))
+
+        async def fake_configure(saved_config):
+            call_order.append(("configure_cameras", saved_config))
+
+        recorder.configure_cameras = fake_configure
+
+        state = backend_fastapi.GlobalState()
+        state.acquisition = recorder
+
+        async def body():
+            with mock.patch.object(
+                backend_fastapi, "get_global_state", return_value=state
+            ):
+                await backend_fastapi._reset_and_configure(
+                    saved_config="/configs/some.yaml", action="Restart"
+                )
+
+        asyncio.run(body())
+
+        statuses = [entry[1] for entry in call_order if entry[0] == "set_status"]
+        configure_idx = next(
+            i for i, entry in enumerate(call_order) if entry[0] == "configure_cameras"
+        )
+        configuring_idx = next(
+            i
+            for i, entry in enumerate(call_order)
+            if entry[0] == "set_status" and entry[1] == "Configuring"
+        )
+        assert "Configuring" in statuses
+        assert configuring_idx < configure_idx, (
+            "set_status('Configuring') must run BEFORE configure_cameras."
+        )

--- a/tests/acquisition/test_health_poller_busy_states.py
+++ b/tests/acquisition/test_health_poller_busy_states.py
@@ -1,6 +1,7 @@
-"""Tests for the health-poller busy-state predicate that skips PySpin GigE
-enumeration during configure / sync / recording, and for the ``Configuring``
-status flip that lets the predicate fire during ``configure_cameras``."""
+"""Tests for the busy-state predicate that gates HealthIdlePoller's PySpin
+GigE enumeration and the recovery endpoints (restart / restore / exclude),
+and for the ``Configuring`` status flip inside ``FlirRecorder.configure_cameras``
+that lets the predicate fire before ``init_camera``'s register writes."""
 
 from __future__ import annotations
 
@@ -54,117 +55,119 @@ except Exception as exc:  # pragma: no cover
     pytest.skip(f"Backend not importable: {exc}", allow_module_level=True)
 
 
+_BUSY_STATUSES = [
+    "Configuring",
+    "Synchronizing",
+    "Synchronized",
+    "Starting",
+    "Recording",
+]
+_FREE_STATUSES = ["Idle", "Uninitialized", "Resetting", None, ""]
+
+
 class TestShouldSkipCameraEnumeration:
     """The poller must skip PySpin GigE enumeration whenever the recorder is
-    in a state that holds camera handles or runs PySpin writes — otherwise
-    enumeration races ``init_camera``'s ``LineMode``/``DeviceLinkThroughputLimit``
-    writes and raises ``GenICam::AccessException``."""
+    in a state that holds camera handles or runs PySpin register writes —
+    otherwise enumeration races ``init_camera``'s ``LineMode`` /
+    ``DeviceLinkThroughputLimit`` writes and raises ``GenICam::AccessException``."""
 
-    @pytest.mark.parametrize(
-        "status,expected",
-        [
-            ("Configuring", True),
-            ("Synchronizing", True),
-            ("Synchronized", True),
-            ("Starting", True),
-            ("Recording", True),
-            ("Idle", False),
-            ("Uninitialized", False),
-            ("Resetting", False),
-            (None, False),
-            ("", False),
-        ],
-    )
-    def test_skip_decision_per_status(self, status, expected) -> None:
-        assert backend_fastapi._should_skip_camera_enumeration(status) is expected
+    @pytest.mark.parametrize("status", _BUSY_STATUSES)
+    def test_skip_during_busy(self, status) -> None:
+        assert backend_fastapi._should_skip_camera_enumeration(status) is True
 
-    def test_pyspin_states_is_superset_of_recording_states(self) -> None:
-        assert backend_fastapi._BUSY_RECORDING_STATES.issubset(
-            backend_fastapi._BUSY_PYSPIN_STATES
-        )
+    @pytest.mark.parametrize("status", _FREE_STATUSES)
+    def test_do_not_skip_when_free(self, status) -> None:
+        assert backend_fastapi._should_skip_camera_enumeration(status) is False
 
 
-class TestConfigureCamerasFlipsToConfiguring:
-    """Both ``configure_cameras`` call sites must flip status to ``Configuring``
-    before awaiting the configure, so the poller skip predicate evaluates to
-    True during ``init_camera``'s PySpin enumeration."""
+class TestFlirRecorderConfigureCameras:
+    """``FlirRecorder.configure_cameras`` is the single locus for the
+    Configuring flip: any future caller (HTTP handler, script, test) gets the
+    correct status transition for free."""
 
-    def test_update_config_sets_configuring_before_configure(self) -> None:
-        from fastapi import HTTPException  # noqa: F401  (matches endpoint impl)
+    def test_configure_cameras_flips_to_configuring_before_pyspin_work(self) -> None:
+        from multi_camera.acquisition.flir_recording_api import FlirRecorder
 
-        recorder = mock.MagicMock()
+        seen: list[str] = []
+
+        def flip_then_abort(status):
+            seen.append(status)
+            raise RuntimeError("__aborted_by_test__")
+
+        recorder = FlirRecorder.__new__(FlirRecorder)
+        recorder.set_status = flip_then_abort
         recorder.config_file = None
-        call_order = []
-        recorder.set_status.side_effect = lambda s: call_order.append(("set_status", s))
+        recorder.excluded_serials = set()
+        recorder.system = mock.MagicMock()
 
-        async def fake_configure(*args, **kwargs):
-            call_order.append(("configure_cameras", args, kwargs))
+        with pytest.raises(RuntimeError, match="__aborted_by_test__"):
+            asyncio.run(recorder.configure_cameras(num_cams=1))
 
-        recorder.configure_cameras = fake_configure
+        assert seen == ["Configuring"], (
+            "configure_cameras' first observable side effect must be "
+            f"set_status('Configuring'); got {seen!r}"
+        )
 
+
+class TestOperatorActionGuards:
+    """Recovery endpoints (restart / restore-defaults / change-exclusion) must
+    refuse with 409 during any PySpin-busy state, not just ``Recording`` —
+    clicking 'Restart acquisition' 200ms after a config-change POST should not
+    race configure_cameras."""
+
+    def _state_with(self, status: str):
         state = backend_fastapi.GlobalState()
-        state.acquisition = recorder
+        state.recording_status = status
+        state.acquisition = mock.MagicMock()
+        return state
 
-        async def body():
-            with mock.patch.object(
-                backend_fastapi, "get_global_state", return_value=state
-            ), mock.patch.object(
-                backend_fastapi,
-                "_refresh_health_after_configure",
-                new=mock.AsyncMock(),
-            ):
-                cfg = backend_fastapi.ConfigFileData(config="cotton_lab.yaml")
-                await backend_fastapi.update_config(cfg)
+    @pytest.mark.parametrize("status", _BUSY_STATUSES)
+    def test_restart_acquisition_409(self, status) -> None:
+        from fastapi import HTTPException
 
-        asyncio.run(body())
-
-        statuses = [entry[1] for entry in call_order if entry[0] == "set_status"]
-        configure_idx = next(
-            i for i, entry in enumerate(call_order) if entry[0] == "configure_cameras"
-        )
-        set_status_idx = next(
-            i for i, entry in enumerate(call_order) if entry[0] == "set_status"
-        )
-        assert "Configuring" in statuses
-        assert set_status_idx < configure_idx, (
-            "set_status('Configuring') must run BEFORE configure_cameras to "
-            "cover the init_camera enumeration window."
-        )
-
-    def test_reset_and_configure_sets_configuring_before_configure(self) -> None:
-        recorder = mock.MagicMock()
-        call_order = []
-        recorder.set_status.side_effect = lambda s: call_order.append(("set_status", s))
-        recorder.reset.side_effect = lambda: call_order.append(("reset",))
-
-        async def fake_configure(saved_config):
-            call_order.append(("configure_cameras", saved_config))
-
-        recorder.configure_cameras = fake_configure
-
-        state = backend_fastapi.GlobalState()
-        state.acquisition = recorder
+        state = self._state_with(status)
 
         async def body():
             with mock.patch.object(
                 backend_fastapi, "get_global_state", return_value=state
             ):
-                await backend_fastapi._reset_and_configure(
-                    saved_config="/configs/some.yaml", action="Restart"
-                )
+                with pytest.raises(HTTPException) as exc:
+                    await backend_fastapi.restart_acquisition()
+                assert exc.value.status_code == 409
+                assert status in str(exc.value.detail)
 
         asyncio.run(body())
 
-        statuses = [entry[1] for entry in call_order if entry[0] == "set_status"]
-        configure_idx = next(
-            i for i, entry in enumerate(call_order) if entry[0] == "configure_cameras"
-        )
-        configuring_idx = next(
-            i
-            for i, entry in enumerate(call_order)
-            if entry[0] == "set_status" and entry[1] == "Configuring"
-        )
-        assert "Configuring" in statuses
-        assert configuring_idx < configure_idx, (
-            "set_status('Configuring') must run BEFORE configure_cameras."
-        )
+    @pytest.mark.parametrize("status", _BUSY_STATUSES)
+    def test_restore_camera_defaults_409(self, status) -> None:
+        from fastapi import HTTPException
+
+        state = self._state_with(status)
+
+        async def body():
+            with mock.patch.object(
+                backend_fastapi, "get_global_state", return_value=state
+            ):
+                with pytest.raises(HTTPException) as exc:
+                    await backend_fastapi.restore_camera_defaults("12345")
+                assert exc.value.status_code == 409
+                assert status in str(exc.value.detail)
+
+        asyncio.run(body())
+
+    @pytest.mark.parametrize("status", _BUSY_STATUSES)
+    def test_set_camera_excluded_409(self, status) -> None:
+        from fastapi import HTTPException
+
+        state = self._state_with(status)
+
+        async def body():
+            with mock.patch.object(
+                backend_fastapi, "get_global_state", return_value=state
+            ):
+                with pytest.raises(HTTPException) as exc:
+                    await backend_fastapi._set_camera_excluded("12345", True)
+                assert exc.value.status_code == 409
+                assert status in str(exc.value.detail)
+
+        asyncio.run(body())


### PR DESCRIPTION
## Summary

  Closes the GUI-side "GenICam::AccessException on LineMode" failure mode that made config selection unreliable in network mode with 12 cameras, and adds the Force IP rescue path operators needed to recover wrong-subnet cameras without manual SpinView intervention.

  Primary fix:
 - `HealthIdlePoller` runs a PySpin GigE enumeration every 30s; the skip-during-busy predicate only covered `Starting`/`Recording`, so a poll tick that landed during `configure_cameras`'s `init_camera` threadpool would race the PySpin register writes (`LineMode`, `DeviceLinkThroughputLimit`, …) and raise `GenICam::AccessException`.

Approach: add a `Configuring` status that the configure path flips to *before* any PySpin work, and widen the poller's skip predicate to cover every PySpin-busy state (`Configuring`, `Synchronizing`, `Synchronized`, `Starting`, `Recording`). The same widened set now guards the three recovery endpoints (restart / restore-defaults / exclude) so a fast click on "Restart acquisition" mid-configure also 409s cleanly instead of racing.

  Force IP infrastructure:

  - New `camera_off_subnet` finding: flag any detected camera whose IP is outside the host NIC's subnet (link-local fallback, stale persistent IP, etc.).
  - New `force_camera_ips.py` CLI + `make force-ip`
  - New `POST /api/v1/cameras/{mac}/force_ip` endpoint + GUI ForceIpButton on the Diagnostics tab for operator-side rescue 
  - Both surfaces (CLI + endpoint) **gated to `DEPLOYMENT_MODE=laptop`**. Deferred how we want to handle force IP on the network mode to future branch
  - Shared module-level helpers (`_enumerate_camera_ips`, `_force_one_camera_ip`) used by both surfaces; CLI doesn't duplicate the PySpin walk.

  ## Test plan

  - [x] 141 unit tests pass across the touched-area suite (`tests/acquisition/test_health_poller_busy_states.py`,
    `test_force_ip_endpoint.py`, `test_health_cameras.py`, `test_main_ws_broadcast.py`, `test_diagnostics_manager.py`, `test_health_integration.py`, `test_health_poller.py`, `test_restart_acquisition.py`, `test_session_summary.py`, `test_health_dhcp.py`).
  - [x] New `test_health_poller_busy_states.py` covers the predicate decision per status and the call-order invariant (Configuring flip must precede `configure_cameras`).
  - [x] New `test_force_ip_endpoint.py` covers the laptop-mode gate, the busy-state gate (parametrized across every PySpin-busy state), exception → HTTP-status mapping, optional body field forwarding.
  - [x] `TestWrongSubnetDetection` cherry-picked from pr4; combined with existing `TestCameraOffSubnet` to cover both detection paths.
  - [x] Operator-side validation on the acquisition laptop: GUI loads, config selection completes cleanly (no AccessException), recording start/stop works end-to-end with 12 cameras in network mode.
  - [ ] Operator-side validation of the Force IP button against a deliberately-induced wrong-subnet camera.

  ## Follow-up branches (tracked separately)

  1. Deployment-mode-aware remediation strings.
  2. `init_camera` LineMode try/except wrapping to surface the failing camera's serial in tracebacks.
  3. `calculate_timespread_drift` empty-input guard.
  4. Frontend: disable config dropdown until initial `fetchHealth` resolves (closes the GUI-side mount-time race vector).
  5. Network-mode Force IP policy design pass, then lift the gate.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)