### PR TITLE
feat(diagnostics): aggregate per-trial findings, add timestamps and h…

### DIFF
--- a/frontend/acquisition/src/components/DiagnosticsPage.js
+++ b/frontend/acquisition/src/components/DiagnosticsPage.js
@@ -276,6 +276,11 @@ const CurrentSessionPanel = () => {
 
                 {sessionSummary && (
                     <>
+                        {sessionSummary.session_header && (
+                            <div className="fw-bold mb-1">
+                                {sessionSummary.session_header}
+                            </div>
+                        )}
                         <div className="mb-3 small text-muted">
                             {sessionSummary.n_trials} trials analyzed.{' '}
                             Last refreshed: {new Date(sessionSummary.generated_at).toLocaleTimeString()}

--- a/multi_camera/acquisition/diagnostics/json_parser.py
+++ b/multi_camera/acquisition/diagnostics/json_parser.py
@@ -142,6 +142,30 @@ def extract_recording_timestamp(json_path: Path) -> str:
     return candidate
 
 
+def format_trial_time(recording_timestamp: str) -> str:
+    """Convert a ``YYYYMMDD_HHMMSS`` recording timestamp to ``HH:MM:SS``.
+
+    Returns the input unchanged if it does not match the expected format,
+    so a malformed timestamp degrades to a visible string rather than an
+    exception.
+    """
+    try:
+        return datetime.strptime(recording_timestamp, "%Y%m%d_%H%M%S").strftime(
+            "%H:%M:%S"
+        )
+    except (ValueError, TypeError):
+        return recording_timestamp
+
+
+def trial_label(t: TrialSyncMetrics) -> str:
+    """Operator-facing label for a trial: index plus wall-clock start time.
+
+    Used to prefix per-trial findings so the operator can tell which
+    recording a finding refers to without cross-referencing trial indices.
+    """
+    return f"Trial {t.trial_index} ({format_trial_time(t.recording_timestamp)})"
+
+
 def load_trial(json_path: Path, trial_index: int) -> TrialSyncMetrics:
     """Load a single JSON metadata file and compute sync deltas."""
     with open(json_path) as f:
@@ -805,7 +829,7 @@ def diagnose_sync_issues(report: SessionSyncReport) -> list[str]:
             nonzero = row[row != 0]
             if len(nonzero) == per_frame_deltas.shape[1] and len(set(nonzero)) == 1:
                 insights.append(
-                    f"Trial {t.trial_index}: all delta cameras show {nonzero[0]:+d} at frame {row_idx} "
+                    f"{trial_label(t)}: all delta cameras show {nonzero[0]:+d} at frame {row_idx} "
                     f"→ reference camera ({t.reference_camera}) skipped, not the others"
                 )
                 break
@@ -841,7 +865,7 @@ def diagnose_sync_issues(report: SessionSyncReport) -> list[str]:
                 and count > n_waited * BOTTLENECK_MIN_FRACTION
             ):
                 insights.append(
-                    f"Trial {t.trial_index}: Camera {cam} was sync bottleneck on {count}/{n_waited} waited frames"
+                    f"{trial_label(t)}: Camera {cam} was sync bottleneck on {count}/{n_waited} waited frames"
                 )
 
     # 6. Queue depth spikes: any camera queue exceeding depth 10
@@ -861,7 +885,7 @@ def diagnose_sync_issues(report: SessionSyncReport) -> list[str]:
                 f"{cam}={d}" for cam, d in sorted(spiked.items(), key=lambda x: -x[1])
             ]
             insights.append(
-                f"Trial {t.trial_index}: Queue depth spikes ({', '.join(parts)}) "
+                f"{trial_label(t)}: Queue depth spikes ({', '.join(parts)}) "
                 f"→ metadata thread falling behind acquisition"
             )
 
@@ -894,7 +918,7 @@ def diagnose_sync_issues(report: SessionSyncReport) -> list[str]:
             longest_run = current_run_len
             longest_run_start = current_run_start
         insights.append(
-            f"Trial {t.trial_index}: Frame-ID cross-camera misalignment first at frame {first_nonzero}, "
+            f"{trial_label(t)}: Frame-ID cross-camera misalignment first at frame {first_nonzero}, "
             f"longest consecutive run of {longest_run} frames starting at frame {longest_run_start}"
         )
 
@@ -924,7 +948,7 @@ def diagnose_sync_issues(report: SessionSyncReport) -> list[str]:
                 if gaps:
                     parts.append(f"{gaps} gaps")
                 insights.append(
-                    f"Trial {t.trial_index}: Camera {cam}: "
+                    f"{trial_label(t)}: Camera {cam}: "
                     f"{', '.join(parts)} ({rate:.1f}% error rate)"
                 )
 
@@ -942,7 +966,7 @@ def diagnose_sync_issues(report: SessionSyncReport) -> list[str]:
                 if overflow > 0:
                     parts.append(f"queue overflow {overflow}")
                 insights.append(
-                    f"Trial {t.trial_index}: Camera {cam} {', '.join(parts)} at device/network level"
+                    f"{trial_label(t)}: Camera {cam} {', '.join(parts)} at device/network level"
                 )
 
     # 10. PTP offset drift: significant change between recording start and end
@@ -957,7 +981,7 @@ def diagnose_sync_issues(report: SessionSyncReport) -> list[str]:
             drift_us = abs(end_ns - start_ns) / 1000
             if drift_us > PTP_DRIFT_THRESHOLD_US:
                 insights.append(
-                    f"Trial {t.trial_index}: Camera {cam} PTP offset drifted {drift_us:.0f} µs during recording "
+                    f"{trial_label(t)}: Camera {cam} PTP offset drifted {drift_us:.0f} µs during recording "
                     f"(start={start_ns} ns, end={end_ns} ns)"
                 )
 
@@ -973,7 +997,7 @@ def diagnose_sync_issues(report: SessionSyncReport) -> list[str]:
             delta = end_temp - start_temp
             if delta > TEMPERATURE_RISE_THRESHOLD_C:
                 insights.append(
-                    f"Trial {t.trial_index}: Camera {cam} temperature rose {delta:.1f}°C "
+                    f"{trial_label(t)}: Camera {cam} temperature rose {delta:.1f}°C "
                     f"({start_temp:.1f}→{end_temp:.1f}°C)"
                 )
 
@@ -986,7 +1010,7 @@ def diagnose_sync_issues(report: SessionSyncReport) -> list[str]:
         for evt in t.sync_timeout_events:
             cameras_involved.update(evt.get("empty_cameras", []))
         insights.append(
-            f"Trial {t.trial_index}: {n_events} sync timeout event(s), "
+            f"{trial_label(t)}: {n_events} sync timeout event(s), "
             f"stalled cameras: {', '.join(sorted(cameras_involved))}"
         )
 
@@ -996,7 +1020,7 @@ def diagnose_sync_issues(report: SessionSyncReport) -> list[str]:
             continue
         alerts = t.timespread_alerts
         insights.append(
-            f"Trial {t.trial_index}: {alerts['count']} timespread alert(s), "
+            f"{trial_label(t)}: {alerts['count']} timespread alert(s), "
             f"max {alerts['max_spread_ms']:.3f} ms, "
             f"frames {alerts['first_frame']}-{alerts['last_frame']}"
         )
@@ -1012,53 +1036,77 @@ def diagnose_sync_issues(report: SessionSyncReport) -> list[str]:
         delta_dropped = last_dropped - first_dropped
         if delta_dropped > 0:
             insights.append(
-                f"Trial {t.trial_index}: NIC rx_dropped increased by {delta_dropped} during recording"
+                f"{trial_label(t)}: NIC rx_dropped increased by {delta_dropped} during recording"
             )
 
-    # 15. Frame skip events: placeholder insertion or unrecovered skips
+    # 15. Frame skip events: one summary line per camera per trial.
+    # A trial can contain hundreds of individual skip events; emitting one
+    # line each makes the findings list unscannable. Aggregate into a
+    # per-camera summary instead — the individual events stay in the saved
+    # JSON metadata for anyone who needs the detail.
     for t in report.trials:
         if not t.frame_skip_events:
             continue
+        events_by_camera: dict[str, list[dict]] = {}
         for evt in t.frame_skip_events:
-            cam = evt["camera_serial"]
-            frame_idx = evt["frame_idx"]
-            gap = evt["gap_size"]
-            if evt["recovered"]:
-                action = "placeholder inserted"
+            events_by_camera.setdefault(evt["camera_serial"], []).append(evt)
+        for cam, events in sorted(events_by_camera.items()):
+            total_skipped = sum(e["gap_size"] for e in events)
+            unrecovered = sum(1 for e in events if not e["recovered"])
+            frame_indices = sorted(e["frame_idx"] for e in events)
+            first_frame, last_frame = frame_indices[0], frame_indices[-1]
+            if unrecovered == 0:
+                recovery = "all recovered with placeholder frames"
+            elif unrecovered == len(events):
+                recovery = "none recovered"
             else:
-                action = "NOT recovered"
-            plural = "s" if gap > 1 else ""
+                recovery = f"{unrecovered} of {len(events)} not recovered"
+            rate = ""
+            if t.n_frames > 0:
+                rate = f", {total_skipped / t.n_frames:.1%} of trial"
+            plural = "s" if len(events) != 1 else ""
             insights.append(
-                f"Trial {t.trial_index}: Camera {cam} skipped {gap} frame{plural} "
-                f"at frame {frame_idx} — {action}"
+                f"{trial_label(t)}: Camera {cam} skipped {total_skipped} frames "
+                f"across {len(events)} event{plural} "
+                f"(frames {first_frame}-{last_frame}{rate}) — {recovery}"
             )
 
-    # 16. PTP timestamp jumps: per-camera clock discontinuities
+    # 16. PTP timestamp jumps: one summary line per camera per trial.
+    # Aggregated for the same reason as detector 15.
     for t in report.trials:
         threshold_ms = frame_period * TIMESTAMP_JUMP_THRESHOLD_FACTOR
         jumps = detect_timestamp_jumps(t, threshold_ms=threshold_ms)
+        if not jumps:
+            continue
+        jumps_by_camera: dict[str, list[dict]] = {}
         for j in jumps:
-            cam = j["camera"]
-            frame = j["frame"]
-            if j["correction_frame"] is not None:
-                frames_affected = j["frames_affected"]
-                residual = j["residual_ms"]
-                if j["frame_ids_aligned"]:
-                    usability = "Frame IDs aligned — frames usable, timestamps unreliable in affected range"
-                else:
-                    usability = "Frame ID drift during jump — manual review recommended"
-                insights.append(
-                    f"Trial {t.trial_index}: Camera {cam} timestamp jumped "
-                    f"{j['magnitude_ms']:+.0f}ms at frame {frame}, "
-                    f"corrected {j['correction_ms']:+.0f}ms at frame {j['correction_frame']} "
-                    f"({frames_affected} frames, residual {residual:+.0f}ms). {usability}"
+            jumps_by_camera.setdefault(j["camera"], []).append(j)
+        for cam, cam_jumps in sorted(jumps_by_camera.items()):
+            corrected = sum(1 for j in cam_jumps if j["correction_frame"] is not None)
+            uncorrected = len(cam_jumps) - corrected
+            max_magnitude = max(abs(j["magnitude_ms"]) for j in cam_jumps)
+            frames = sorted(j["frame"] for j in cam_jumps)
+            if uncorrected == 0:
+                outcome = (
+                    "all corrected within the trial — timestamps unreliable "
+                    "only in the affected ranges"
+                )
+            elif corrected == 0:
+                outcome = (
+                    "none corrected within the trial — timestamps unreliable "
+                    "from the first jump onward"
                 )
             else:
-                insights.append(
-                    f"Trial {t.trial_index}: Camera {cam} PTP jump "
-                    f"{j['magnitude_ms']:+.0f}ms at frame {frame} — "
-                    f"not corrected within trial. Timestamps unreliable from frame {frame} onward"
+                outcome = (
+                    f"{corrected} corrected, {uncorrected} not corrected — "
+                    "review the uncorrected ranges"
                 )
+            plural = "s" if len(cam_jumps) != 1 else ""
+            insights.append(
+                f"{trial_label(t)}: Camera {cam} had {len(cam_jumps)} PTP timestamp "
+                f"jump{plural} (max {max_magnitude:.0f} ms, "
+                f"frames {frames[0]}-{frames[-1]}) — {outcome}"
+            )
 
     return insights
 

--- a/multi_camera/backend/fastapi.py
+++ b/multi_camera/backend/fastapi.py
@@ -38,6 +38,7 @@ from multi_camera.acquisition.flir_recording_api import FlirRecorder, CameraStat
 from multi_camera.acquisition.diagnostics.json_parser import (
     diagnose_session_issues,
     diagnose_sync_issues,
+    format_trial_time,
     load_session,
 )
 from multi_camera.acquisition.health import (
@@ -673,7 +674,35 @@ class SessionSummaryReport(BaseModel):
     insights: List[str]
     recommendations: List[str]
     trial_findings: List[str] = []
+    session_header: str = ""
     generated_at: datetime.datetime
+
+
+def _build_session_header(session_dir: str, report=None) -> str:
+    """Build the one-line session-scope header for the Diagnostics tab.
+
+    ``session_dir`` is ``RECORDING_BASE/{participant}/{YYYYMMDD}``, so the
+    participant and date come from the path. The trial count and time
+    range come from the loaded report; ``report`` is None when the session
+    has no trials yet.
+    """
+    path = Path(session_dir)
+    participant = path.parent.name or "unknown"
+    try:
+        date_label = datetime.datetime.strptime(path.name, "%Y%m%d").strftime(
+            "%Y-%m-%d"
+        )
+    except ValueError:
+        date_label = path.name
+    trials = report.trials if report is not None else []
+    if not trials:
+        return f"Session: {participant} — {date_label} (no trials yet)"
+    times = sorted(format_trial_time(t.recording_timestamp) for t in trials)
+    plural = "s" if len(trials) != 1 else ""
+    return (
+        f"Session: {participant} — {date_label} "
+        f"({len(trials)} trial{plural}, {times[0]} → {times[-1]})"
+    )
 
 
 def _build_session_summary(session_dir: str) -> SessionSummaryReport:
@@ -692,6 +721,7 @@ def _build_session_summary(session_dir: str) -> SessionSummaryReport:
             insights=[],
             recommendations=[],
             trial_findings=[],
+            session_header=_build_session_header(session_dir),
             generated_at=now,
         )
     insights, recommendations = diagnose_session_issues(report)
@@ -701,6 +731,7 @@ def _build_session_summary(session_dir: str) -> SessionSummaryReport:
         insights=insights,
         recommendations=recommendations,
         trial_findings=trial_findings,
+        session_header=_build_session_header(session_dir, report),
         generated_at=now,
     )
 

--- a/tests/acquisition/test_session_summary.py
+++ b/tests/acquisition/test_session_summary.py
@@ -147,6 +147,22 @@ def test_session_summary_endpoint_returns_insights_list(configured_session) -> N
     assert isinstance(body["trial_findings"], list)
 
 
+def test_session_summary_includes_session_header(configured_session) -> None:
+    """The summary carries a one-line session-scope header so the operator
+    can tell which participant / date / trial range is being shown.
+    """
+    with TestClient(backend_fastapi.app) as client:
+        r = client.get("/api/v1/health/session_summary")
+    assert r.status_code == 200
+    header = r.json()["session_header"]
+    assert "participant_1" in header
+    assert "2026-04-22" in header
+    assert "3 trials" in header
+    # The three trial sidecars are named ..._120000 / _120001 / _120002.
+    assert "12:00:00" in header
+    assert "12:00:02" in header
+
+
 def test_session_summary_returns_404_without_session(
     configured_session, monkeypatch
 ) -> None:
@@ -180,3 +196,5 @@ def test_session_summary_returns_empty_when_no_trials_yet(
     assert body["insights"] == []
     assert body["recommendations"] == []
     assert body["trial_findings"] == []
+    assert "no trials yet" in body["session_header"]
+    assert "participant_2" in body["session_header"]

--- a/tests/acquisition/test_sync_diagnostics.py
+++ b/tests/acquisition/test_sync_diagnostics.py
@@ -16,9 +16,11 @@ from multi_camera.acquisition.diagnostics.json_parser import (
     detect_timestamp_jumps,
     diagnose_session_issues,
     diagnose_sync_issues,
+    format_trial_time,
     load_session,
     load_trial,
     save_report,
+    trial_label,
 )
 
 CAMERA_IDS = ["CAM_A", "CAM_B", "CAM_C"]
@@ -572,6 +574,21 @@ class TestJsonCompaction:
         assert report.trials[0].has_diagnostics is True
 
 
+class TestTrialLabel:
+    def test_format_trial_time_converts_to_hms(self) -> None:
+        assert format_trial_time("20260521_133418") == "13:34:18"
+
+    def test_format_trial_time_degrades_on_bad_input(self) -> None:
+        # A malformed timestamp returns unchanged rather than raising.
+        assert format_trial_time("not-a-timestamp") == "not-a-timestamp"
+
+    def test_trial_label_combines_index_and_time(self, tmp_path: Path) -> None:
+        data = _make_json_data()
+        _write_json(tmp_path, data, filename="test_20250101_120000.json")
+        report = load_session(tmp_path)
+        assert trial_label(report.trials[0]) == "Trial 0 (12:00:00)"
+
+
 class TestFrameSkipInsight:
     def test_recovered_skip_insight(self, tmp_path: Path) -> None:
         events = [
@@ -596,8 +613,8 @@ class TestFrameSkipInsight:
         skip_insights = [i for i in insights if "skipped" in i]
         assert len(skip_insights) == 1
         assert "CAM_A" in skip_insights[0]
-        assert "placeholder inserted" in skip_insights[0]
-        assert "frame 100" in skip_insights[0]
+        assert "recovered with placeholder frames" in skip_insights[0]
+        assert "frames 100-100" in skip_insights[0]
 
     def test_unrecovered_skip_insight(self, tmp_path: Path) -> None:
         events = [
@@ -622,8 +639,56 @@ class TestFrameSkipInsight:
         skip_insights = [i for i in insights if "skipped" in i]
         assert len(skip_insights) == 1
         assert "CAM_C" in skip_insights[0]
-        assert "NOT recovered" in skip_insights[0]
-        assert "2 frames" in skip_insights[0]
+        assert "none recovered" in skip_insights[0]
+        assert "skipped 2 frames" in skip_insights[0]
+
+    def test_many_events_aggregate_to_one_line_per_camera(
+        self, tmp_path: Path
+    ) -> None:
+        """A trial with hundreds of skip events must produce one summary
+        line per camera, not one line per event — this is the core fix.
+        """
+        events = []
+        for i in range(150):
+            events.append(
+                {
+                    "frame_idx": i * 2,
+                    "camera_serial": "CAM_A",
+                    "expected_frame_id": 1000 + i,
+                    "actual_frame_id": 1001 + i,
+                    "gap_size": 1,
+                    "recovered": True,
+                }
+            )
+        for i in range(40):
+            events.append(
+                {
+                    "frame_idx": i * 3,
+                    "camera_serial": "CAM_B",
+                    "expected_frame_id": 2000 + i,
+                    "actual_frame_id": 2001 + i,
+                    "gap_size": 1,
+                    "recovered": False,
+                }
+            )
+        data = _make_json_data(
+            include_diagnostics=True,
+            diagnostics_version=2,
+            frame_skip_events=events,
+        )
+        _write_json(tmp_path, data)
+        report = load_session(tmp_path)
+        insights = diagnose_sync_issues(report)
+
+        skip_insights = [i for i in insights if "skipped" in i]
+        # 190 events → exactly 2 lines (one per camera), not 190.
+        assert len(skip_insights) == 2
+        cam_a = next(i for i in skip_insights if "CAM_A" in i)
+        cam_b = next(i for i in skip_insights if "CAM_B" in i)
+        assert "skipped 150 frames across 150 events" in cam_a
+        assert "recovered with placeholder frames" in cam_a
+        assert "skipped 40 frames across 40 events" in cam_b
+        assert "none recovered" in cam_b
 
     def test_no_skip_events_no_insight(self, tmp_path: Path) -> None:
         data = _make_json_data(include_diagnostics=True, diagnostics_version=2)
@@ -860,7 +925,7 @@ class TestDetectTimestampJumps:
 
 class TestPtpTimestampJumpInsight:
     def test_paired_jump_usability(self, tmp_path: Path) -> None:
-        """Paired + aligned → 'frames usable' in insight."""
+        """Paired (corrected) jump → summary reports it as corrected."""
         n = 100
         timestamps = _make_jump_timestamps(
             n_frames=n,
@@ -877,14 +942,12 @@ class TestPtpTimestampJumpInsight:
         report = load_session(tmp_path)
         insights = diagnose_sync_issues(report)
 
-        jump_insights = [
-            i for i in insights if "PTP jump" in i or "timestamp jumped" in i
-        ]
-        assert len(jump_insights) >= 1
-        assert "frames usable" in jump_insights[0]
+        jump_insights = [i for i in insights if "PTP timestamp jump" in i]
+        assert len(jump_insights) == 1
+        assert "all corrected within the trial" in jump_insights[0]
 
     def test_unrecovered_jump_insight(self, tmp_path: Path) -> None:
-        """Single jump → 'not corrected' in insight."""
+        """Single uncorrected jump → summary reports none corrected."""
         n = 50
         timestamps = _make_jump_timestamps(
             n_frames=n, n_cams=3, jump_camera_col=2, jump_frame=20, jump_ms=500.0
@@ -895,11 +958,9 @@ class TestPtpTimestampJumpInsight:
         report = load_session(tmp_path)
         insights = diagnose_sync_issues(report)
 
-        jump_insights = [
-            i for i in insights if "PTP jump" in i or "timestamp jumped" in i
-        ]
-        assert len(jump_insights) >= 1
-        assert "not corrected" in jump_insights[0]
+        jump_insights = [i for i in insights if "PTP timestamp jump" in i]
+        assert len(jump_insights) == 1
+        assert "none corrected within the trial" in jump_insights[0]
 
 
 class TestPtpJumpReportOutput:


### PR DESCRIPTION
## Aggregate per-trial findings, add timestamps and a session header

  ### Problem

  The per-trial findings section of the Diagnostics tab rendered one line for every individual frame-skip event and every PTP timestamp jump. A single session could produce several thousand lines, which the operator could not scan. The findings were also labelled only "Trial 0", "Trial 1", with no indication of when each trial was recorded or which session was being shown.
  
  ### Change

  Three related changes, all in the per-trial diagnostics path:
  
  1. **Aggregation.** The frame-skip detector and the PTP-timestamp-jump detector now emit one summary line per camera per trial instead of one line per event. A camera with 150 skip events produces a single line giving the total number of frames skipped, the event count, the affected frame range, and the recovery status. A camera with several PTP jumps produces one line giving the jump count, the largest magnitude, the frame range, and how many jumps were corrected within the trial. The individual events are still written to the saved JSON metadata for anyone who needs that level of detail.

  2. **Timestamps.** Every per-trial finding is now prefixed with the trial's wall-clock start time, for example "Trial 0 (13:34:18): ...". A new `trial_label` helper builds the prefix, and a `format_trial_time` helper converts the recording timestamp to HH:MM:SS and returns the raw string unchanged if it does not match the expected format.
  
  3. **Session header.** The session summary carries a new `session_header` field — a single line giving the participant, the date, the trial count, and the time range, for example "Session: t111 — 2026-05-22 (5 trials, 12:30:25 → 12:42:18)". The Diagnostics tab renders this header above the trial count so the operator can tell at a glance which session is being shown.