### PR TITLE
Fix/wizard datajoint config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,12 @@ services:
       DHCP_LEASE_FILE: ${DHCP_LEASE_FILE:-/var/lib/dhcp/dhcpd.leases}
       DISK_SPACE_WARNING_THRESHOLD_GB: ${DISK_SPACE_WARNING_THRESHOLD_GB:-50}
       HEALTH_IDLE_POLL_S: ${HEALTH_IDLE_POLL_S:-30}
+      # DataJoint credentials. DataJoint reads DJ_HOST/DJ_USER/DJ_PASS natively and
+      # they override the baked /root/.datajoint_config.json, so creds live in .env
+      # instead of the image. database.port is not env-driven; it stays in the config file.
+      DJ_HOST: ${DJ_HOST}
+      DJ_USER: ${DJ_USER}
+      DJ_PASS: ${DJ_PASS}
     volumes:
       - ${DATA_VOLUME:-/data}:/data
       - ${CAMERA_CONFIGS:-/camera_configs}:/configs
@@ -39,6 +45,12 @@ services:
       DHCP_LEASE_FILE: ${DHCP_LEASE_FILE:-/var/lib/dhcp/dhcpd.leases}
       DISK_SPACE_WARNING_THRESHOLD_GB: ${DISK_SPACE_WARNING_THRESHOLD_GB:-50}
       HEALTH_IDLE_POLL_S: ${HEALTH_IDLE_POLL_S:-30}
+      # DataJoint credentials. DataJoint reads DJ_HOST/DJ_USER/DJ_PASS natively and
+      # they override the baked /root/.datajoint_config.json, so creds live in .env
+      # instead of the image. database.port is not env-driven; it stays in the config file.
+      DJ_HOST: ${DJ_HOST}
+      DJ_USER: ${DJ_USER}
+      DJ_PASS: ${DJ_PASS}
     volumes:
       - ${TEST_DATA_VOLUME:-/data-test}:/data
       - ${CAMERA_CONFIGS:-/camera_configs}:/configs

--- a/multi_camera/backend/fastapi.py
+++ b/multi_camera/backend/fastapi.py
@@ -89,10 +89,16 @@ log_format = colorlog.ColoredFormatter(
     log_colors=log_colors_config,
 )
 acquisition_logger = logging.getLogger("acquisition")
-streamHandler = logging.StreamHandler()
-streamHandler.setFormatter(log_format)
-acquisition_logger.addHandler(streamHandler)
+# This module is imported twice under `python -m ...fastapi`: once as __main__,
+# then again when uvicorn resolves the "...:app" import string. The "acquisition"
+# logger is a process-global singleton, so guard the handler add (otherwise every
+# line is emitted twice) and keep records off the root logger.
+if not acquisition_logger.handlers:
+    streamHandler = logging.StreamHandler()
+    streamHandler.setFormatter(log_format)
+    acquisition_logger.addHandler(streamHandler)
 acquisition_logger.setLevel(logging.DEBUG)
+acquisition_logger.propagate = False
 
 
 class Session(BaseModel):

