### PR TITLE
Feat/diagnostics pr4 rebased

### DIFF
--- a/frontend/acquisition/src/AcquisitionApi.js
+++ b/frontend/acquisition/src/AcquisitionApi.js
@@ -33,6 +33,8 @@ const BUSY_PYSPIN_STATES = [
     'Synchronized',
     'Starting',
     'Recording',
+    'Resetting',
+    'Reset complete. Waiting to reconfigure.',
 ];
 
 export const isBusyPySpinState = (status) =>

--- a/frontend/acquisition/src/AcquisitionApi.js
+++ b/frontend/acquisition/src/AcquisitionApi.js
@@ -106,48 +106,60 @@ export const AcquisitionApi = (props) => {
     }, []);
 
     useEffectOnce(() => {
-
+        // Persist a single socket ref across reconnect attempts and a flag
+        // so the cleanup function knows we're intentionally closing.
         const url = `${WS_BASE_URL}`;
-        const socket = new WebSocket(url);
+        const state = { socket: null, closed: false, backoffMs: 500 };
 
-        console.log("Connecting to websocket..." + url)
+        const connect = () => {
+            console.log("Connecting to websocket..." + url);
+            const socket = new WebSocket(url);
+            state.socket = socket;
 
-        socket.onopen = (event) => {
-            console.log("WebSocket connection established" + url, event);
+            socket.onopen = () => {
+                console.log("WebSocket connection established " + url);
+                state.backoffMs = 500;
+                // Re-fetch the authoritative status on every (re)open so
+                // the GUI never sits with stale recordingSystemStatus if
+                // a broadcast was missed while disconnected (MCT-e8o).
+                fetchRecordingStatus();
+            };
+
+            socket.onmessage = (event) => {
+                const data = JSON.parse(event.data);
+                if (data.status !== undefined) {
+                    setRecordingSystemStatus(data.status);
+                }
+                if (data.progress !== undefined) {
+                    setRecordingProgress(Math.ceil(data.progress * 100));
+                }
+            };
+
+            socket.onclose = (event) => {
+                console.log("WebSocket connection closed " + url, event);
+                if (state.closed) return;
+                // Backoff: 0.5s → 1s → 2s → 4s → cap at 5s
+                const delay = state.backoffMs;
+                state.backoffMs = Math.min(state.backoffMs * 2, 5000);
+                setTimeout(connect, delay);
+            };
+
+            socket.onerror = (event) => {
+                console.log("WebSocket error observed " + url + ":", event);
+            };
         };
 
-        socket.onmessage = (event) => {
-            const data = JSON.parse(event.data);
-            if (data.status !== undefined) {
-                setRecordingSystemStatus(data.status);
-            }
-            if (data.progress !== undefined) {
-                setRecordingProgress(Math.ceil(data.progress * 100));
-            }
-        };
+        connect();
 
-        socket.onclose = (event) => {
-            console.log("WebSocket connection closed" + url, event);
-        };
-
-        socket.onerror = (event) => {
-            console.log("WebSocket error observed" + url + ":", event);
-        }
-
-        //clean up function when we close page
         return () => {
-            console.log("Closing WebSocket " + url + " ...")
-            socket.close();
-        }
+            state.closed = true;
+            console.log("Closing WebSocket " + url + " ...");
+            if (state.socket) state.socket.close();
+        };
     }, []);
 
     useEffectOnce(() => {
-        const socket = new WebSocket(WS_DIAGNOSTICS_URL);
-        console.log("Connecting to diagnostics websocket...", WS_DIAGNOSTICS_URL);
-
-        socket.onopen = () => {
-            console.log("Diagnostics WebSocket connection established");
-        };
+        const state = { socket: null, closed: false, backoffMs: 500 };
 
         const appendInsight = (env, dedupKey) => {
             setSessionInsights(prev => {
@@ -159,33 +171,56 @@ export const AcquisitionApi = (props) => {
             });
         };
 
-        socket.onmessage = (event) => {
-            const env = JSON.parse(event.data);
-            switch (env.type) {
-                case "health_report":
-                    fetchHealth();
-                    break;
-                case "session_insight":
-                    appendInsight(env, (i) => i.message);
-                    break;
-                case "error":
-                    fetchHealth();
-                    appendInsight(env, (i) => `${i.code}::${i.message}`);
-                    break;
-                default:
-                    break;
-            }
+        const connect = () => {
+            const socket = new WebSocket(WS_DIAGNOSTICS_URL);
+            state.socket = socket;
+            console.log("Connecting to diagnostics websocket...", WS_DIAGNOSTICS_URL);
+
+            socket.onopen = () => {
+                console.log("Diagnostics WebSocket connection established");
+                state.backoffMs = 500;
+                // Re-fetch health on every (re)open so a dropped health_report
+                // broadcast doesn't leave the GUI stuck on a stale banner.
+                fetchHealth();
+            };
+
+            socket.onmessage = (event) => {
+                const env = JSON.parse(event.data);
+                switch (env.type) {
+                    case "health_report":
+                        fetchHealth();
+                        break;
+                    case "session_insight":
+                        appendInsight(env, (i) => i.message);
+                        break;
+                    case "error":
+                        fetchHealth();
+                        appendInsight(env, (i) => `${i.code}::${i.message}`);
+                        break;
+                    default:
+                        break;
+                }
+            };
+
+            socket.onclose = () => {
+                console.log("Diagnostics WebSocket closed");
+                if (state.closed) return;
+                const delay = state.backoffMs;
+                state.backoffMs = Math.min(state.backoffMs * 2, 5000);
+                setTimeout(connect, delay);
+            };
+
+            socket.onerror = (event) => {
+                console.log("Diagnostics WebSocket error:", event);
+            };
         };
 
-        socket.onclose = () => {
-            console.log("Diagnostics WebSocket closed");
-        };
+        connect();
 
-        socket.onerror = (event) => {
-            console.log("Diagnostics WebSocket error:", event);
+        return () => {
+            state.closed = true;
+            if (state.socket) state.socket.close();
         };
-
-        return () => socket.close();
     }, []);
 
     useEffect(() => {

--- a/frontend/acquisition/src/AcquisitionApi.js
+++ b/frontend/acquisition/src/AcquisitionApi.js
@@ -121,7 +121,7 @@ export const AcquisitionApi = (props) => {
                 state.backoffMs = 500;
                 // Re-fetch the authoritative status on every (re)open so
                 // the GUI never sits with stale recordingSystemStatus if
-                // a broadcast was missed while disconnected (MCT-e8o).
+                // a broadcast was missed while disconnected.
                 fetchRecordingStatus();
             };
 

--- a/frontend/acquisition/src/AcquisitionApi.js
+++ b/frontend/acquisition/src/AcquisitionApi.js
@@ -460,6 +460,11 @@ export const AcquisitionApi = (props) => {
         return response.data;
     };
 
+    const markRigRecalibrate = async () => {
+        const response = await axios.post(`${API_BASE_URL}/rig/recalibrate`);
+        return response.data;
+    };
+
     const forceIpCamera = async (mac, ip, mask, gateway) => {
         const body = {};
         if (ip) body.ip = ip;
@@ -596,6 +601,7 @@ export const AcquisitionApi = (props) => {
         restoreCameraDefaults,
         setCameraExcluded,
         forceIpCamera,
+        markRigRecalibrate,
         newSession,
         newTrial,
         previewVideo,

--- a/frontend/acquisition/src/AnalysisHome.js
+++ b/frontend/acquisition/src/AnalysisHome.js
@@ -1,4 +1,5 @@
-import React, { useContext, useState, useRef, useEffect } from "react";
+import React, { useContext, useState, useRef } from "react";
+import { useEffectOnce } from "./AcquisitionApi";
 import { Accordion, Table, Form, Container, Button, Col, Row, ButtonGroup, ToggleButton } from 'react-bootstrap';
 import path from 'path-browserify';
 import { AcquisitionState } from "./AcquisitionApi";
@@ -249,17 +250,17 @@ const AnalysisHome = () => {
         onCalibrate: onCalibrate
     }
 
-    useEffect(() => {
-
+    // Fetch the recording DB once on mount. fetchRecordingDb is recreated
+    // on every AcquisitionApi render, so adding it as a dependency would
+    // cause an endless re-fetch loop.
+    useEffectOnce(() => {
         const fetchData = async () => {
             const recordings = await fetchRecordingDb();
             console.log("recordings", recordings);
             setRecordingDb(recordings);
-        }
-
+        };
         fetchData();
-
-    }, [fetchRecordingDb]);
+    }, []);
 
     const resyncData = async () => {
         const recordings = await fetchRecordingDb();

--- a/frontend/acquisition/src/components/DiagnosticsPage.js
+++ b/frontend/acquisition/src/components/DiagnosticsPage.js
@@ -433,9 +433,10 @@ const ForceIpButton = ({ mac }) => {
 };
 
 const RecalibrateRigButton = () => {
-    const { markRigRecalibrate } = useContext(AcquisitionState);
+    const { markRigRecalibrate, currentConfig } = useContext(AcquisitionState);
     const [busy, setBusy] = useState(false);
     const [error, setError] = useState(null);
+    const noConfig = !currentConfig;
 
     const handleClick = async () => {
         const ok = window.confirm(
@@ -461,10 +462,12 @@ const RecalibrateRigButton = () => {
         <div>
             <Button
                 onClick={handleClick}
-                disabled={busy}
+                disabled={busy || noConfig}
                 size="sm"
                 variant="outline-info"
-                title="Force a new camera_config_hash for subsequent trials (after a camera was bumped/moved)"
+                title={noConfig
+                    ? 'Select a camera config first'
+                    : 'Force a new camera_config_hash for subsequent trials (after a camera was bumped/moved)'}
             >
                 {busy ? '…' : 'Camera moved'}
             </Button>

--- a/frontend/acquisition/src/components/DiagnosticsPage.js
+++ b/frontend/acquisition/src/components/DiagnosticsPage.js
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useContext, useState } from 'react';
 import { Container, Card, Badge, Button, ListGroup, Accordion, Table, Row, Col } from 'react-bootstrap';
 import { AcquisitionState, isBusyPySpinState } from '../AcquisitionApi';
 
@@ -242,12 +242,12 @@ const CurrentSessionPanel = () => {
     const { sessionSummary, fetchSessionSummary } = useContext(AcquisitionState);
     const [refreshing, setRefreshing] = useState(false);
 
-    useEffect(() => {
-        fetchSessionSummary();
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+    // Deliberately no auto-fetch on mount. _build_session_summary walks
+    // every trial JSON in the session directory and can take seconds with
+    // a populated session — running it on every Diagnostics tab visit is
+    // wasted work the operator didn't ask for. Wait for an explicit click.
 
-    const handleRefresh = async () => {
+    const handleGenerate = async () => {
         setRefreshing(true);
         try {
             await fetchSessionSummary();
@@ -256,17 +256,24 @@ const CurrentSessionPanel = () => {
         }
     };
 
+    const buttonLabel = sessionSummary
+        ? (refreshing ? 'Refreshing…' : 'Refresh summary')
+        : (refreshing ? 'Generating…' : 'Generate session summary');
+
     return (
         <Card className="mb-4">
             <Card.Header className="d-flex justify-content-between align-items-center">
                 <strong>Current Session</strong>
-                <Button onClick={handleRefresh} disabled={refreshing} size="sm" variant="outline-primary">
-                    {refreshing ? 'Refreshing…' : 'Refresh summary'}
+                <Button onClick={handleGenerate} disabled={refreshing} size="sm" variant="outline-primary">
+                    {buttonLabel}
                 </Button>
             </Card.Header>
             <Card.Body>
                 {!sessionSummary && (
-                    <p className="text-muted mb-0">No active session, or no trials yet.</p>
+                    <p className="text-muted mb-0">
+                        Click "Generate session summary" to scan the current session's
+                        trial files for patterns and recommendations.
+                    </p>
                 )}
 
                 {sessionSummary && (

--- a/frontend/acquisition/src/components/DiagnosticsPage.js
+++ b/frontend/acquisition/src/components/DiagnosticsPage.js
@@ -242,10 +242,8 @@ const CurrentSessionPanel = () => {
     const { sessionSummary, fetchSessionSummary } = useContext(AcquisitionState);
     const [refreshing, setRefreshing] = useState(false);
 
-    // Deliberately no auto-fetch on mount. _build_session_summary walks
-    // every trial JSON in the session directory and can take seconds with
-    // a populated session — running it on every Diagnostics tab visit is
-    // wasted work the operator didn't ask for. Wait for an explicit click.
+    // No auto-fetch — _build_session_summary walks every trial JSON
+    // and can take seconds. Wait for an explicit click.
 
     const handleGenerate = async () => {
         setRefreshing(true);

--- a/frontend/acquisition/src/components/DiagnosticsPage.js
+++ b/frontend/acquisition/src/components/DiagnosticsPage.js
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useState } from 'react';
-import { Container, Card, Badge, Button, ListGroup, Accordion, Table } from 'react-bootstrap';
+import { Container, Card, Badge, Button, ListGroup, Accordion, Table, Row, Col } from 'react-bootstrap';
 import { AcquisitionState, isBusyPySpinState } from '../AcquisitionApi';
 
 const severityVariant = {
@@ -41,17 +41,28 @@ const FindingList = ({ findings }) => {
     );
 };
 
-const SubsystemCard = ({ title, severity, findings, extra }) => (
-    <Card className="mb-3">
-        <Card.Header className="d-flex justify-content-between align-items-center">
+const SubsystemPanel = ({ title, severity, findings, extra }) => (
+    <div className="h-100">
+        <div className="d-flex justify-content-between align-items-center mb-2 pb-1 border-bottom">
             <strong>{title}</strong>
             <SeverityBadge level={severity} />
-        </Card.Header>
-        <Card.Body>
-            {extra}
-            <FindingList findings={findings} />
-        </Card.Body>
-    </Card>
+        </div>
+        {extra}
+        <FindingList findings={findings} />
+    </div>
+);
+
+// Compact 2-column definition list. Use instead of a borderless Table
+// for tight key/value summaries.
+const KvDl = ({ entries }) => (
+    <dl className="row small mb-2 gx-2">
+        {entries.map(([k, v], i) => (
+            <React.Fragment key={i}>
+                <dt className="col-5 fw-normal text-muted">{k}</dt>
+                <dd className="col-7 mb-1">{v}</dd>
+            </React.Fragment>
+        ))}
+    </dl>
 );
 
 const HostHealthPanel = () => {
@@ -110,135 +121,125 @@ const HostHealthPanel = () => {
                     Last checked: {generated_at ? new Date(generated_at).toLocaleString() : '—'}
                 </div>
 
-                <SubsystemCard
-                    title="DHCP server"
-                    severity={maxLevel(dhcpFindings)}
-                    findings={dhcpFindings}
-                    extra={
-                        dhcp && dhcp.applicable ? (
-                            <Table size="sm" borderless className="mb-2">
-                                <tbody>
-                                    <tr><td>Service</td><td>{describeBool(dhcp.service_active)}</td></tr>
-                                    <tr><td>Interface IP</td><td><code>{dhcp.interface_ip || '—'}</code></td></tr>
-                                    <tr><td>Active leases</td><td>{dhcp.lease_count}</td></tr>
-                                </tbody>
-                            </Table>
-                        ) : (
-                            <p className="text-muted small mb-2">DHCP checks skipped (laptop mode).</p>
-                        )
-                    }
-                />
+                <Row className="g-3 mb-3">
+                    <Col md={4}>
+                        <SubsystemPanel
+                            title="DHCP server"
+                            severity={maxLevel(dhcpFindings)}
+                            findings={dhcpFindings}
+                            extra={
+                                dhcp && dhcp.applicable ? (
+                                    <KvDl entries={[
+                                        ['Service', describeBool(dhcp.service_active)],
+                                        ['Interface IP', <code key="ip">{dhcp.interface_ip || '—'}</code>],
+                                        ['Active leases', dhcp.lease_count],
+                                    ]} />
+                                ) : (
+                                    <p className="text-muted small mb-2">DHCP checks skipped (laptop mode).</p>
+                                )
+                            }
+                        />
+                    </Col>
+                    <Col md={4}>
+                        <SubsystemPanel
+                            title="Cameras"
+                            severity={maxLevel(cameraFindings)}
+                            findings={cameraFindings}
+                            extra={
+                                <KvDl entries={[
+                                    ['Expected', expectedList.length],
+                                    ['Detected', detectedList.length],
+                                    ['Missing', missingList.join(', ') || '—'],
+                                    ['Extra', extraList.join(', ') || '—'],
+                                ]} />
+                            }
+                        />
+                    </Col>
+                    <Col md={4}>
+                        <SubsystemPanel
+                            title="Host network"
+                            severity={maxLevel(hostFindings)}
+                            findings={hostFindings}
+                            extra={
+                                host_network ? (
+                                    <KvDl entries={[
+                                        ['Interface', <code key="if">{host_network.interface}</code>],
+                                        ['Carrier', describeBool(host_network.carrier_up)],
+                                        ['MTU', `${host_network.mtu == null ? '—' : host_network.mtu} (expected ${host_network.expected_mtu})`],
+                                        ['rmem_max', `${host_network.rmem_max == null ? '—' : host_network.rmem_max} (expected ${host_network.expected_rmem_max})`],
+                                    ]} />
+                                ) : null
+                            }
+                        />
+                    </Col>
+                </Row>
 
-                <SubsystemCard
-                    title="Cameras"
-                    severity={maxLevel(cameraFindings)}
-                    findings={cameraFindings}
-                    extra={
-                        <>
-                            <Table size="sm" borderless className="mb-2">
-                                <tbody>
-                                    <tr><td>Expected</td><td>{expectedList.length}</td></tr>
-                                    <tr><td>Detected</td><td>{detectedList.length}</td></tr>
-                                    <tr><td>Missing</td><td>{missingList.join(', ') || '—'}</td></tr>
-                                    <tr><td>Extra</td><td>{extraList.join(', ') || '—'}</td></tr>
-                                </tbody>
-                            </Table>
-                            {wrongSubnet.length > 0 && (
-                                <Table size="sm" striped bordered className="mb-2">
-                                    <thead>
-                                        <tr>
-                                            <th colSpan={3}>Cameras on wrong subnet</th>
-                                            <th>Action</th>
-                                        </tr>
-                                        <tr>
-                                            <th>MAC</th>
-                                            <th>Current IP</th>
-                                            <th>Model</th>
-                                            <th></th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        {wrongSubnet.map((c) => (
-                                            <tr key={c.mac}>
-                                                <td><code>{c.mac}</code></td>
-                                                <td>{c.current_ip || '—'}</td>
-                                                <td>{c.model || '—'}</td>
-                                                <td><ForceIpButton mac={c.mac} /></td>
-                                            </tr>
-                                        ))}
-                                    </tbody>
-                                </Table>
-                            )}
-                            {perCamera.length > 0 && (
-                                <Table size="sm" striped bordered className="mb-2">
-                                    <thead>
-                                        <tr>
-                                            <th>Serial</th>
-                                            <th>IP</th>
-                                            <th>Link</th>
-                                            <th>Throughput</th>
-                                            <th>Status</th>
-                                            <th>Action</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        {perCamera.map((c) => (
-                                            <tr key={c.serial}>
-                                                <td>{c.serial}</td>
-                                                <td>{c.ip || '—'}</td>
-                                                <td>{deriveLinkLabel(c)}</td>
-                                                <td>{c.link_throughput_bytes_per_sec != null
-                                                    ? `${Math.round(c.link_throughput_bytes_per_sec * 8 / 1000000)} Mbps`
-                                                    : '—'}</td>
-                                                <td>{c.excluded
-                                                    ? 'excluded'
-                                                    : (c.detected ? 'reachable' : (c.expected ? 'missing' : 'unexpected'))}</td>
-                                                <td>{(c.excluded || c.expected || c.detected)
-                                                    ? <ExcludeCameraButton serial={c.serial} excluded={c.excluded} />
-                                                    : null}</td>
-                                            </tr>
-                                        ))}
-                                    </tbody>
-                                </Table>
-                            )}
-                        </>
-                    }
-                />
+                {wrongSubnet.length > 0 && (
+                    <Table size="sm" striped bordered className="mb-3">
+                        <thead>
+                            <tr>
+                                <th colSpan={3}>Cameras on wrong subnet</th>
+                                <th>Action</th>
+                            </tr>
+                            <tr>
+                                <th>MAC</th>
+                                <th>Current IP</th>
+                                <th>Model</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {wrongSubnet.map((c) => (
+                                <tr key={c.mac}>
+                                    <td><code>{c.mac}</code></td>
+                                    <td>{c.current_ip || '—'}</td>
+                                    <td>{c.model || '—'}</td>
+                                    <td><ForceIpButton mac={c.mac} /></td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </Table>
+                )}
 
-                <SubsystemCard
-                    title="Host network"
-                    severity={maxLevel(hostFindings)}
-                    findings={hostFindings}
-                    extra={
-                        host_network ? (
-                            <Table size="sm" borderless className="mb-2">
-                                <tbody>
-                                    <tr><td>Interface</td><td><code>{host_network.interface}</code></td></tr>
-                                    <tr><td>Carrier</td><td>{describeBool(host_network.carrier_up)}</td></tr>
-                                    <tr>
-                                        <td>MTU</td>
-                                        <td>
-                                            {host_network.mtu == null ? '—' : host_network.mtu} (expected {host_network.expected_mtu})
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td>rmem_max</td>
-                                        <td>
-                                            {host_network.rmem_max == null ? '—' : host_network.rmem_max} (expected {host_network.expected_rmem_max})
-                                        </td>
-                                    </tr>
-                                </tbody>
-                            </Table>
-                        ) : null
-                    }
-                />
+                {perCamera.length > 0 && (
+                    <Table size="sm" striped bordered className="mb-0">
+                        <thead>
+                            <tr>
+                                <th>Serial</th>
+                                <th>IP</th>
+                                <th>Link</th>
+                                <th>Throughput</th>
+                                <th>Status</th>
+                                <th>Action</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {perCamera.map((c) => (
+                                <tr key={c.serial}>
+                                    <td>{c.serial}</td>
+                                    <td>{c.ip || '—'}</td>
+                                    <td>{deriveLinkLabel(c)}</td>
+                                    <td>{c.link_throughput_bytes_per_sec != null
+                                        ? `${Math.round(c.link_throughput_bytes_per_sec * 8 / 1000000)} Mbps`
+                                        : '—'}</td>
+                                    <td>{c.excluded
+                                        ? 'excluded'
+                                        : (c.detected ? 'reachable' : (c.expected ? 'missing' : 'unexpected'))}</td>
+                                    <td>{(c.excluded || c.expected || c.detected)
+                                        ? <ExcludeCameraButton serial={c.serial} excluded={c.excluded} />
+                                        : null}</td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </Table>
+                )}
             </Card.Body>
         </Card>
     );
 };
 
 const CurrentSessionPanel = () => {
-    const { sessionSummary, sessionInsights, fetchSessionSummary } = useContext(AcquisitionState);
+    const { sessionSummary, fetchSessionSummary } = useContext(AcquisitionState);
     const [refreshing, setRefreshing] = useState(false);
 
     useEffect(() => {
@@ -265,7 +266,7 @@ const CurrentSessionPanel = () => {
             </Card.Header>
             <Card.Body>
                 {!sessionSummary && (
-                    <p className="text-muted">No active session, or no trials yet.</p>
+                    <p className="text-muted mb-0">No active session, or no trials yet.</p>
                 )}
 
                 {sessionSummary && (
@@ -305,38 +306,40 @@ const CurrentSessionPanel = () => {
                         </Accordion>
                     </>
                 )}
-
-                {sessionInsights && sessionInsights.length > 0 && (
-                    <Card className="mt-3">
-                        <Card.Header><strong>Live trial events</strong></Card.Header>
-                        <Card.Body>
-                            <ListGroup variant="flush">
-                                {sessionInsights.map((ev, i) => {
-                                    const steps = (ev.details && ev.details.remediation) || null;
-                                    return (
-                                        <ListGroup.Item key={i} className="d-flex justify-content-between align-items-start">
-                                            <div className="ms-2 me-auto">
-                                                <div className="fw-bold">{ev.message}</div>
-                                                {steps && steps.length > 0 && (
-                                                    <ol className="small mb-1 mt-1 ps-3">
-                                                        {steps.map((step, j) => (
-                                                            <li key={j}>{step}</li>
-                                                        ))}
-                                                    </ol>
-                                                )}
-                                                <small className="text-muted">
-                                                    {ev.code}{ev.ts ? ` · ${new Date(ev.ts).toLocaleTimeString()}` : ''}
-                                                </small>
-                                            </div>
-                                            <SeverityBadge level={ev.level} />
-                                        </ListGroup.Item>
-                                    );
-                                })}
-                            </ListGroup>
-                        </Card.Body>
-                    </Card>
-                )}
             </Card.Body>
+        </Card>
+    );
+};
+
+const LiveTrialEventsPanel = () => {
+    const { sessionInsights } = useContext(AcquisitionState);
+    if (!sessionInsights || sessionInsights.length === 0) return null;
+    return (
+        <Card className="mb-4">
+            <Card.Header><strong>Live trial events</strong></Card.Header>
+            <ListGroup variant="flush">
+                {sessionInsights.map((ev, i) => {
+                    const steps = (ev.details && ev.details.remediation) || null;
+                    return (
+                        <ListGroup.Item key={i} className="d-flex justify-content-between align-items-start">
+                            <div className="ms-2 me-auto">
+                                <div className="fw-bold">{ev.message}</div>
+                                {steps && steps.length > 0 && (
+                                    <ol className="small mb-1 mt-1 ps-3">
+                                        {steps.map((step, j) => (
+                                            <li key={j}>{step}</li>
+                                        ))}
+                                    </ol>
+                                )}
+                                <small className="text-muted">
+                                    {ev.code}{ev.ts ? ` · ${new Date(ev.ts).toLocaleTimeString()}` : ''}
+                                </small>
+                            </div>
+                            <SeverityBadge level={ev.level} />
+                        </ListGroup.Item>
+                    );
+                })}
+            </ListGroup>
         </Card>
     );
 };
@@ -517,6 +520,7 @@ const DiagnosticsPage = () => (
             </div>
         </div>
         <HostHealthPanel />
+        <LiveTrialEventsPanel />
         <CurrentSessionPanel />
     </Container>
 );

--- a/frontend/acquisition/src/components/DiagnosticsPage.js
+++ b/frontend/acquisition/src/components/DiagnosticsPage.js
@@ -429,6 +429,47 @@ const ForceIpButton = ({ mac }) => {
     );
 };
 
+const RecalibrateRigButton = () => {
+    const { markRigRecalibrate } = useContext(AcquisitionState);
+    const [busy, setBusy] = useState(false);
+    const [error, setError] = useState(null);
+
+    const handleClick = async () => {
+        const ok = window.confirm(
+            'Mark the rig for recalibration? Subsequent trials in this session ' +
+            'will record under a new camera_config_hash, so DataJoint will ' +
+            'treat them as a new calibration setup. Capture a new calibration ' +
+            'recording before your next trial.'
+        );
+        if (!ok) return;
+        setBusy(true);
+        setError(null);
+        try {
+            await markRigRecalibrate();
+        } catch (e) {
+            const msg = (e && e.response && e.response.data && e.response.data.detail) || e.message;
+            setError(msg || 'Mark failed.');
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    return (
+        <div>
+            <Button
+                onClick={handleClick}
+                disabled={busy}
+                size="sm"
+                variant="outline-info"
+                title="Force a new camera_config_hash for subsequent trials (after a camera was bumped/moved)"
+            >
+                {busy ? '…' : 'Camera moved'}
+            </Button>
+            {error && <div className="text-danger small mt-1">{error}</div>}
+        </div>
+    );
+};
+
 const RestartAcquisitionButton = () => {
     const { restartAcquisition, recordingSystemStatus } = useContext(AcquisitionState);
     const [busy, setBusy] = useState(false);
@@ -470,7 +511,10 @@ const DiagnosticsPage = () => (
     <Container className="mt-3">
         <div className="d-flex justify-content-between align-items-center mb-3">
             <h3 className="mb-0">Diagnostics</h3>
-            <RestartAcquisitionButton />
+            <div className="d-flex gap-2">
+                <RecalibrateRigButton />
+                <RestartAcquisitionButton />
+            </div>
         </div>
         <HostHealthPanel />
         <CurrentSessionPanel />

--- a/frontend/acquisition/src/components/DiagnosticsPage.js
+++ b/frontend/acquisition/src/components/DiagnosticsPage.js
@@ -311,17 +311,27 @@ const CurrentSessionPanel = () => {
                         <Card.Header><strong>Live trial events</strong></Card.Header>
                         <Card.Body>
                             <ListGroup variant="flush">
-                                {sessionInsights.map((ev, i) => (
-                                    <ListGroup.Item key={i} className="d-flex justify-content-between align-items-start">
-                                        <div className="ms-2 me-auto">
-                                            <div className="fw-bold">{ev.message}</div>
-                                            <small className="text-muted">
-                                                {ev.code}{ev.ts ? ` · ${new Date(ev.ts).toLocaleTimeString()}` : ''}
-                                            </small>
-                                        </div>
-                                        <SeverityBadge level={ev.level} />
-                                    </ListGroup.Item>
-                                ))}
+                                {sessionInsights.map((ev, i) => {
+                                    const steps = (ev.details && ev.details.remediation) || null;
+                                    return (
+                                        <ListGroup.Item key={i} className="d-flex justify-content-between align-items-start">
+                                            <div className="ms-2 me-auto">
+                                                <div className="fw-bold">{ev.message}</div>
+                                                {steps && steps.length > 0 && (
+                                                    <ol className="small mb-1 mt-1 ps-3">
+                                                        {steps.map((step, j) => (
+                                                            <li key={j}>{step}</li>
+                                                        ))}
+                                                    </ol>
+                                                )}
+                                                <small className="text-muted">
+                                                    {ev.code}{ev.ts ? ` · ${new Date(ev.ts).toLocaleTimeString()}` : ''}
+                                                </small>
+                                            </div>
+                                            <SeverityBadge level={ev.level} />
+                                        </ListGroup.Item>
+                                    );
+                                })}
                             </ListGroup>
                         </Card.Body>
                     </Card>

--- a/frontend/acquisition/src/components/RecordingControl.js
+++ b/frontend/acquisition/src/components/RecordingControl.js
@@ -5,13 +5,18 @@ import { AcquisitionState } from "../AcquisitionApi";
 import Spinner from 'react-bootstrap/Spinner';
 
 const RecordingControl = () => {
-    const { participant, newTrial, recordingFilename, recordingProgress, recordingSystemStatus, calibrationVideo, previewVideo, stopAcquisition } = useContext(AcquisitionState);
+    const { participant, currentConfig, newTrial, recordingFilename, recordingProgress, recordingSystemStatus, calibrationVideo, previewVideo, stopAcquisition } = useContext(AcquisitionState);
 
     const [comment, setComment] = useState("");
     const [maxFrames, setMaxFrames] = useState(1000);
 
     const needsParticipant = !participant || participant.length === 0;
-    const participantTooltip = needsParticipant ? "Please set a Participant ID and press Enter first" : "";
+    const noConfig = !currentConfig;
+    const disableReasons = [];
+    if (needsParticipant) disableReasons.push("Set a Participant ID first");
+    if (noConfig) disableReasons.push("Select a config first");
+    const startTooltip = disableReasons.join(" · ");
+    const startDisabled = recordingSystemStatus !== "Idle" || needsParticipant || noConfig;
 
     return (
         <div >
@@ -35,25 +40,25 @@ const RecordingControl = () => {
                         <Col md="auto">
                             <Button id="preview"
                                 className="btn btn-secondary"
-                                disabled={recordingSystemStatus !== "Idle" || needsParticipant}
+                                disabled={startDisabled}
                                 onClick={() => previewVideo(maxFrames)}
-                                title={participantTooltip}
+                                title={startTooltip}
                             >Preview</Button>
                         </Col>
                         <Col md="auto">
                             <Button id="calibration"
                                 className="btn btn-secondary"
-                                disabled={recordingSystemStatus !== "Idle" || needsParticipant}
+                                disabled={startDisabled}
                                 onClick={() => calibrationVideo(maxFrames)}
-                                title={participantTooltip}
+                                title={startTooltip}
                             >Calibration</Button>
                         </Col>
                         <Col md="auto">
                             <Button id="new_trial"
-                                disabled={recordingSystemStatus !== "Idle" || needsParticipant}
+                                disabled={startDisabled}
                                 onClick={() => newTrial(comment, maxFrames)}
                                 className="btn btn-primary"
-                                title={participantTooltip}
+                                title={startTooltip}
                             >New Trial</Button>
                         </Col>
                         <Col md="auto">

--- a/multi_camera/acquisition/flir_recording_api.py
+++ b/multi_camera/acquisition/flir_recording_api.py
@@ -1182,12 +1182,12 @@ class FlirRecorder:
 
         self.trigger = trigger
 
-        # NOTE: PySpin InterfaceEventHandler registration was disabled in
-        # PR 4 testing — registering a handler appears to leak a C++ ref to
+        # PySpin InterfaceEventHandler registration is intentionally
+        # disabled: registering a handler appears to leak a C++ ref to
         # the interface that survives UnregisterEventHandler, causing
         # `terminate called ... [-1004] Can't clear interface` on
-        # subsequent reset_cameras. Camera-disconnect detection now relies
-        # on acquire_frames' -1002/-1012 catch path. Tracked in a bead.
+        # subsequent reset_cameras. Camera-disconnect detection currently
+        # relies on acquire_frames' -1002/-1012 catch path.
         # self._register_interface_events()
 
         self.iface.TLInterface.GevActionDeviceKey.SetValue(0)
@@ -1863,12 +1863,11 @@ class FlirRecorder:
                     )
                     if "-1002" in err_text or "no longer valid" in err_text:
                         # Disconnect during grab — surface to the operator
-                        # and bail out of this worker. Without the break
+                        # and bail out of this worker. Without the break,
                         # the loop would spam -1002 every few ms for the
-                        # rest of the trial (observed: x244 in a single
-                        # ~5s window during PR 4 testing). Putting None
-                        # in the acquisition_queue lets the corresponding
-                        # writer thread drain and exit cleanly.
+                        # rest of the trial. Putting None in the
+                        # acquisition_queue lets the corresponding writer
+                        # thread drain and exit cleanly.
                         self._fire_diagnostic_once(
                             camera_serial=camera_serial,
                             code="camera_disconnected",

--- a/multi_camera/acquisition/flir_recording_api.py
+++ b/multi_camera/acquisition/flir_recording_api.py
@@ -970,6 +970,18 @@ class FlirRecorder:
         )
         return new_hash
 
+    def get_salt(self) -> str:
+        """Current config_hash_salt. Empty string means no rig bump has
+        happened yet (or the salt was cleared)."""
+        return self._config_hash_salt
+
+    def set_salt(self, salt: str) -> None:
+        """Restore the config_hash_salt from external storage (typically a
+        session-scoped sidecar file maintained by the backend). Empty
+        string clears it back to the pre-bump default.
+        """
+        self._config_hash_salt = salt
+
     def get_detailed_processor_info(self):
         cpu_info = ""
 

--- a/multi_camera/acquisition/flir_recording_api.py
+++ b/multi_camera/acquisition/flir_recording_api.py
@@ -231,6 +231,62 @@ def _force_one_camera_ip(
     return False
 
 
+class _RecorderInterfaceEventHandler(PySpin.InterfaceEventHandler):
+    """Fires diagnostic envelopes when a camera arrives or is removed from
+    the GigE interface the recorder is using.
+
+    Cleaner primary signal than the reactive ``-1002`` error catch in
+    ``acquire_frames``: the SDK calls these methods immediately on cable
+    disconnect/reconnect, before the dead handle starts spamming errors.
+    """
+
+    def __init__(self, recorder: "FlirRecorder", interface_id: str):
+        super().__init__()
+        self._recorder = recorder
+        self._interface_id = interface_id
+
+    @staticmethod
+    def _read_serial(camera) -> str:
+        try:
+            nodemap = camera.GetTLDeviceNodeMap()
+            node = PySpin.CStringPtr(nodemap.GetNode("DeviceSerialNumber"))
+            if PySpin.IsReadable(node):
+                return node.GetValue()
+        except Exception:  # noqa: BLE001
+            pass
+        return ""
+
+    def OnDeviceArrival(self, camera) -> None:
+        serial = self._read_serial(camera)
+        if not serial:
+            return
+        self._recorder._fire_diagnostic_once(
+            camera_serial=serial,
+            code="camera_reconnected",
+            level="ok",
+            message=(
+                f"Camera {serial} reconnected on {self._interface_id}. "
+                "Click Restart acquisition to bring it back into the rig."
+            ),
+            details={"interface": self._interface_id},
+        )
+
+    def OnDeviceRemoval(self, camera) -> None:
+        serial = self._read_serial(camera)
+        if not serial:
+            return
+        self._recorder._fire_diagnostic_once(
+            camera_serial=serial,
+            code="camera_disconnected",
+            level="error",
+            message=(
+                f"Camera {serial} was removed from {self._interface_id}. "
+                "Check the cable and power."
+            ),
+            details={"interface": self._interface_id},
+        )
+
+
 def init_camera(
     c: Camera,
     jumbo_packet: bool = True,
@@ -798,6 +854,10 @@ class FlirRecorder:
         self._diagnostics_fired: set[tuple[str, str]] = set()
         self._diagnostics_fired_lock = threading.Lock()
 
+        # PySpin requires us to hold refs to event handlers — without these
+        # the handler gets GC'd and the callbacks silently stop firing.
+        self._event_handlers: list = []
+
         self.set_status("Uninitialized")
 
         self.pixel_format_conversion = {
@@ -892,6 +952,35 @@ class FlirRecorder:
             # The callback is best-effort: it must not break acquisition.
             print(f"[diagnostics_callback] {camera_serial}/{code} raised: {e}")
 
+    def _register_interface_events(self) -> None:
+        """Subscribe to PySpin device arrival/removal on the active interface."""
+        if self.iface is None:
+            return
+        try:
+            interface_id = (
+                self.iface.TLInterface.InterfaceID.GetValue()
+                if PySpin.IsReadable(self.iface.TLInterface.InterfaceID)
+                else "unknown"
+            )
+        except Exception:  # noqa: BLE001
+            interface_id = "unknown"
+        handler = _RecorderInterfaceEventHandler(self, interface_id)
+        try:
+            self.iface.RegisterEventHandler(handler)
+        except Exception as e:  # noqa: BLE001
+            print(f"[event_handler] failed to register on {interface_id}: {e}")
+            return
+        self._event_handlers.append((self.iface, handler))
+
+    def _unregister_interface_events(self) -> None:
+        """Detach all registered handlers. Called from close()."""
+        for iface, handler in self._event_handlers:
+            try:
+                iface.UnregisterEventHandler(handler)
+            except Exception as e:  # noqa: BLE001
+                print(f"[event_handler] failed to unregister: {e}")
+        self._event_handlers = []
+
     def check_queue_sizes(self, queue_dict):
         for name, q in queue_dict.items():
             print(name, q.qsize())
@@ -977,6 +1066,11 @@ class FlirRecorder:
         self.iface_cameras = selected_cams
 
         self.trigger = trigger
+
+        # Subscribe to device arrival/removal events on this interface so a
+        # cable unplug gets surfaced immediately via session_insight, instead
+        # of waiting for the acquire_frames loop to start producing -1002.
+        self._register_interface_events()
 
         self.iface.TLInterface.GevActionDeviceKey.SetValue(0)
         self.iface.TLInterface.GevActionGroupKey.SetValue(1)
@@ -2199,6 +2293,8 @@ class FlirRecorder:
 
     def close(self):
         """Close all the cameras and release the system"""
+
+        self._unregister_interface_events()
 
         if len(self.cams) > 0:
 

--- a/multi_camera/acquisition/flir_recording_api.py
+++ b/multi_camera/acquisition/flir_recording_api.py
@@ -931,6 +931,11 @@ class FlirRecorder:
         # camera_config_hash on subsequent trials.
         self._config_hash_salt: str = ""
 
+        # Populated by configure_cameras when a YAML is selected. Default
+        # None so accessors (bump_config_hash, etc.) can detect the
+        # "no config loaded yet" state without an AttributeError.
+        self.camera_config = None
+
         self.set_status("Uninitialized")
 
         self.pixel_format_conversion = {

--- a/multi_camera/acquisition/flir_recording_api.py
+++ b/multi_camera/acquisition/flir_recording_api.py
@@ -237,9 +237,8 @@ def classify_spinnaker_error(err) -> dict | None:
     render. Returns ``None`` for unrecognized errors so the caller can fall
     back to a generic message.
 
-    Mapping comes from operator-observed failure modes
-    (MultiCameraTracking-0dg). The remediation steps reference the
-    existing in-GUI buttons rather than raw Linux commands.
+    The remediation steps reference in-GUI buttons rather than raw
+    Linux commands.
     """
     text = str(err)
     lower = text.lower()
@@ -265,7 +264,7 @@ def classify_spinnaker_error(err) -> dict | None:
                 "If the issue persists, click Restart acquisition.",
             ],
         }
-    if "wrong subnet" in lower or "incompatible" in lower:
+    if "wrong subnet" in lower or "incompatible device" in lower:
         return {
             "code": "camera_wrong_subnet",
             "level": "error",

--- a/multi_camera/acquisition/flir_recording_api.py
+++ b/multi_camera/acquisition/flir_recording_api.py
@@ -1051,31 +1051,6 @@ class FlirRecorder:
                 print(f"[event_handler] failed to unregister: {e}")
         self._event_handlers = []
 
-    def _drop_dead_handles(self, cams: list) -> list:
-        """Return ``cams`` minus any handles that no longer respond to a
-        basic read. Probes ``DeviceSerialNumber`` because it's available on
-        un-Init'd cameras and is the cheapest reachability check the SDK
-        supports. Fires a ``camera_handle_invalid`` envelope per dropped
-        camera.
-        """
-        alive = []
-        for c in cams:
-            try:
-                serial = c.DeviceSerialNumber
-            except Exception as e:  # noqa: BLE001
-                self._fire_diagnostic_once(
-                    camera_serial="?",
-                    code="camera_handle_invalid",
-                    level="warn",
-                    message=(
-                        "A camera handle was invalid before init "
-                        f"(skipping it for this session): {e}"
-                    ),
-                )
-                continue
-            alive.append(c)
-        return alive
-
     def check_queue_sizes(self, queue_dict):
         for name, q in queue_dict.items():
             print(name, q.qsize())
@@ -1219,19 +1194,6 @@ class FlirRecorder:
             "chunk_data": self.chunk_data,
             "camera_info": self.camera_info,
         }
-
-        # Probe each handle for liveness before submitting to init_camera.
-        # A handle for a camera that was unplugged before configure_cameras
-        # ran will raise AccessException on the first node write inside
-        # init_camera (e.g. LineMode = "Output"), which leaves the system
-        # in a half-state. Drop dead handles up-front and fire a structured
-        # finding so the operator knows which camera went missing.
-        self.cams = self._drop_dead_handles(self.cams)
-        if not self.cams:
-            raise RuntimeError(
-                "No usable camera handles after pre-Init validation; "
-                "all configured cameras appear unreachable."
-            )
 
         with concurrent.futures.ThreadPoolExecutor(
             max_workers=len(self.cams)

--- a/multi_camera/acquisition/flir_recording_api.py
+++ b/multi_camera/acquisition/flir_recording_api.py
@@ -1564,6 +1564,14 @@ class FlirRecorder:
         config_metadata["frame_skip_events"] = self._frame_skip_events
         config_metadata["ptp_jump_events"] = self._ptp_jump_events
 
+        # Surface the hash this trial will land under so the operator can
+        # verify rig-recalibrate behavior without opening the JSON sidecar.
+        salt_state = "set" if self._config_hash_salt else "empty"
+        print(
+            f"[config_hash] trial recording under camera_config_hash="
+            f"{config_metadata.get('camera_config_hash', '?')} (salt={salt_state})"
+        )
+
         # Set max_frames = self.video_segment_len. self.video_segment_len is either set to max_frames or
         # a value from the config file.
         max_frames = self.video_segment_len

--- a/multi_camera/acquisition/flir_recording_api.py
+++ b/multi_camera/acquisition/flir_recording_api.py
@@ -1809,9 +1809,13 @@ class FlirRecorder:
                         f"{camera_serial}: Failed to get image — {err_text}",
                     )
                     if "-1002" in err_text or "no longer valid" in err_text:
-                        # Disconnect during grab — surface to the operator.
-                        # The arrival/removal event handler usually beats us
-                        # here, but we keep this path as defense-in-depth.
+                        # Disconnect during grab — surface to the operator
+                        # and bail out of this worker. Without the break
+                        # the loop would spam -1002 every few ms for the
+                        # rest of the trial (observed: x244 in a single
+                        # ~5s window during PR 4 testing). Putting None
+                        # in the acquisition_queue lets the corresponding
+                        # writer thread drain and exit cleanly.
                         self._fire_diagnostic_once(
                             camera_serial=camera_serial,
                             code="camera_disconnected",
@@ -1822,6 +1826,8 @@ class FlirRecorder:
                             ),
                             details={"spinnaker_error": err_text},
                         )
+                        self.acquisition_queue[camera_serial].put(None)
+                        break
                     elif "-1012" in err_text or "aborted" in err_text:
                         self._fire_diagnostic_once(
                             camera_serial=camera_serial,
@@ -1833,6 +1839,8 @@ class FlirRecorder:
                             ),
                             details={"spinnaker_error": err_text},
                         )
+                        self.acquisition_queue[camera_serial].put(None)
+                        break
                     else:
                         classified = classify_spinnaker_error(err_text)
                         if classified is not None:

--- a/multi_camera/acquisition/flir_recording_api.py
+++ b/multi_camera/acquisition/flir_recording_api.py
@@ -1137,10 +1137,13 @@ class FlirRecorder:
 
         self.trigger = trigger
 
-        # Subscribe to device arrival/removal events on this interface so a
-        # cable unplug gets surfaced immediately via session_insight, instead
-        # of waiting for the acquire_frames loop to start producing -1002.
-        self._register_interface_events()
+        # NOTE: PySpin InterfaceEventHandler registration was disabled in
+        # PR 4 testing — registering a handler appears to leak a C++ ref to
+        # the interface that survives UnregisterEventHandler, causing
+        # `terminate called ... [-1004] Can't clear interface` on
+        # subsequent reset_cameras. Camera-disconnect detection now relies
+        # on acquire_frames' -1002/-1012 catch path. Tracked in a bead.
+        # self._register_interface_events()
 
         self.iface.TLInterface.GevActionDeviceKey.SetValue(0)
         self.iface.TLInterface.GevActionGroupKey.SetValue(1)
@@ -1458,6 +1461,36 @@ class FlirRecorder:
         self.set_status("Recording")
         with self._diagnostics_fired_lock:
             self._diagnostics_fired.clear()
+
+        # Drop any camera handles that went dead between configure_cameras
+        # and now (e.g. operator unplugged a camera while the system was
+        # idle). Cameras are Init'd at this point, so DeviceSerialNumber
+        # is readable on live ones and raises CameraError on dead ones.
+        # Without this filter, the image_queue_dict comprehension below
+        # crashes start_acquisition with no clean recovery.
+        live_cams = []
+        for c in self.cams:
+            try:
+                serial = c.DeviceSerialNumber
+            except Exception as e:  # noqa: BLE001
+                self._fire_diagnostic_once(
+                    camera_serial="?",
+                    code="camera_handle_invalid",
+                    level="warn",
+                    message=(
+                        f"A camera handle was dead at start of trial "
+                        f"(skipping it): {e}. Click Restart acquisition "
+                        "to bring it back in."
+                    ),
+                )
+                continue
+            live_cams.append(c)
+        if not live_cams:
+            raise RuntimeError(
+                "No live camera handles at start of trial — every "
+                "configured camera appears disconnected."
+            )
+        self.cams = live_cams
         self._diagnostics_level = diagnostics_level
         self._timespread_alert_threshold_ms = timespread_alert_threshold_ms
         self._sync_timeout_s = sync_timeout_s
@@ -2415,15 +2448,33 @@ class FlirRecorder:
         if len(self.cams) > 0:
 
             def close_cam(c):
-                print("Closing camera", c.DeviceSerialNumber)
-                c.cam.DeInit()
-                c.close()
+                # Every read off c can raise CameraError if the camera was
+                # unplugged. Guard each step independently so one dead
+                # handle doesn't prevent the rest of the cameras (and the
+                # system release) from being cleaned up.
+                serial = "?"
+                try:
+                    serial = c.DeviceSerialNumber
+                except Exception:  # noqa: BLE001
+                    pass
+                print("Closing camera", serial)
+                try:
+                    c.cam.DeInit()
+                except Exception as e:  # noqa: BLE001
+                    print(f"DeInit on {serial} raised (continuing): {e}")
+                try:
+                    c.close()
+                except Exception as e:  # noqa: BLE001
+                    print(f"close on {serial} raised (continuing): {e}")
                 del c
 
+            # Use list() to force materialization of all futures, so any
+            # exception that DID slip past the inner guards is collected
+            # rather than swallowed by the executor's iterator.
             with concurrent.futures.ThreadPoolExecutor(
                 max_workers=len(self.cams)
             ) as executor:
-                executor.map(close_cam, self.cams)
+                list(executor.map(close_cam, self.cams))
 
         self.cams = []
 

--- a/multi_camera/acquisition/flir_recording_api.py
+++ b/multi_camera/acquisition/flir_recording_api.py
@@ -926,6 +926,11 @@ class FlirRecorder:
         # the handler gets GC'd and the callbacks silently stop firing.
         self._event_handlers: list = []
 
+        # Salt mixed into get_config_hash. Empty until the operator clicks
+        # 'Camera moved' mid-session; setting it forces a fresh
+        # camera_config_hash on subsequent trials.
+        self._config_hash_salt: str = ""
+
         self.set_status("Uninitialized")
 
         self.pixel_format_conversion = {
@@ -935,12 +940,35 @@ class FlirRecorder:
         }
 
     def get_config_hash(self, yaml_content, hash_len=10):
-        # Sorting keys to ensure consistent hashing
+        # Sorting keys to ensure consistent hashing. ``self._config_hash_salt``
+        # is mutated by bump_config_hash() when the operator clicks 'Camera
+        # moved' — that produces a fresh hash without re-loading the YAML,
+        # so DataJoint treats subsequent trials as a new calibration setup.
         file_str = json.dumps(yaml_content, sort_keys=True)
+        if self._config_hash_salt:
+            file_str = f"{file_str}\nsalt={self._config_hash_salt}"
         encoded_config = file_str.encode("utf-8")
 
         # Create hash of encoded config file and return
         return hashlib.sha256(encoded_config).hexdigest()[:hash_len]
+
+    def bump_config_hash(self, reason: str | None = None) -> str:
+        """Rotate ``self._config_hash_salt`` so the next ``get_config_hash``
+        returns a different value. Used when the operator reports a camera
+        was physically bumped or the rig was moved mid-session — future
+        trials need to record under a fresh ``camera_config_hash`` so
+        DataJoint creates a separate calibration entry. Returns the new
+        effective hash for confirmation.
+        """
+        import secrets
+        self._config_hash_salt = secrets.token_hex(8)
+        new_hash = (
+            self.get_config_hash(self.camera_config) if self.camera_config else "?"
+        )
+        print(
+            f"[config_hash] bumped salt (reason={reason!r}); new hash={new_hash}"
+        )
+        return new_hash
 
     def get_detailed_processor_info(self):
         cpu_info = ""

--- a/multi_camera/acquisition/flir_recording_api.py
+++ b/multi_camera/acquisition/flir_recording_api.py
@@ -231,6 +231,74 @@ def _force_one_camera_ip(
     return False
 
 
+def classify_spinnaker_error(err) -> dict | None:
+    """Translate a Spinnaker/PySpin exception (or its string repr) into a
+    structured envelope ``{code, level, message, remediation}`` the GUI can
+    render. Returns ``None`` for unrecognized errors so the caller can fall
+    back to a generic message.
+
+    Mapping comes from operator-observed failure modes
+    (MultiCameraTracking-0dg). The remediation steps reference the
+    existing in-GUI buttons rather than raw Linux commands.
+    """
+    text = str(err)
+    lower = text.lower()
+
+    if "gevieee1588datasetlatch" in lower:
+        return {
+            "code": "ptp_node_not_writable",
+            "level": "error",
+            "message": "PTP/IEEE1588 sync node is not writable on a camera.",
+            "remediation": [
+                "This typically happens if a camera was unplugged after init.",
+                "Click 'Reset Cameras' on the main page.",
+                "If the issue persists, unplug and re-plug the affected camera, then click Restart acquisition.",
+            ],
+        }
+    if "linemode" in lower and "not writable" in lower:
+        return {
+            "code": "gpio_linemode_rejected",
+            "level": "error",
+            "message": "Camera rejected the GPIO line-mode configuration.",
+            "remediation": [
+                "Click 'Reset Cameras' on the main page.",
+                "If the issue persists, click Restart acquisition.",
+            ],
+        }
+    if "wrong subnet" in lower or "incompatible" in lower:
+        return {
+            "code": "camera_wrong_subnet",
+            "level": "error",
+            "message": "A camera is on the wrong subnet.",
+            "remediation": [
+                "Click 'Force IP' on the camera row in Diagnostics.",
+                "If the camera doesn't appear in Diagnostics, run `make reset`.",
+            ],
+        }
+    if "deviceserialnumber" in lower and "not readable" in lower:
+        return {
+            "code": "camera_handle_invalid",
+            "level": "error",
+            "message": "A camera handle stopped responding to basic reads.",
+            "remediation": [
+                "Click 'Restart acquisition' on the Diagnostics tab.",
+                "If the issue persists, click 'Reset Cameras' on the main page.",
+            ],
+        }
+    if "nonetype" in lower and "getinterfaces" in lower:
+        return {
+            "code": "pyspin_system_uninitialized",
+            "level": "error",
+            "message": "The Spinnaker system handle is uninitialized.",
+            "remediation": [
+                "Click 'Restart acquisition' on the Diagnostics tab.",
+                "If the issue persists, restart the acquisition application (`make run`).",
+                "If still failing after that, reboot the acquisition laptop.",
+            ],
+        }
+    return None
+
+
 class _RecorderInterfaceEventHandler(PySpin.InterfaceEventHandler):
     """Fires diagnostic envelopes when a camera arrives or is removed from
     the GigE interface the recorder is using.
@@ -925,6 +993,7 @@ class FlirRecorder:
         level: str,
         message: str,
         details: dict | None = None,
+        remediation: list[str] | None = None,
     ) -> None:
         """Fire ``diagnostics_callback`` exactly once per (camera, code) per
         session, then suppress subsequent calls. The acquisition workers
@@ -939,15 +1008,16 @@ class FlirRecorder:
             if key in self._diagnostics_fired:
                 return
             self._diagnostics_fired.add(key)
+        envelope = {
+            "level": level,
+            "code": code,
+            "message": message,
+            "details": {"serial": camera_serial, **(details or {})},
+        }
+        if remediation:
+            envelope["remediation"] = remediation
         try:
-            self.diagnostics_callback(
-                {
-                    "level": level,
-                    "code": code,
-                    "message": message,
-                    "details": {"serial": camera_serial, **(details or {})},
-                }
-            )
+            self.diagnostics_callback(envelope)
         except Exception as e:  # noqa: BLE001
             # The callback is best-effort: it must not break acquisition.
             print(f"[diagnostics_callback] {camera_serial}/{code} raised: {e}")
@@ -1166,7 +1236,24 @@ class FlirRecorder:
         with concurrent.futures.ThreadPoolExecutor(
             max_workers=len(self.cams)
         ) as executor:
-            list(executor.map(lambda c: init_camera(c, **config_params), self.cams))
+            try:
+                list(executor.map(lambda c: init_camera(c, **config_params), self.cams))
+            except Exception as init_err:
+                # Classify before re-raising so the GUI sees the right
+                # remediation steps. Backend's _reset_and_configure
+                # catches the re-raised exception and broadcasts a
+                # generic reconfigure_failed envelope as a fallback.
+                classified = classify_spinnaker_error(init_err)
+                if classified is not None:
+                    self._fire_diagnostic_once(
+                        camera_serial="?",
+                        code=classified["code"],
+                        level=classified["level"],
+                        message=classified["message"],
+                        remediation=classified["remediation"],
+                        details={"spinnaker_error": str(init_err)},
+                    )
+                raise
 
         await self.synchronize_cameras()
 
@@ -1727,6 +1814,9 @@ class FlirRecorder:
                         f"{camera_serial}: Failed to get image — {err_text}",
                     )
                     if "-1002" in err_text or "no longer valid" in err_text:
+                        # Disconnect during grab — surface to the operator.
+                        # The arrival/removal event handler usually beats us
+                        # here, but we keep this path as defense-in-depth.
                         self._fire_diagnostic_once(
                             camera_serial=camera_serial,
                             code="camera_disconnected",
@@ -1749,15 +1839,26 @@ class FlirRecorder:
                             details={"spinnaker_error": err_text},
                         )
                     else:
-                        self._fire_diagnostic_once(
-                            camera_serial=camera_serial,
-                            code="camera_grab_error",
-                            level="warn",
-                            message=(
-                                f"Camera {camera_serial} failed to deliver a frame: {err_text}"
-                            ),
-                            details={"spinnaker_error": err_text},
-                        )
+                        classified = classify_spinnaker_error(err_text)
+                        if classified is not None:
+                            self._fire_diagnostic_once(
+                                camera_serial=camera_serial,
+                                code=classified["code"],
+                                level=classified["level"],
+                                message=classified["message"],
+                                remediation=classified["remediation"],
+                                details={"spinnaker_error": err_text},
+                            )
+                        else:
+                            self._fire_diagnostic_once(
+                                camera_serial=camera_serial,
+                                code="camera_grab_error",
+                                level="warn",
+                                message=(
+                                    f"Camera {camera_serial} failed to deliver a frame: {err_text}"
+                                ),
+                                details={"spinnaker_error": err_text},
+                            )
                     time.sleep(0.1)
                     continue
 

--- a/multi_camera/acquisition/flir_recording_api.py
+++ b/multi_camera/acquisition/flir_recording_api.py
@@ -981,6 +981,31 @@ class FlirRecorder:
                 print(f"[event_handler] failed to unregister: {e}")
         self._event_handlers = []
 
+    def _drop_dead_handles(self, cams: list) -> list:
+        """Return ``cams`` minus any handles that no longer respond to a
+        basic read. Probes ``DeviceSerialNumber`` because it's available on
+        un-Init'd cameras and is the cheapest reachability check the SDK
+        supports. Fires a ``camera_handle_invalid`` envelope per dropped
+        camera.
+        """
+        alive = []
+        for c in cams:
+            try:
+                serial = c.DeviceSerialNumber
+            except Exception as e:  # noqa: BLE001
+                self._fire_diagnostic_once(
+                    camera_serial="?",
+                    code="camera_handle_invalid",
+                    level="warn",
+                    message=(
+                        "A camera handle was invalid before init "
+                        f"(skipping it for this session): {e}"
+                    ),
+                )
+                continue
+            alive.append(c)
+        return alive
+
     def check_queue_sizes(self, queue_dict):
         for name, q in queue_dict.items():
             print(name, q.qsize())
@@ -1125,6 +1150,19 @@ class FlirRecorder:
             "camera_info": self.camera_info,
         }
 
+        # Probe each handle for liveness before submitting to init_camera.
+        # A handle for a camera that was unplugged before configure_cameras
+        # ran will raise AccessException on the first node write inside
+        # init_camera (e.g. LineMode = "Output"), which leaves the system
+        # in a half-state. Drop dead handles up-front and fire a structured
+        # finding so the operator knows which camera went missing.
+        self.cams = self._drop_dead_handles(self.cams)
+        if not self.cams:
+            raise RuntimeError(
+                "No usable camera handles after pre-Init validation; "
+                "all configured cameras appear unreachable."
+            )
+
         with concurrent.futures.ThreadPoolExecutor(
             max_workers=len(self.cams)
         ) as executor:
@@ -1146,31 +1184,46 @@ class FlirRecorder:
         self.set_status("Idle")
 
     async def get_camera_status(self) -> List[CameraStatus]:
-        status = [
-            CameraStatus(
-                SerialNumber=c.DeviceSerialNumber,
-                Status="Initialized",
-                # PixelSize=c.PixelSize,
-                PixelFormat=c.PixelFormat,
-                BinningHorizontal=c.BinningHorizontal,
-                BinningVertical=c.BinningVertical,
-                Width=c.Width,
-                Height=c.Height,
-            )
-            for c in self.cams
-        ]
+        # Per-camera try/except so one dead handle (e.g. wrong-subnet camera
+        # whose DeviceSerialNumber isn't readable) doesn't crash the entire
+        # status endpoint with a 500. The arrival/removal event handler
+        # should normally have already dropped the camera; this is the
+        # defense-in-depth path for cases the handler can't observe.
+        status: List[CameraStatus] = []
+        for c in self.cams:
+            try:
+                cs = CameraStatus(
+                    SerialNumber=c.DeviceSerialNumber,
+                    Status="Initialized",
+                    PixelFormat=c.PixelFormat,
+                    BinningHorizontal=c.BinningHorizontal,
+                    BinningVertical=c.BinningVertical,
+                    Width=c.Width,
+                    Height=c.Height,
+                )
+            except Exception as e:  # noqa: BLE001
+                self._fire_diagnostic_once(
+                    camera_serial="?",
+                    code="camera_status_unreadable",
+                    level="warn",
+                    message=(
+                        "A camera handle did not respond to a basic status "
+                        f"read: {e}. Try Restart acquisition."
+                    ),
+                )
+                continue
+            status.append(cs)
 
         for c in self.cams:
-            c.GevIEEE1588DataSetLatch()
-            # print(
-            #    "Primary" if c.GevIEEE1588StatusLatched == "Master" else "Secondary",
-            #    c.GevIEEE1588OffsetFromMasterLatched,
-            # )
-
-            # set the corresponding camera status
+            try:
+                c.GevIEEE1588DataSetLatch()
+                offset = c.GevIEEE1588OffsetFromMasterLatched
+                serial = c.DeviceSerialNumber
+            except Exception:  # noqa: BLE001
+                continue
             for cs in status:
-                if cs.SerialNumber == c.DeviceSerialNumber:
-                    cs.SyncOffset = c.GevIEEE1588OffsetFromMasterLatched
+                if cs.SerialNumber == serial:
+                    cs.SyncOffset = offset
 
         status.sort(key=lambda x: x.SerialNumber)
 

--- a/multi_camera/acquisition/flir_recording_api.py
+++ b/multi_camera/acquisition/flir_recording_api.py
@@ -1,6 +1,6 @@
 import PySpin
 import simple_pyspin
-from simple_pyspin import Camera
+from simple_pyspin import Camera, CameraError
 import numpy as np
 from tqdm import tqdm
 import datetime
@@ -1442,37 +1442,49 @@ class FlirRecorder:
         return serial_msg, frame_count
 
     def _read_ptp_offsets(self) -> dict[str, int]:
-        """Read GevIEEE1588OffsetFromMasterLatched for each camera."""
+        """Read GevIEEE1588OffsetFromMasterLatched for each camera. Skips
+        cameras whose handle has been invalidated mid-session rather than
+        aborting the whole read.
+        """
         offsets: dict[str, int] = {}
         for c in self.cams:
-            serial = c.DeviceSerialNumber
             try:
+                serial = c.DeviceSerialNumber
                 c.GevIEEE1588DataSetLatch()
                 offsets[serial] = c.GevIEEE1588OffsetFromMasterLatched
-            except (AttributeError, PySpin.SpinnakerException):
+            except (AttributeError, PySpin.SpinnakerException, CameraError):
                 pass
         return offsets
 
     def _read_camera_temperatures(self) -> dict[str, float]:
-        """Read DeviceTemperature for each camera."""
+        """Read DeviceTemperature for each camera. Skips cameras whose
+        handle has been invalidated mid-session (e.g. cable unplug)
+        rather than aborting the whole read.
+        """
         temps: dict[str, float] = {}
         for c in self.cams:
-            serial = c.DeviceSerialNumber
             try:
+                serial = c.DeviceSerialNumber
                 temps[serial] = float(c.DeviceTemperature)
-            except (AttributeError, PySpin.SpinnakerException):
+            except (AttributeError, PySpin.SpinnakerException, CameraError):
                 pass
         return temps
 
     def _read_camera_stats(self) -> dict[str, dict[str, int]]:
+        """Read per-camera stream stats. Skips cameras whose handle has
+        been invalidated mid-session rather than aborting the whole read.
+        """
         stats: dict[str, dict[str, int]] = {}
         for c in self.cams:
-            serial = c.DeviceSerialNumber
+            try:
+                serial = c.DeviceSerialNumber
+            except (AttributeError, PySpin.SpinnakerException, CameraError):
+                continue
             cam_stats: dict[str, int] = {}
             for attr in ["StreamDroppedFrameCount", "TransferQueueOverflowCount"]:
                 try:
                     cam_stats[attr] = getattr(c, attr)
-                except (AttributeError, PySpin.SpinnakerException):
+                except (AttributeError, PySpin.SpinnakerException, CameraError):
                     pass
             stats[serial] = cam_stats
         return stats

--- a/multi_camera/backend/fastapi.py
+++ b/multi_camera/backend/fastapi.py
@@ -877,6 +877,21 @@ async def get_status() -> Dict:
 
 @api_router.post("/new_trial")
 async def new_trial(data: NewTrialData, db: Session = Depends(db_dependency)):
+    state: GlobalState = get_global_state()
+    if state.recording_status in _BUSY_PYSPIN_STATES:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"Cannot start a trial while the system is busy "
+                f"(state: {state.recording_status})."
+            ),
+        )
+    if not getattr(state.acquisition, "cams", None):
+        raise HTTPException(
+            status_code=409,
+            detail="No cameras configured — select a config before starting a trial.",
+        )
+
     recording_dir = data.recording_dir
     recording_filename = data.recording_filename
     comment = data.comment
@@ -990,12 +1005,26 @@ async def new_trial(data: NewTrialData, db: Session = Depends(db_dependency)):
 
 @api_router.post("/preview")
 async def preview(data: PreviewData):
+    state: GlobalState = get_global_state()
+    if state.recording_status in _BUSY_PYSPIN_STATES:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"Cannot start a trial while the system is busy "
+                f"(state: {state.recording_status})."
+            ),
+        )
+    if not getattr(state.acquisition, "cams", None):
+        raise HTTPException(
+            status_code=409,
+            detail="No cameras configured — select a config before previewing.",
+        )
+
     max_frames = data.max_frames
 
     def receive_frames_wrapper(frames):
         loop.create_task(receive_frames(frames))
 
-    state: GlobalState = get_global_state()
     state.selected_camera = None
     await run_in_threadpool(
         state.acquisition.start_acquisition,

--- a/multi_camera/backend/fastapi.py
+++ b/multi_camera/backend/fastapi.py
@@ -1275,16 +1275,21 @@ async def get_current_config() -> str:
     return os.path.split(config)[-1]
 
 
-# States during which PySpin is in flight — either holding camera handles
-# or actively writing camera registers (LineMode, DeviceLinkThroughputLimit,
-# BeginAcquisition, …). Used by HealthIdlePoller to skip its GigE
-# enumeration (which would race those writes → GenICam::AccessException),
-# and by recovery endpoints (restart / restore / exclude) that must 409
-# instead of racing the in-flight operation. "Starting" closes the gap
-# between new_trial returning 200 and start_acquisition flipping to
-# "Recording" on its worker thread.
+# States during which the recorder is holding camera handles, writing
+# camera registers, or waiting for cameras to come back online after a
+# hardware reset. The health poller skips its GigE enumeration in these
+# states, and the recovery endpoints return 409 instead of starting an
+# operation that would collide with whatever is already running.
 _BUSY_PYSPIN_STATES = frozenset(
-    {"Configuring", "Synchronizing", "Synchronized", "Starting", "Recording"}
+    {
+        "Configuring",
+        "Synchronizing",
+        "Synchronized",
+        "Starting",
+        "Recording",
+        "Resetting",
+        "Reset complete. Waiting to reconfigure.",
+    }
 )
 
 

--- a/multi_camera/backend/fastapi.py
+++ b/multi_camera/backend/fastapi.py
@@ -488,7 +488,12 @@ async def lifespan(app: FastAPI):
         on_poll=_on_idle_health_poll,
         logger=acquisition_logger,
     )
-    state._health_poller.start()
+    # Deliberately NOT started here: before a config is loaded, the poller's
+    # PySpin GigE enumeration produces no useful signal (nothing to compare
+    # against), and even with skip_camera_enumeration the thread sits idle
+    # racing the GUI's mount-time fetches. update_config starts it after
+    # the first successful configure_cameras; start() is idempotent so
+    # subsequent configures are no-ops on the poller.
 
     db = get_db()
 
@@ -1359,6 +1364,12 @@ async def update_config(config: ConfigFileData):
         await state.acquisition.configure_cameras(
             os.path.join(CONFIG_PATH, config.config)
         )
+        # Start the idle health poller on first successful configure.
+        # Lifespan only constructs it; selecting a config is the operator
+        # action that gives PySpin enumeration something useful to do.
+        # start() is idempotent so re-selects are no-ops.
+        if state._health_poller is not None:
+            state._health_poller.start()
     await _refresh_health_after_configure()
     return {"status": "success", "config": config.config}
 

--- a/multi_camera/backend/fastapi.py
+++ b/multi_camera/backend/fastapi.py
@@ -488,12 +488,9 @@ async def lifespan(app: FastAPI):
         on_poll=_on_idle_health_poll,
         logger=acquisition_logger,
     )
-    # Deliberately NOT started here: before a config is loaded, the poller's
-    # PySpin GigE enumeration produces no useful signal (nothing to compare
-    # against), and even with skip_camera_enumeration the thread sits idle
-    # racing the GUI's mount-time fetches. update_config starts it after
-    # the first successful configure_cameras; start() is idempotent so
-    # subsequent configures are no-ops on the poller.
+    # Constructed here, started by update_config after the first successful
+    # configure_cameras. start() is idempotent so subsequent configures
+    # are no-ops on the poller.
 
     db = get_db()
 
@@ -622,11 +619,8 @@ async def _get_health_report(force_refresh: bool = False) -> HealthCheckReport:
 
         expected = _expected_serials(state.acquisition)
         recording_state = state.recording_status or "Idle"
-        # PySpin GigE enumeration (used for both regular discovery and
-        # wrong-subnet detection) is the slow leg — multiple seconds in
-        # network mode. Skip it when there's no config loaded: nothing to
-        # compare detected cameras against, and the operator already sees
-        # 'select a config' guidance from cameras_not_configured.
+        # Skip the slow PySpin enum when busy (see _BUSY_PYSPIN_STATES)
+        # or when there's nothing to enumerate against.
         skip_enum = (
             _should_skip_camera_enumeration(recording_state)
             or _no_cameras_to_enumerate(state.acquisition)
@@ -1135,12 +1129,9 @@ async def validate_sync():
 @api_router.get("/prior_recordings", response_model=List[PriorRecordings])
 async def get_prior_recordings(db=Depends(db_dependency)) -> List[PriorRecordings]:
     state = get_global_state()
-    # Without a participant, get_recordings walks every participant ×
-    # every session × every recording in the DB, plus an N+1 Imported
-    # lookup per session — multi-second on a populated lab database.
-    # Skip the walk: the operator has no meaningful use for "every
-    # recording ever" before they've picked a participant, and the
-    # table shows nothing useful in that state anyway.
+    # No participant means get_recordings would walk the full DB plus
+    # N+1 per session — skip the walk since the table has nothing
+    # meaningful to show without a participant filter anyway.
     if state.current_session is None:
         return []
     participant_name = state.current_session.participant_name

--- a/multi_camera/backend/fastapi.py
+++ b/multi_camera/backend/fastapi.py
@@ -1135,10 +1135,15 @@ async def validate_sync():
 @api_router.get("/prior_recordings", response_model=List[PriorRecordings])
 async def get_prior_recordings(db=Depends(db_dependency)) -> List[PriorRecordings]:
     state = get_global_state()
+    # Without a participant, get_recordings walks every participant ×
+    # every session × every recording in the DB, plus an N+1 Imported
+    # lookup per session — multi-second on a populated lab database.
+    # Skip the walk: the operator has no meaningful use for "every
+    # recording ever" before they've picked a participant, and the
+    # table shows nothing useful in that state anyway.
     if state.current_session is None:
-        participant_name = None
-    else:
-        participant_name = state.current_session.participant_name
+        return []
+    participant_name = state.current_session.participant_name
     prior_recordings = []
     db_recordings: ParticipantOut = get_recordings(
         db, participant_name=participant_name

--- a/multi_camera/backend/fastapi.py
+++ b/multi_camera/backend/fastapi.py
@@ -982,11 +982,17 @@ async def new_trial(data: NewTrialData, db: Session = Depends(db_dependency)):
             import traceback
 
             acquisition_logger.error(f"Trial failed: {e}", exc_info=True)
-            # If start_acquisition raised before its set_status("Recording")
-            # ran, status is still "Starting" — clear it so recovery
-            # endpoints aren't blocked.
-            if state.recording_status == "Starting":
-                state.recording_status = "Idle"
+            # The trial died (could be before or after set_status("Recording")
+            # ran on the worker). Reset to Idle unconditionally — leaving
+            # status at "Starting" or "Recording" would lock the operator
+            # out of the recovery endpoints (Restart acquisition, Restore
+            # defaults, Force IP, etc.) since they 409 in busy states.
+            # set_status pushes to the frontend WS so buttons re-enable.
+            if (
+                state.recording_status in _BUSY_PYSPIN_STATES
+                and state.acquisition is not None
+            ):
+                state.acquisition.set_status("Idle")
             broadcast_event(
                 event_type="error",
                 level="error",
@@ -1404,6 +1410,35 @@ async def restore_camera_defaults(serial: str):
     )
 
     return {"status": "success", "serial": serial, "config": saved_config}
+
+
+@api_router.post("/rig/recalibrate")
+async def mark_rig_recalibrate():
+    """Operator bumped/moved at least one camera; subsequent trials in this
+    session need a fresh camera_config_hash so DataJoint creates a separate
+    calibration entry. Rig-level (not per-camera) because the calibration
+    is a joint estimate of all cameras' relative poses — moving one
+    invalidates the whole rig's extrinsics.
+
+    Rotates a salt inside FlirRecorder.get_config_hash — no reconfigure
+    needed (the cameras themselves are unchanged, just their physical
+    pose). Returns the new hash.
+    """
+    state: GlobalState = get_global_state()
+    new_hash = await run_in_threadpool(
+        state.acquisition.bump_config_hash, "rig recalibrate"
+    )
+    broadcast_event(
+        event_type="session_insight",
+        level="warn",
+        code="rig_recalibrate",
+        message=(
+            "Rig marked for recalibration. Future trials will record under "
+            f"a new camera_config_hash ({new_hash}) — capture a new "
+            "calibration recording before the next trial."
+        ),
+    )
+    return {"status": "success", "new_config_hash": new_hash}
 
 
 class ForceIpData(BaseModel):

--- a/multi_camera/backend/fastapi.py
+++ b/multi_camera/backend/fastapi.py
@@ -240,14 +240,21 @@ def _on_acquisition_diagnostic(envelope: dict) -> None:
 
     Called from acquisition worker threads when the recorder catches a
     Spinnaker error per camera. Forwards the envelope to the existing
-    diagnostics WS fan-out as a ``session_insight`` event.
+    diagnostics WS fan-out as a ``session_insight`` event. If the
+    recorder attached a ``remediation`` list (from
+    ``classify_spinnaker_error``), the steps are passed through in
+    ``details`` so the Diagnostics tab renders them as a numbered list.
     """
+    details = dict(envelope.get("details", {}))
+    remediation = envelope.get("remediation")
+    if remediation:
+        details["remediation"] = remediation
     broadcast_event(
         event_type="session_insight",
         level=envelope.get("level", "warn"),
         code=envelope.get("code", "acquisition_error"),
         message=envelope.get("message", ""),
-        details=envelope.get("details", {}),
+        details=details,
     )
 
 

--- a/multi_camera/backend/fastapi.py
+++ b/multi_camera/backend/fastapi.py
@@ -432,6 +432,20 @@ def _expected_serials(recorder: FlirRecorder | None) -> list[str]:
     return [str(s) for s in camera_info.keys()]
 
 
+def _no_cameras_to_enumerate(recorder: FlirRecorder | None) -> bool:
+    """True when neither the config nor the live recorder names any cameras.
+
+    Used to short-circuit the slow PySpin GigE enumeration: no expected
+    serials AND no held cams means there's nothing to compare detected
+    cameras against, so the GUI gets ``cameras_not_configured`` guidance
+    fast and the idle poller doesn't churn the GigE network in the
+    background.
+    """
+    return not _expected_serials(recorder) and not bool(
+        getattr(recorder, "cams", None)
+    )
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # Bind module-level loop to uvicorn's; worker-thread broadcasts dispatch onto it.
@@ -462,11 +476,13 @@ async def lifespan(app: FastAPI):
             expected_serials=_expected_serials(state.acquisition),
             recorder=state.acquisition,
             recording_state=state.recording_status or "Idle",
-            # See _BUSY_PYSPIN_STATES: skip enumeration whenever the recorder
-            # is holding handles or writing camera registers. DHCP and
-            # host-network checks still run.
-            skip_camera_enumeration=_should_skip_camera_enumeration(
-                state.recording_status
+            # Skip the slow PySpin GigE enumeration whenever the recorder
+            # is holding handles / writing registers (see _BUSY_PYSPIN_STATES)
+            # OR when there's no config loaded so nothing's worth enumerating
+            # against. DHCP and host-network arms always run.
+            skip_camera_enumeration=(
+                _should_skip_camera_enumeration(state.recording_status)
+                or _no_cameras_to_enumerate(state.acquisition)
             ),
         ),
         on_poll=_on_idle_health_poll,
@@ -606,10 +622,9 @@ async def _get_health_report(force_refresh: bool = False) -> HealthCheckReport:
         # network mode. Skip it when there's no config loaded: nothing to
         # compare detected cameras against, and the operator already sees
         # 'select a config' guidance from cameras_not_configured.
-        recorder_has_cams = bool(getattr(state.acquisition, "cams", None))
         skip_enum = (
             _should_skip_camera_enumeration(recording_state)
-            or (not expected and not recorder_has_cams)
+            or _no_cameras_to_enumerate(state.acquisition)
         )
         report = await run_in_threadpool(
             run_health_check,

--- a/multi_camera/backend/fastapi.py
+++ b/multi_camera/backend/fastapi.py
@@ -601,12 +601,23 @@ async def _get_health_report(force_refresh: bool = False) -> HealthCheckReport:
 
         expected = _expected_serials(state.acquisition)
         recording_state = state.recording_status or "Idle"
+        # PySpin GigE enumeration (used for both regular discovery and
+        # wrong-subnet detection) is the slow leg — multiple seconds in
+        # network mode. Skip it when there's no config loaded: nothing to
+        # compare detected cameras against, and the operator already sees
+        # 'select a config' guidance from cameras_not_configured.
+        recorder_has_cams = bool(getattr(state.acquisition, "cams", None))
+        skip_enum = (
+            _should_skip_camera_enumeration(recording_state)
+            or (not expected and not recorder_has_cams)
+        )
         report = await run_in_threadpool(
             run_health_check,
             config=state.health_config,
             expected_serials=expected,
             recorder=state.acquisition,
             recording_state=recording_state,
+            skip_camera_enumeration=skip_enum,
         )
         state._health_cache = report
         state._health_cache_ts = now_mono
@@ -1470,6 +1481,14 @@ async def mark_rig_recalibrate():
     pose). Returns the new hash.
     """
     state: GlobalState = get_global_state()
+    if not getattr(state.acquisition, "camera_config", None):
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "No camera config loaded — select a config before marking "
+                "the rig for recalibration."
+            ),
+        )
     new_hash = await run_in_threadpool(
         state.acquisition.bump_config_hash, "rig recalibrate"
     )

--- a/multi_camera/backend/fastapi.py
+++ b/multi_camera/backend/fastapi.py
@@ -100,6 +100,41 @@ class Session(BaseModel):
     recording_path: str
 
 
+# Sidecar file inside the session directory that persists the
+# config_hash_salt for the active session. Survives a mid-session
+# container restart (operator reopens the same participant + date and
+# the salt is restored); a brand-new session next day has no sidecar
+# and starts from the original un-bumped hash.
+_SESSION_SALT_FILENAME = ".config_hash_salt"
+
+
+def _session_salt_path(session: "Session | None") -> "Path | None":
+    if session is None or not session.recording_path:
+        return None
+    return Path(session.recording_path) / _SESSION_SALT_FILENAME
+
+
+def _persist_session_salt(session: "Session | None", salt: str) -> None:
+    path = _session_salt_path(session)
+    if path is None:
+        return
+    try:
+        path.write_text(salt)
+    except OSError as e:
+        acquisition_logger.warning(f"Could not write {path}: {e}")
+
+
+def _load_session_salt(session: "Session | None") -> str:
+    path = _session_salt_path(session)
+    if path is None or not path.exists():
+        return ""
+    try:
+        return path.read_text().strip()
+    except OSError as e:
+        acquisition_logger.warning(f"Could not read {path}: {e}")
+        return ""
+
+
 @dataclass
 class GlobalState:
     preview_queue: asyncio.Queue = field(default_factory=asyncio.Queue)
@@ -740,6 +775,16 @@ async def set_session(
     )
     state.last_session_insights = set()
     print("New session: ", state.current_session)
+
+    # Restore the rig-recalibrate salt if a sidecar exists in this
+    # session's directory — handles the mid-session restart case where
+    # the operator clicked 'Camera moved', then the container restarted,
+    # then they reopened the same participant + date.
+    saved_salt = _load_session_salt(state.current_session)
+    if state.acquisition is not None:
+        state.acquisition.set_salt(saved_salt)
+        if saved_salt:
+            print(f"Restored config_hash_salt from {_session_salt_path(state.current_session)}")
 
     if fin and fin.strip():
         from multi_camera.backend.recording_db import store_fin
@@ -1428,6 +1473,11 @@ async def mark_rig_recalibrate():
     new_hash = await run_in_threadpool(
         state.acquisition.bump_config_hash, "rig recalibrate"
     )
+    # Persist the salt scoped to the active session so a mid-session
+    # container restart preserves the bumped state. A new session next
+    # day gets its own sidecar (or none) and starts from the original
+    # un-salted hash.
+    _persist_session_salt(state.current_session, state.acquisition.get_salt())
     broadcast_event(
         event_type="session_insight",
         level="warn",

--- a/scripts/acquisition/check_env.sh
+++ b/scripts/acquisition/check_env.sh
@@ -77,6 +77,36 @@ set_env_value() {
     fi
 }
 
+# Echo a suggested DEPLOYMENT_MODE ("laptop" or "network") plus a one-line
+# rationale on stderr, based on signs that this host runs its own DHCP server
+# for the camera subnet. Empty echo on stdout means "no strong signal".
+suggest_deployment_mode() {
+    local rationale=""
+    local mode=""
+    if command -v nmcli >/dev/null 2>&1 && nmcli -t -f NAME con show 2>/dev/null | grep -qx "DHCP-Server"; then
+        mode="laptop"
+        rationale="NetworkManager profile 'DHCP-Server' is configured"
+    elif command -v dhcpd >/dev/null 2>&1 || dpkg -s isc-dhcp-server >/dev/null 2>&1; then
+        mode="laptop"
+        rationale="isc-dhcp-server is installed"
+    else
+        local iface
+        iface="$(get_env_value NETWORK_INTERFACE)"
+        if [ -n "$iface" ] && command -v ip >/dev/null 2>&1; then
+            local addrs
+            addrs="$(ip -4 -o addr show dev "$iface" 2>/dev/null | awk '{print $4}')"
+            if [ -n "$addrs" ] && ! echo "$addrs" | grep -q '^192\.168\.1\.'; then
+                mode="network"
+                rationale="$iface has $addrs (no 192.168.1.x address)"
+            fi
+        fi
+    fi
+    if [ -n "$mode" ]; then
+        echo "$mode"
+        [ -n "$rationale" ] && echo "  hint: detected $mode mode ($rationale)" >&2
+    fi
+}
+
 print_header "Validating .env against .env.template"
 
 if [ ! -f "$TEMPLATE_FILE" ]; then
@@ -111,9 +141,14 @@ while IFS= read -r -u 3 line; do
         echo "$var"
         desc=$(describe_var "$var")
         [ -n "$desc" ] && echo "  $desc"
-        if [ -n "$template_default" ]; then
-            read -r -p "  value [$template_default]: " value
-            value="${value:-$template_default}"
+        prompt_default="$template_default"
+        if [ "$var" = "DEPLOYMENT_MODE" ]; then
+            suggested="$(suggest_deployment_mode)"
+            [ -n "$suggested" ] && prompt_default="$suggested"
+        fi
+        if [ -n "$prompt_default" ]; then
+            read -r -p "  value [$prompt_default]: " value
+            value="${value:-$prompt_default}"
         else
             read -r -p "  value: " value
         fi

--- a/scripts/acquisition/start_acquisition.sh
+++ b/scripts/acquisition/start_acquisition.sh
@@ -421,9 +421,10 @@ start_acquisition() {
     print_success "Docker is ready"
     echo ""
 
-    # Check if mocap image exists
-    if ! docker images | grep -q mocap; then
-        print_warning "mocap Docker image not found"
+    # The docker-compose mocap service tags the image as `isr/mct_acquisition`
+    # (see docker-compose.yml). `docker image inspect` exits 0 iff present.
+    if ! docker image inspect isr/mct_acquisition >/dev/null 2>&1; then
+        print_warning "mocap Docker image (isr/mct_acquisition) not found"
         print_info "Building Docker image (this may take several minutes)..."
         echo ""
         make build-mocap

--- a/tests/acquisition/conftest.py
+++ b/tests/acquisition/conftest.py
@@ -1,0 +1,44 @@
+"""Shared test scaffolding for acquisition tests.
+
+PySpin and simple_pyspin can't be installed in the dev container (they ship as
+binary wheels tied to the host Spinnaker SDK), so we stub the symbols imported
+at module load time. Tests that need richer behaviour can override the stubs
+locally before importing the backend.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+
+def _install_pyspin_stubs() -> None:
+    if "PySpin" in sys.modules and "simple_pyspin" in sys.modules:
+        return
+
+    if "simple_pyspin" not in sys.modules:
+        stub = types.ModuleType("simple_pyspin")
+
+        class _Camera:
+            def __init__(self, *args, **kwargs):
+                raise RuntimeError("PySpin stub")
+
+        stub.Camera = _Camera  # type: ignore[attr-defined]
+        stub._SYSTEM = None  # type: ignore[attr-defined]
+        stub.list_cameras = lambda: []  # type: ignore[attr-defined]
+        sys.modules["simple_pyspin"] = stub
+
+    if "PySpin" not in sys.modules:
+        stub = types.ModuleType("PySpin")
+
+        class _InterfaceEventHandler:
+            def __init__(self, *args, **kwargs):
+                pass
+
+        stub.InterfaceEventHandler = _InterfaceEventHandler  # type: ignore[attr-defined]
+        stub.IsReadable = lambda node: False  # type: ignore[attr-defined]
+        stub.CStringPtr = lambda node: None  # type: ignore[attr-defined]
+        sys.modules["PySpin"] = stub
+
+
+_install_pyspin_stubs()

--- a/tests/acquisition/conftest.py
+++ b/tests/acquisition/conftest.py
@@ -23,7 +23,13 @@ def _install_pyspin_stubs() -> None:
             def __init__(self, *args, **kwargs):
                 raise RuntimeError("PySpin stub")
 
+        class _CameraError(Exception):
+            """Mirror of simple_pyspin.CameraError. Raised when a camera
+            attribute access fails (e.g. dead handle after disconnect).
+            """
+
         stub.Camera = _Camera  # type: ignore[attr-defined]
+        stub.CameraError = _CameraError  # type: ignore[attr-defined]
         stub._SYSTEM = None  # type: ignore[attr-defined]
         stub.list_cameras = lambda: []  # type: ignore[attr-defined]
         sys.modules["simple_pyspin"] = stub
@@ -35,7 +41,11 @@ def _install_pyspin_stubs() -> None:
             def __init__(self, *args, **kwargs):
                 pass
 
+        class _SpinnakerException(Exception):
+            """Mirror of PySpin.SpinnakerException."""
+
         stub.InterfaceEventHandler = _InterfaceEventHandler  # type: ignore[attr-defined]
+        stub.SpinnakerException = _SpinnakerException  # type: ignore[attr-defined]
         stub.IsReadable = lambda node: False  # type: ignore[attr-defined]
         stub.CStringPtr = lambda node: None  # type: ignore[attr-defined]
         sys.modules["PySpin"] = stub

--- a/tests/acquisition/test_force_ip_endpoint.py
+++ b/tests/acquisition/test_force_ip_endpoint.py
@@ -152,7 +152,15 @@ class TestBusyStateGate:
 
     @pytest.mark.parametrize(
         "status",
-        ["Configuring", "Synchronizing", "Synchronized", "Starting", "Recording"],
+        [
+            "Configuring",
+            "Synchronizing",
+            "Synchronized",
+            "Starting",
+            "Recording",
+            "Resetting",
+            "Reset complete. Waiting to reconfigure.",
+        ],
     )
     def test_endpoint_refuses_in_pyspin_busy_state(self, status: str) -> None:
         state = _make_state(recording_status=status)

--- a/tests/acquisition/test_health_cameras.py
+++ b/tests/acquisition/test_health_cameras.py
@@ -684,6 +684,51 @@ class TestWrongSubnetDetection:
         assert report.wrong_subnet == []
 
 
+class TestBumpConfigHash:
+    """get_config_hash mixes in self._config_hash_salt so bump_config_hash
+    can force a new hash without changing the YAML config — used when the
+    operator reports a camera was physically bumped or the rig was moved
+    mid-session.
+    """
+
+    def _make_recorder(self):
+        from multi_camera.acquisition.flir_recording_api import FlirRecorder
+        # __init__ calls _get_pyspin_system which we can't run in dev container,
+        # so build a bare instance bypassing __init__ and seed the required
+        # fields directly.
+        rec = FlirRecorder.__new__(FlirRecorder)
+        rec._config_hash_salt = ""
+        rec.camera_config = {"camera-info": {"111": {}}, "meta": "x"}
+        return rec
+
+    def test_bump_changes_hash(self) -> None:
+        rec = self._make_recorder()
+        before = rec.get_config_hash(rec.camera_config)
+        bumped = rec.bump_config_hash(reason="test")
+        after = rec.get_config_hash(rec.camera_config)
+        assert before != after
+        assert bumped == after
+
+    def test_consecutive_bumps_keep_changing(self) -> None:
+        rec = self._make_recorder()
+        h1 = rec.bump_config_hash()
+        h2 = rec.bump_config_hash()
+        assert h1 != h2
+
+    def test_unsalted_hash_is_unchanged_from_pre_bump(self) -> None:
+        """A fresh recorder with empty salt should hash to the same value as
+        the historical (pre-PR-4) implementation. This protects existing
+        recordings' hashes from drifting on upgrade.
+        """
+        import hashlib
+        import json
+        rec = self._make_recorder()
+        expected = hashlib.sha256(
+            json.dumps(rec.camera_config, sort_keys=True).encode("utf-8")
+        ).hexdigest()[:10]
+        assert rec.get_config_hash(rec.camera_config) == expected
+
+
 class TestClassifySpinnakerError:
     """The classifier translates Spinnaker exception strings into
     structured operator-facing envelopes. Pure-logic test, no PySpin

--- a/tests/acquisition/test_health_cameras.py
+++ b/tests/acquisition/test_health_cameras.py
@@ -783,6 +783,20 @@ class TestClassifySpinnakerError:
         assert env["code"] == "camera_wrong_subnet"
         assert any("Force IP" in step for step in env["remediation"])
 
+    def test_incompatible_device_classifies_as_wrong_subnet(self) -> None:
+        env = self._classify(
+            "Spinnaker: An incompatible device has been detected on the interface."
+        )
+        assert env is not None
+        assert env["code"] == "camera_wrong_subnet"
+
+    def test_bare_incompatible_does_not_match(self) -> None:
+        # Narrow the pattern: ``incompatible`` alone is too loose
+        # (matches ``incompatible version``, ``incompatible parameters``,
+        # etc.). Only ``IncompatibleDevice`` should classify as wrong-subnet.
+        assert self._classify("incompatible version detected") is None
+        assert self._classify("error: incompatible parameters") is None
+
     def test_device_serial_not_readable(self) -> None:
         env = self._classify("Camera property 'DeviceSerialNumber' is not readable")
         assert env is not None

--- a/tests/acquisition/test_health_cameras.py
+++ b/tests/acquisition/test_health_cameras.py
@@ -728,6 +728,27 @@ class TestBumpConfigHash:
         ).hexdigest()[:10]
         assert rec.get_config_hash(rec.camera_config) == expected
 
+    def test_set_salt_restores_bumped_hash(self) -> None:
+        """set_salt(get_salt()) round-trip reproduces the bumped hash —
+        the contract the backend's session-sidecar persistence relies on.
+        """
+        rec_a = self._make_recorder()
+        bumped_hash = rec_a.bump_config_hash()
+        salt = rec_a.get_salt()
+
+        rec_b = self._make_recorder()
+        assert rec_b.get_config_hash(rec_b.camera_config) != bumped_hash
+        rec_b.set_salt(salt)
+        assert rec_b.get_config_hash(rec_b.camera_config) == bumped_hash
+
+    def test_set_salt_empty_clears(self) -> None:
+        rec = self._make_recorder()
+        unsalted = rec.get_config_hash(rec.camera_config)
+        rec.bump_config_hash()
+        assert rec.get_config_hash(rec.camera_config) != unsalted
+        rec.set_salt("")
+        assert rec.get_config_hash(rec.camera_config) == unsalted
+
 
 class TestClassifySpinnakerError:
     """The classifier translates Spinnaker exception strings into

--- a/tests/acquisition/test_health_cameras.py
+++ b/tests/acquisition/test_health_cameras.py
@@ -819,3 +819,66 @@ class TestClassifySpinnakerError:
         env = self._classify(RuntimeError("LineMode is not writable"))
         assert env is not None
         assert env["code"] == "gpio_linemode_rejected"
+
+
+class TestPostTrialStatReadersSkipDeadHandles:
+    """The post-trial cleanup path in start_acquisition reads PTP offsets,
+    temperatures, and stream stats off each camera. If a camera was
+    unplugged mid-trial, its handle reads raise simple_pyspin.CameraError;
+    the readers must skip it rather than aborting the whole cleanup with
+    an unhandled exception that the GUI then surfaces as "Trial failed".
+    """
+
+    def _make_recorder(self, cams):
+        from multi_camera.acquisition.flir_recording_api import FlirRecorder
+        rec = FlirRecorder.__new__(FlirRecorder)
+        rec.cams = cams
+        return rec
+
+    def _dead_camera(self):
+        """A camera whose DeviceSerialNumber raises CameraError."""
+        from simple_pyspin import CameraError
+
+        class _DeadCam:
+            def __getattr__(self, name):
+                if name in {
+                    "DeviceSerialNumber",
+                    "DeviceTemperature",
+                    "StreamDroppedFrameCount",
+                    "TransferQueueOverflowCount",
+                    "GevIEEE1588OffsetFromMasterLatched",
+                }:
+                    raise CameraError(f"Camera property '{name}' is not readable")
+                if name == "GevIEEE1588DataSetLatch":
+                    def _raise(*_a, **_kw):
+                        raise CameraError("Camera property is not readable")
+                    return _raise
+                raise AttributeError(name)
+        return _DeadCam()
+
+    def _live_camera(self, serial: str):
+        class _LiveCam:
+            DeviceSerialNumber = serial
+            DeviceTemperature = 42.0
+            StreamDroppedFrameCount = 0
+            TransferQueueOverflowCount = 0
+            GevIEEE1588OffsetFromMasterLatched = 12
+            def GevIEEE1588DataSetLatch(self):  # noqa: N802
+                return None
+        return _LiveCam()
+
+    def test_read_camera_stats_skips_dead_handle(self) -> None:
+        rec = self._make_recorder([self._live_camera("AAA"), self._dead_camera()])
+        stats = rec._read_camera_stats()
+        assert "AAA" in stats
+        assert len(stats) == 1
+
+    def test_read_camera_temperatures_skips_dead_handle(self) -> None:
+        rec = self._make_recorder([self._live_camera("AAA"), self._dead_camera()])
+        temps = rec._read_camera_temperatures()
+        assert temps == {"AAA": 42.0}
+
+    def test_read_ptp_offsets_skips_dead_handle(self) -> None:
+        rec = self._make_recorder([self._live_camera("AAA"), self._dead_camera()])
+        offsets = rec._read_ptp_offsets()
+        assert offsets == {"AAA": 12}

--- a/tests/acquisition/test_health_cameras.py
+++ b/tests/acquisition/test_health_cameras.py
@@ -682,3 +682,60 @@ class TestWrongSubnetDetection:
             wrong_subnet_enumerator=boom,
         )
         assert report.wrong_subnet == []
+
+
+class TestClassifySpinnakerError:
+    """The classifier translates Spinnaker exception strings into
+    structured operator-facing envelopes. Pure-logic test, no PySpin
+    runtime needed beyond the stub installed by conftest.
+    """
+
+    def _classify(self, text: str):
+        from multi_camera.acquisition.flir_recording_api import classify_spinnaker_error
+        return classify_spinnaker_error(text)
+
+    def test_ptp_node_not_writable(self) -> None:
+        env = self._classify(
+            "AccessException — Node is not writable, GevIEEE1588DataSetLatch.Execute()"
+        )
+        assert env is not None
+        assert env["code"] == "ptp_node_not_writable"
+        assert env["level"] == "error"
+        assert any("Reset Cameras" in step for step in env["remediation"])
+
+    def test_linemode_rejected(self) -> None:
+        env = self._classify(
+            "Failed to write enumeration value. Enum entry is not writable, node 'LineMode'"
+        )
+        assert env is not None
+        assert env["code"] == "gpio_linemode_rejected"
+        assert any("Reset Cameras" in step for step in env["remediation"])
+
+    def test_wrong_subnet(self) -> None:
+        env = self._classify("camera on wrong subnet detected")
+        assert env is not None
+        assert env["code"] == "camera_wrong_subnet"
+        assert any("Force IP" in step for step in env["remediation"])
+
+    def test_device_serial_not_readable(self) -> None:
+        env = self._classify("Camera property 'DeviceSerialNumber' is not readable")
+        assert env is not None
+        assert env["code"] == "camera_handle_invalid"
+
+    def test_pyspin_system_uninitialized(self) -> None:
+        env = self._classify(
+            "AttributeError: 'NoneType' object has no attribute 'GetInterfaces'"
+        )
+        assert env is not None
+        assert env["code"] == "pyspin_system_uninitialized"
+        # Tiered remediation: try Restart first, then container restart, then reboot.
+        assert len(env["remediation"]) >= 3
+
+    def test_unrecognized_returns_none(self) -> None:
+        assert self._classify("totally unrelated error message") is None
+
+    def test_accepts_exception_object(self) -> None:
+        """Classifier should work on Exception objects too, not just strings."""
+        env = self._classify(RuntimeError("LineMode is not writable"))
+        assert env is not None
+        assert env["code"] == "gpio_linemode_rejected"

--- a/tests/acquisition/test_health_poller_busy_states.py
+++ b/tests/acquisition/test_health_poller_busy_states.py
@@ -171,3 +171,61 @@ class TestOperatorActionGuards:
                 assert status in str(exc.value.detail)
 
         asyncio.run(body())
+
+
+class TestPollerDeferredStart:
+    """The HealthIdlePoller is constructed in lifespan but deliberately not
+    started until update_config completes its first successful
+    configure_cameras call. Before that, the poller's PySpin enumeration
+    has nothing useful to compare against and adds latency / background
+    churn on the GUI's mount-time fetches.
+    """
+
+    def test_update_config_with_a_yaml_starts_the_poller(self) -> None:
+        recorder = mock.MagicMock()
+        recorder.configure_cameras = mock.AsyncMock()
+        poller = mock.MagicMock()
+
+        state = backend_fastapi.GlobalState()
+        state.acquisition = recorder
+        state._health_poller = poller
+
+        async def body():
+            with mock.patch.object(
+                backend_fastapi, "get_global_state", return_value=state
+            ), mock.patch.object(
+                backend_fastapi, "_refresh_health_after_configure", new=mock.AsyncMock()
+            ):
+                await backend_fastapi.update_config(
+                    backend_fastapi.ConfigFileData(config="cotton_lab_config_12_cam.yaml")
+                )
+
+        asyncio.run(body())
+        recorder.configure_cameras.assert_awaited_once()
+        poller.start.assert_called_once()
+
+    def test_update_config_empty_string_does_not_start_the_poller(self) -> None:
+        """An empty config means 'reset' — no cameras to enumerate against,
+        so the poller stays in whatever state it was in (not auto-started).
+        """
+        recorder = mock.MagicMock()
+        recorder.reset = mock.MagicMock()
+        poller = mock.MagicMock()
+
+        state = backend_fastapi.GlobalState()
+        state.acquisition = recorder
+        state._health_poller = poller
+
+        async def body():
+            with mock.patch.object(
+                backend_fastapi, "get_global_state", return_value=state
+            ), mock.patch.object(
+                backend_fastapi, "_refresh_health_after_configure", new=mock.AsyncMock()
+            ):
+                await backend_fastapi.update_config(
+                    backend_fastapi.ConfigFileData(config="")
+                )
+
+        asyncio.run(body())
+        recorder.reset.assert_called_once()
+        poller.start.assert_not_called()

--- a/tests/acquisition/test_health_poller_busy_states.py
+++ b/tests/acquisition/test_health_poller_busy_states.py
@@ -61,8 +61,10 @@ _BUSY_STATUSES = [
     "Synchronized",
     "Starting",
     "Recording",
+    "Resetting",
+    "Reset complete. Waiting to reconfigure.",
 ]
-_FREE_STATUSES = ["Idle", "Uninitialized", "Resetting", None, ""]
+_FREE_STATUSES = ["Idle", "Uninitialized", None, ""]
 
 
 class TestShouldSkipCameraEnumeration:

--- a/tests/acquisition/test_session_salt_persistence.py
+++ b/tests/acquisition/test_session_salt_persistence.py
@@ -1,0 +1,203 @@
+"""Tests for the session-scoped config_hash_salt sidecar.
+
+Verifies the two halves of the lifecycle:
+  - POST /rig/recalibrate writes the new salt to
+    {session.recording_path}/.config_hash_salt.
+  - set_session restores the salt from that sidecar onto the
+    FlirRecorder so trials after a mid-session restart land under the
+    same camera_config_hash as trials before the restart.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime
+import sys
+import types
+import unittest.mock as mock
+from pathlib import Path
+
+import pytest
+
+
+def _install_pyspin_stubs() -> None:
+    for name in ("PySpin", "simple_pyspin"):
+        if name in sys.modules:
+            continue
+        stub = types.ModuleType(name)
+        if name == "simple_pyspin":
+
+            class _Camera:
+                def __init__(self, *args, **kwargs):
+                    raise RuntimeError("PySpin stub")
+
+            stub.Camera = _Camera  # type: ignore[attr-defined]
+            stub._SYSTEM = None  # type: ignore[attr-defined]
+            stub.list_cameras = lambda: []  # type: ignore[attr-defined]
+        sys.modules[name] = stub
+
+
+_install_pyspin_stubs()
+
+
+def _import_backend():
+    import os
+
+    real_listdir = os.listdir
+
+    def safe_listdir(path):
+        if str(path).startswith("/configs"):
+            return []
+        return real_listdir(path)
+
+    os.makedirs("data", exist_ok=True)
+    with mock.patch("os.listdir", side_effect=safe_listdir):
+        from multi_camera.backend import fastapi as _backend_fastapi
+    return _backend_fastapi
+
+
+try:
+    backend_fastapi = _import_backend()
+except Exception as exc:  # pragma: no cover
+    pytest.skip(f"Backend not importable: {exc}", allow_module_level=True)
+
+
+def _make_session(tmp_path: Path):
+    """Build a Session pointed at a real on-disk directory under tmp_path
+    so the sidecar helpers can actually write/read."""
+    session_dir = tmp_path / "t111" / "20260520"
+    session_dir.mkdir(parents=True)
+    return backend_fastapi.Session(
+        participant_name="t111",
+        session_date=datetime.date(2026, 5, 20),
+        recording_path=str(session_dir),
+    )
+
+
+class TestSidecarRoundTrip:
+    """The two helpers are the source of truth for the sidecar contract;
+    the endpoint wiring just calls them. Round-trip them directly."""
+
+    def test_persist_then_load(self, tmp_path: Path) -> None:
+        session = _make_session(tmp_path)
+        backend_fastapi._persist_session_salt(session, "deadbeefdeadbeef")
+        assert backend_fastapi._load_session_salt(session) == "deadbeefdeadbeef"
+
+    def test_load_returns_empty_when_no_sidecar(self, tmp_path: Path) -> None:
+        session = _make_session(tmp_path)
+        assert backend_fastapi._load_session_salt(session) == ""
+
+    def test_helpers_noop_when_session_is_none(self, tmp_path: Path) -> None:
+        # Shouldn't raise; persist silently skips, load returns "".
+        backend_fastapi._persist_session_salt(None, "x")
+        assert backend_fastapi._load_session_salt(None) == ""
+
+
+class TestEndpointPersistsSalt:
+    """POST /rig/recalibrate writes the salt to the session sidecar."""
+
+    def _make_state(self, session, recorder):
+        state = backend_fastapi.GlobalState()
+        state.current_session = session
+        state.acquisition = recorder
+        state.recording_status = "Idle"
+        return state
+
+    def test_recalibrate_writes_sidecar(self, tmp_path: Path) -> None:
+        session = _make_session(tmp_path)
+        recorder = mock.MagicMock()
+        recorder.bump_config_hash = mock.MagicMock(return_value="abc123")
+        # get_salt is called AFTER bump_config_hash to grab what was rotated.
+        recorder.get_salt = mock.MagicMock(return_value="newsalt123")
+
+        state = self._make_state(session, recorder)
+
+        async def body():
+            with mock.patch.object(
+                backend_fastapi, "get_global_state", return_value=state
+            ), mock.patch.object(
+                backend_fastapi, "broadcast_event", new=mock.MagicMock()
+            ):
+                return await backend_fastapi.mark_rig_recalibrate()
+
+        result = asyncio.run(body())
+        assert result == {"status": "success", "new_config_hash": "abc123"}
+
+        sidecar = Path(session.recording_path) / ".config_hash_salt"
+        assert sidecar.exists()
+        assert sidecar.read_text() == "newsalt123"
+
+    def test_recalibrate_without_active_session_does_not_crash(
+        self, tmp_path: Path
+    ) -> None:
+        """If the operator clicks 'Camera moved' before opening a session
+        (rare but possible), the bump still happens — there's just nowhere
+        to persist it. Endpoint must not error.
+        """
+        recorder = mock.MagicMock()
+        recorder.bump_config_hash = mock.MagicMock(return_value="abc123")
+        recorder.get_salt = mock.MagicMock(return_value="newsalt123")
+
+        state = backend_fastapi.GlobalState()
+        state.current_session = None
+        state.acquisition = recorder
+        state.recording_status = "Idle"
+
+        async def body():
+            with mock.patch.object(
+                backend_fastapi, "get_global_state", return_value=state
+            ), mock.patch.object(
+                backend_fastapi, "broadcast_event", new=mock.MagicMock()
+            ):
+                return await backend_fastapi.mark_rig_recalibrate()
+
+        result = asyncio.run(body())
+        assert result["status"] == "success"
+
+
+class TestSetSessionRestoresSalt:
+    """Mid-session restart path: operator reopens the same participant +
+    date, set_session reads the sidecar and seeds the recorder's salt."""
+
+    def test_set_session_restores_existing_salt(self, tmp_path: Path) -> None:
+        session = _make_session(tmp_path)
+        # Simulate a prior bump that wrote a sidecar before the restart.
+        (Path(session.recording_path) / ".config_hash_salt").write_text("priorsalt")
+
+        recorder = mock.MagicMock()
+        state = backend_fastapi.GlobalState()
+        state.acquisition = recorder
+
+        # Stub the set_session pieces that touch the filesystem / DB.
+        with mock.patch.object(
+            backend_fastapi, "get_global_state", return_value=state
+        ), mock.patch.object(
+            backend_fastapi, "RECORDING_BASE", str(tmp_path)
+        ), mock.patch.object(
+            backend_fastapi.datetime,
+            "date",
+            mock.MagicMock(today=mock.MagicMock(return_value=session.session_date)),
+        ):
+            asyncio.run(backend_fastapi.set_session(subject_id="t111", db=mock.MagicMock()))
+
+        recorder.set_salt.assert_called_once_with("priorsalt")
+
+    def test_set_session_clears_salt_when_no_sidecar(self, tmp_path: Path) -> None:
+        recorder = mock.MagicMock()
+        state = backend_fastapi.GlobalState()
+        state.acquisition = recorder
+
+        with mock.patch.object(
+            backend_fastapi, "get_global_state", return_value=state
+        ), mock.patch.object(
+            backend_fastapi, "RECORDING_BASE", str(tmp_path)
+        ), mock.patch.object(
+            backend_fastapi.datetime,
+            "date",
+            mock.MagicMock(today=mock.MagicMock(return_value=datetime.date(2026, 5, 21))),
+        ):
+            asyncio.run(backend_fastapi.set_session(subject_id="t999", db=mock.MagicMock()))
+
+        # New session has no sidecar → recorder.set_salt("") clears whatever
+        # may have been set during a prior session in the same process.
+        recorder.set_salt.assert_called_once_with("")

--- a/tests/acquisition/test_session_salt_persistence.py
+++ b/tests/acquisition/test_session_salt_persistence.py
@@ -154,6 +154,35 @@ class TestEndpointPersistsSalt:
         result = asyncio.run(body())
         assert result["status"] == "success"
 
+    def test_recalibrate_409_when_no_config_loaded(self, tmp_path: Path) -> None:
+        """Clicking 'Camera moved' before a config has been selected would
+        crash bump_config_hash (no camera_config to hash). 409 instead.
+        """
+        from fastapi import HTTPException
+
+        recorder = mock.MagicMock()
+        recorder.camera_config = None
+        recorder.bump_config_hash = mock.MagicMock(return_value="abc123")
+
+        state = backend_fastapi.GlobalState()
+        state.current_session = _make_session(tmp_path)
+        state.acquisition = recorder
+        state.recording_status = "Idle"
+
+        async def body():
+            with mock.patch.object(
+                backend_fastapi, "get_global_state", return_value=state
+            ), mock.patch.object(
+                backend_fastapi, "broadcast_event", new=mock.MagicMock()
+            ):
+                with pytest.raises(HTTPException) as exc:
+                    await backend_fastapi.mark_rig_recalibrate()
+                assert exc.value.status_code == 409
+                assert "config" in exc.value.detail.lower()
+
+        asyncio.run(body())
+        recorder.bump_config_hash.assert_not_called()
+
 
 class TestSetSessionRestoresSalt:
     """Mid-session restart path: operator reopens the same participant +


### PR DESCRIPTION
### Resilience (Tier A)

  - **`get_camera_status` per-cam try/except** - one camera does not cause the entire process to error and now get more informative message
  - **Dead-handle survival in `close()` / `start_acquisition` / `acquire_frames`** - Trying to address the system hanging so it can be recovered easier
  - **`-1002` / `-1012` handling** — disconnected camera no longer spams hundreds of error messages over the rest of a trial; worker writes `None` into its queue and exits.
  - **PySpin device arrival/removal event handler** — scaffolding present but registration intentionally disabled (causes `terminate -1004` on subsequent reset; will be addressed in future work).
  - **`classify_spinnaker_error`** — maps known Spinnaker error families to structured `{code, level, message, remediation}` envelopes the GUI renders inline. Operator sees "Click Reset Cameras" instead of a Python traceback.
  
  ### Operator recovery actions (Tier B)
  
  - **"Camera moved" button** (`POST /api/v1/rig/recalibrate`) — rotates a salt into `get_config_hash` so subsequent trials in the session record under a new `camera_config_hash`. DataJoint treats them as a separate calibration entry.
  - **Session-scoped salt persistence** — the salt is written to `{session.recording_path}/.config_hash_salt` so a mid-session container restart preserves the bumped state. A new session next day starts fresh.
  - **Trial-failure recovery** — `task_done_callback` resets status to `Idle` from any busy state on failure, so recovery buttons stay clickable instead of getting stuck after a failed trial.
  - **Gates for when there is no config** — `new_trial`, `preview`, `rig/recalibrate` all 409 when no config is loaded; frontend buttons disable in the matching states.
  
  ### Performance / UX (laptop testing follow-ups)
  
  - **Idle health poller deferred until first configure** — pre-config, the poller's PySpin enumeration produced no useful signal and added measurable latency to GUI mount-time fetches. Lifespan now constructs the poller but doesn't start it; `update_config` starts it after the first successful `configure_cameras`.
  - **`/health` endpoint skips camera enumeration when no config loaded** — same path on the HTTP side.
  - **`/prior_recordings` short-circuits when no participant is set** — previously walked the entire SQLite DB (every participant × session × recording, plus N+1 `Imported` lookups). The endpoint is called 3× on every Acquisition tab mount, which made tab navigation visibly slow on populated lab databases.
  - **`/health/session_summary` is now operator-triggered, not auto-fetched** — the underlying scan walks every trial JSON in the session directory; running it on every Diagnostics tab visit was wasted work. Pre-existing "Refresh summary" button now also serves as the initial "Generate" trigger.

  ### Frontend

  - **3-col Diagnostics layout** — DHCP / Cameras / Host network in a responsive grid, collapses to single-column below md width; live trial events lifted out of the nested Current Session card.
  - **WebSocket auto-reconnect with exponential backoff** — both `/ws` and `/ws/diagnostics` reconnect on close (0.5s → 1s → 2s → 4s, cap 5s), re-fetching authoritative state on every (re)open so the GUI converges even if a broadcast was missed.
  - **Frontend `BUSY_PYSPIN_STATES` helper** — mirrors backend; the four recovery buttons (Force IP, Exclude/Include, Restore defaults, Restart acquisition) disable consistently across the full busy-state set rather than only on `Recording`.
  - **Camera-moved button gated on `currentConfig`** — disabled until an operator selects a config.

  ### Scripts / infra 

  - **`start_acquisition.sh` docker-image check fix** — was looking for an image named `mocap` but compose tags it `isr/mct_acquisition`; the rebuild path fired on every `make run`. Switch to `docker image inspect`.
  - **`check_env.sh` DEPLOYMENT_MODE auto-suggest** — heuristic based on NetworkManager `DHCP-Server` profile / `isc-dhcp-server` installation / current NIC IP. Soft hint, not enforced.
  
  ## Test plan

  Unit / wire-up coverage is green (219 tests). For operator validation on the laptop after merging, the critical paths to 
  exercise:

  - [x] **Camera moved button**: click → next trial's `camera_config_hash` in DataJoint differs from prior trials in the session.
  - [x] **Salt persistence**: click Camera moved → kill container → reopen same session (same participant + date) → trial should still record under the bumped hash (look for `[config_hash] trial recording under camera_config_hash=… (salt=set)` in stdout).  
  - [x] **New session next day**: hash returns to original un-salted value (`salt=empty`).
  - [ ] **Cable-unplug + preview**: no `DeviceSerialNumber not readable` 500; affected camera reports `last_error` in `/api/v1/camera_status` response.
  - [ ] **Cable-unplug mid-trial**: no `-1002` spam; trial finishes on remaining cameras.
  - [ ] **Trial failure**: recovery buttons (Restart acquisition, Force IP, etc.) stay clickable without a page reload.
  - [x] **No-config gates**: Preview / New Trial / Camera moved all refuse cleanly until a config is selected.
  - [x] **Diagnostics tab on a wide monitor**: 3-col layout, no whitespace gaps.
  - [x] **Acquisition tab navigation when no participant set**: should be snappy (was multi-second on populated databases pre-fix).

  🤖 Generated with [Claude Code](https://claude.com/claude-code)