--- a/scripts/acquisition/setup_acquisition_system.sh
+++ b/scripts/acquisition/setup_acquisition_system.sh
@@ -746,12 +746,18 @@ PY
 apply_persistence() {
     print_header "Step 8: Persistent Network Settings"
 
-    print_info "Making network settings (MTU, buffers, DHCP) persist across reboots"
+    print_info "This makes the camera network settings stick after a restart, so the"
+    print_info "cameras keep working without any manual setup each time the computer"
+    print_info "reboots. If you skip this, the cameras may drop frames or fail to"
+    print_info "connect after a reboot until the settings are applied again by hand."
     echo ""
 
-    if ask_yes_no "Apply persistent settings now?" "y"; then
-        # Run persistence script as actual user
-        sudo -u "$ACTUAL_USER" ./scripts/acquisition/make_settings_persistent.sh
+    if ask_yes_no "Save the camera network settings so they survive a restart?" "y"; then
+        # The wizard already runs as root; run the persistence script directly
+        # rather than via `sudo -u "$ACTUAL_USER"`. It re-invokes sudo internally
+        # to edit system files, which would prompt for a password and hang when
+        # dropped to a user without passwordless sudo. Its writes are root-owned anyway.
+        ./scripts/acquisition/make_settings_persistent.sh
         print_success "Persistence settings applied"
     else
         print_warning "Skipped persistence setup"
@@ -768,12 +774,19 @@ apply_persistence() {
 install_sudoers() {
     print_header "Step 8b: Passwordless-sudo Rules"
 
-    print_info "Without these rules, start_acquisition.sh's auto-remediation"
-    print_info "(MTU/rmem fix, isc-dhcp-server start, nmcli profile activation)"
-    print_info "falls back to printing manual commands instead of actually fixing."
+    print_info "This lets the acquisition system fix common network problems on its"
+    print_info "own — for example restoring the camera network settings or restarting"
+    print_info "the address server — without stopping to ask for a password each time."
+    echo ""
+    print_info "If you skip this, the system can still detect those problems but will"
+    print_info "only print instructions for you to run by hand, instead of fixing them"
+    print_info "automatically."
+    echo ""
+    print_info "You can undo this later by removing the permissions file:"
+    print_info "  sudo rm /etc/sudoers.d/mocap-acquisition"
     echo ""
 
-    if ask_yes_no "Install /etc/sudoers.d/mocap-acquisition now?" "y"; then
+    if ask_yes_no "Allow the system to fix network problems automatically?" "y"; then
         ./scripts/acquisition/install_sudoers.sh "$ACTUAL_USER"
     else
         print_warning "Skipped sudoers install"

--- a/scripts/acquisition/setup_acquisition_system.sh
+++ b/scripts/acquisition/setup_acquisition_system.sh
@@ -689,9 +689,12 @@ create_datajoint_config() {
     local template_file="template.datajoint_config.json"
 
     # The Dockerfile COPYs datajoint_config.json into the image unconditionally,
-    # so the build fails outright if it is missing. It is gitignored (it holds
-    # DB credentials), so a fresh checkout never has it. Generate it here from
-    # the template, injecting the DataJoint credentials collected in Step 7.
+    # so the build fails outright if it is missing, and a fresh checkout never
+    # has it (it is gitignored, per-machine). Generate it from the template with
+    # the connection target (host and port) only. The username and password are
+    # NOT written here — the COPY would bake them into the image. They live in
+    # .env and are forwarded to the container at runtime, where DataJoint reads
+    # them natively and they override this file (see docker-compose.yml).
     if [ -f "$config_file" ]; then
         print_success "$config_file already exists — leaving it untouched"
         echo ""
@@ -706,36 +709,33 @@ create_datajoint_config() {
     if ! command -v python3 &>/dev/null; then
         print_error "python3 not found — cannot generate $config_file"
         print_info "Create it by hand: cp $template_file $config_file"
-        print_info "then add database.host/port/user/password from your .env"
+        print_info "then add database.host/port from your .env (user/password stay in .env)"
         exit 1
     fi
 
     # Step 7 may have been skipped (operator kept an existing .env), so read the
-    # credentials back from .env rather than relying on the in-memory values.
-    local dj_user dj_pass dj_host dj_port
-    dj_user=$(grep '^DJ_USER=' .env | cut -d= -f2-)
-    dj_pass=$(grep '^DJ_PASS=' .env | cut -d= -f2-)
+    # connection target back from .env rather than relying on in-memory values.
+    # Only host and port are written to the file; the credentials stay in .env.
+    local dj_host dj_port
     dj_host=$(grep '^DJ_HOST=' .env | cut -d= -f2-)
     dj_port=$(grep '^DJ_PORT=' .env | cut -d= -f2-)
 
     print_info "Creating $config_file from $template_file..."
-    python3 - "$template_file" "$config_file" "$dj_host" "$dj_port" "$dj_user" "$dj_pass" <<'PY'
+    python3 - "$template_file" "$config_file" "$dj_host" "$dj_port" <<'PY'
 import json
 import sys
 
-template, out, host, port, user, password = sys.argv[1:7]
+template, out, host, port = sys.argv[1:5]
 with open(template) as f:
     cfg = json.load(f)
 cfg["database.host"] = host
 cfg["database.port"] = int(port)
-cfg["database.user"] = user
-cfg["database.password"] = password
 with open(out, "w") as f:
     json.dump(cfg, f, indent=4)
 PY
 
     chown "$ACTUAL_USER:$ACTUAL_USER" "$config_file"
-    print_success "$config_file created (connects to $dj_host:$dj_port as $dj_user)"
+    print_success "$config_file created — connects to $dj_host:$dj_port; credentials read from .env at runtime"
     echo ""
 }
 

--- a/scripts/acquisition/setup_acquisition_system.sh
+++ b/scripts/acquisition/setup_acquisition_system.sh
@@ -679,6 +679,67 @@ EOF
 }
 
 ################################################################################
+# Step 7b: DataJoint Config File
+################################################################################
+
+create_datajoint_config() {
+    print_header "Step 7b: DataJoint Config File"
+
+    local config_file="datajoint_config.json"
+    local template_file="template.datajoint_config.json"
+
+    # The Dockerfile COPYs datajoint_config.json into the image unconditionally,
+    # so the build fails outright if it is missing. It is gitignored (it holds
+    # DB credentials), so a fresh checkout never has it. Generate it here from
+    # the template, injecting the DataJoint credentials collected in Step 7.
+    if [ -f "$config_file" ]; then
+        print_success "$config_file already exists — leaving it untouched"
+        echo ""
+        return 0
+    fi
+
+    if [ ! -f "$template_file" ]; then
+        print_error "$template_file not found — cannot create $config_file"
+        exit 1
+    fi
+
+    if ! command -v python3 &>/dev/null; then
+        print_error "python3 not found — cannot generate $config_file"
+        print_info "Create it by hand: cp $template_file $config_file"
+        print_info "then add database.host/port/user/password from your .env"
+        exit 1
+    fi
+
+    # Step 7 may have been skipped (operator kept an existing .env), so read the
+    # credentials back from .env rather than relying on the in-memory values.
+    local dj_user dj_pass dj_host dj_port
+    dj_user=$(grep '^DJ_USER=' .env | cut -d= -f2-)
+    dj_pass=$(grep '^DJ_PASS=' .env | cut -d= -f2-)
+    dj_host=$(grep '^DJ_HOST=' .env | cut -d= -f2-)
+    dj_port=$(grep '^DJ_PORT=' .env | cut -d= -f2-)
+
+    print_info "Creating $config_file from $template_file..."
+    python3 - "$template_file" "$config_file" "$dj_host" "$dj_port" "$dj_user" "$dj_pass" <<'PY'
+import json
+import sys
+
+template, out, host, port, user, password = sys.argv[1:7]
+with open(template) as f:
+    cfg = json.load(f)
+cfg["database.host"] = host
+cfg["database.port"] = int(port)
+cfg["database.user"] = user
+cfg["database.password"] = password
+with open(out, "w") as f:
+    json.dump(cfg, f, indent=4)
+PY
+
+    chown "$ACTUAL_USER:$ACTUAL_USER" "$config_file"
+    print_success "$config_file created (connects to $dj_host:$dj_port as $dj_user)"
+    echo ""
+}
+
+################################################################################
 # Step 8: Apply Persistence Settings
 ################################################################################
 
@@ -858,6 +919,7 @@ main() {
     setup_dhcp_server
     create_directories
     create_env_file
+    create_datajoint_config
     apply_persistence
     install_sudoers
     download_flir_sdk

--- a/scripts/acquisition/start_acquisition.sh
+++ b/scripts/acquisition/start_acquisition.sh
@@ -496,14 +496,20 @@ main() {
         fi
     fi
 
-    # Wait for cameras (optional, non-blocking)
-    if [ "$DEPLOYMENT_MODE" = "laptop" ]; then
+    # Wait for cameras (laptop mode only). Skipped under --skip-checks: it is a
+    # 30s pre-flight wait that only makes sense when cameras are expected, and the
+    # operator has opted out of pre-flight (e.g. opening the GUI just to push data).
+    if ! $SKIP_CHECKS && [ "$DEPLOYMENT_MODE" = "laptop" ]; then
         wait_for_cameras
     fi
 
     # Start acquisition software
     echo ""
-    print_success "All checks passed - ready to start acquisition"
+    if $SKIP_CHECKS; then
+        print_success "Ready to start acquisition (checks skipped)"
+    else
+        print_success "All checks passed - ready to start acquisition"
+    fi
     echo ""
 
     start_acquisition

--- a/scripts/acquisition/start_acquisition.sh
+++ b/scripts/acquisition/start_acquisition.sh
@@ -479,12 +479,21 @@ main() {
         fi
     fi
 
-    # Activate network (laptop mode only)
+    # Activate network (laptop mode only). With --skip-checks the operator may be
+    # starting the GUI with no camera network attached — e.g. from a desk just to
+    # review or push already-recorded data — so a failure here is non-fatal: warn
+    # and continue so the GUI still opens. A normal `make run` stays strict.
     if ! activate_network; then
         echo ""
-        print_error "Network activation failed"
-        echo ""
-        exit 1
+        if $SKIP_CHECKS; then
+            print_warning "Network activation failed — continuing anyway (--skip-checks)"
+            print_info "Cameras will be unavailable; the GUI will still open for data review/push"
+            echo ""
+        else
+            print_error "Network activation failed"
+            echo ""
+            exit 1
+        fi
     fi
 
     # Wait for cameras (optional, non-blocking)


### PR DESCRIPTION
 # Harden acquisition startup & setup wizard

  This branch began as a fix for the setup wizard failing to generate `datajoint_config.json`, and grew to cover a cluster of related operator-facing startup and setup issues found alongside it. Everything here is in the acquisition path (setup wizard, container startup, compose wiring, backend logging) and is independent of the analysis/DataJoint pipeline.

  ## DataJoint configuration & credentials

  Three commits that together fix container startup and tighten credential handling:

  - **Generate `datajoint_config.json` in the wizard (`8f8b1f4`).** The Dockerfile `COPY`s this file unconditionally, so `make build-mocap` failed with a checksum/"not found" error whenever it was absent. The wizard now generates it from `template.datajoint_config.json`.

  - **Forward DJ creds from `.env` into the containers (`273661f`).** At startup, `synchronize_to_datajoint()` opens a DataJoint connection. With no credentials, DataJoint prompted interactively for a username — but the container has no TTY, so it hit `EOF when reading a line` and the sync failed. The `mocap` and `mocap-test` services now forward `DJ_HOST`/`DJ_USER`/`DJ_PASS`, which DataJoint reads natively and which override the config file.

  - **Keep credentials out of the generated file (`2256960`).** The generator originally injected `database.user`/`database.password` into the file, which the Dockerfile then baked into the image. Now that creds come from `.env` at runtime, the generated file carries only the connection target (host and port), so the credentials live in exactly one place (`.env`) and nothing sensitive is baked into the image. Port stays in the file because DataJoint does not read `DJ_PORT` from the environment.

  ## Stop duplicate acquisition log lines (`befb210`)

  Launching via `python -m multi_camera.backend.fastapi` imports the module as `__main__`, then `uvicorn.run("...:app")` imports it again to resolve the app. The module-level `addHandler` ran twice on the process-global `acquisition` logger, so every line was emitted twice. The handler add is now guarded and `propagate` is disabled.

  ## Fix double-sudo hang + reword wizard Step 8/8b (`c1852df`)

  - **Hang:** Step 8 ran the persistence script via `sudo -u "$ACTUAL_USER"`, but the wizard already runs as root and that script re-invokes `sudo` internally to edit system files. Dropping to the user made the inner `sudo` prompt for a password and hang when passwordless sudo wasn't configured. It now runs directly as root; its writes are root-owned regardless.

  ## Let `make run-no-checks` open the GUI with no camera network (`983f661`)

  Under `--skip-checks` the system checks were skipped, but `activate_network` still ran and `exit 1`'d on failure, so an operator couldn't open the GUI from a desk with no cameras attached (e.g. just to review or push already-recorded data). `activate_network` failure is now non-fatal under `--skip-checks` — it warns and continues so the GUI launches. A normal `make run` stays strict.