### PR TITLE
feat(recordings): JSON metadata container (#28) + per-trial duration (#25)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ _docker-run:
 # Start acquisition with isolated test data (TEST_DATA_VOLUME, default /data-test).
 # Cannot run simultaneously with 'make run' — both bind host ports 8000 and 3000.
 run-mocap-test:
-	docker compose run --rm mocap-test
+	if [ -f .env ]; then set -a; . ./.env; set +a; fi; docker compose run --rm mocap-test
 
 # Run all acquisition tests (cameras required for test matrix)
 test:
@@ -118,8 +118,11 @@ init-dj-test:
 # Run 'make init-dj-test' once before first use.
 # --build rebuilds the image so Python source changes under multi_camera/ are picked up
 # (the Dockerfile bakes source in via COPY; there is no source bind mount on this service).
+# Source .env first (same as start_acquisition.sh does for `make run`) so the container
+# inherits REACT_APP_BASE_URL / NETWORK_INTERFACE / etc. instead of the compose defaults —
+# otherwise the GUI bundle is built for localhost and only works in a browser on the server.
 run-mocap-test-dj:
-	docker compose run --rm --build mocap-test-dj
+	if [ -f .env ]; then set -a; . ./.env; set +a; fi; docker compose run --rm --build mocap-test-dj
 
 # Drop and recreate the test DataJoint database (clean-slate testing).
 # Stops the container, removes the data volume, and restarts.

--- a/frontend/acquisition/src/AcquisitionApi.js
+++ b/frontend/acquisition/src/AcquisitionApi.js
@@ -574,8 +574,8 @@ export const AcquisitionApi = (props) => {
     const changeComment = async (participant, filename, newComment) => {
         console.log(`Comment changed for ${participant} ${filename}: ${newComment}`);
         const matchedRecording = await getMatchingPriorRecordings(participant, filename);
-        // Mutate only the comment element; spread preserves other container keys (e.g. 10mwt_time)
-        matchedRecording.metadata = { ...(matchedRecording.metadata || {}), comment: newComment };
+        // Mutate only the comment element; Object.assign preserves other container keys (e.g. 10mwt_time)
+        matchedRecording.metadata = Object.assign({}, matchedRecording.metadata || {}, { comment: newComment });
         await axios.post(`${API_BASE_URL}/update_recording`, matchedRecording);
         fetchRecordings();
     };

--- a/frontend/acquisition/src/AcquisitionApi.js
+++ b/frontend/acquisition/src/AcquisitionApi.js
@@ -2,9 +2,16 @@ import React from 'react';
 import { useState, useEffect, useRef, createContext } from 'react';
 import axios from 'axios';
 
-// get first part of base url from environment variable
-// if not set, then use localhost
-const BASE_HOSTNAME = process.env.REACT_APP_BASE_URL || 'localhost';
+// API host resolution. Prefer an explicitly-configured, non-localhost host; but
+// otherwise use the host the page is being served from, so the GUI works from any
+// machine without a build-time base URL (the same way the FastAPI-served page does
+// with relative calls). A bare 'localhost' — the default .env value — is treated as
+// unset, so a browser on another machine still reaches the server instead of itself.
+const _configuredHost = process.env.REACT_APP_BASE_URL;
+const BASE_HOSTNAME =
+    _configuredHost && _configuredHost !== 'localhost'
+        ? _configuredHost
+        : (typeof window !== 'undefined' && window.location.hostname) || 'localhost';
 
 const BASE_URL = `${BASE_HOSTNAME}:8000/api/v1`;
 const API_BASE_URL = `http://${BASE_URL}`;

--- a/frontend/acquisition/src/AcquisitionApi.js
+++ b/frontend/acquisition/src/AcquisitionApi.js
@@ -548,10 +548,12 @@ export const AcquisitionApi = (props) => {
                         participant: participant,
                         filename: filename,
                         recording_timestamp: matchedRecording[0].recording_timestamp,
-                        comment: matchedRecording[0].comment,
+                        // Whole metadata container — must round-trip unknown keys on update
+                        metadata: matchedRecording[0].metadata,
                         config_file: matchedRecording[0].config_file,
                         should_process: matchedRecording[0].should_process,
-                        timestamp_spread: matchedRecording[0].timestamp_spread
+                        timestamp_spread: matchedRecording[0].timestamp_spread,
+                        duration: matchedRecording[0].duration
                     }
                     console.log("prior_recording: ", prior_recording)
                     return prior_recording;
@@ -572,7 +574,8 @@ export const AcquisitionApi = (props) => {
     const changeComment = async (participant, filename, newComment) => {
         console.log(`Comment changed for ${participant} ${filename}: ${newComment}`);
         const matchedRecording = await getMatchingPriorRecordings(participant, filename);
-        matchedRecording.comment = newComment;
+        // Mutate only the comment element; spread preserves other container keys (e.g. 10mwt_time)
+        matchedRecording.metadata = { ...(matchedRecording.metadata || {}), comment: newComment };
         await axios.post(`${API_BASE_URL}/update_recording`, matchedRecording);
         fetchRecordings();
     };

--- a/frontend/acquisition/src/AnalysisHome.js
+++ b/frontend/acquisition/src/AnalysisHome.js
@@ -38,7 +38,8 @@ const RecordingTable = ({ recordings, participant, session_date, imported, callb
                 </thead>
                 <tbody>
                     {recordings.map((recording, index) => {
-                        const comment = recording.metadata?.comment ?? '';
+                        const metadata = recording.metadata || {};
+                        const comment = metadata.comment || '';
                         return (
                         <tr key={recording.filename}>
                             <td>{stripPath(recording.filename)}</td>

--- a/frontend/acquisition/src/AnalysisHome.js
+++ b/frontend/acquisition/src/AnalysisHome.js
@@ -32,23 +32,28 @@ const RecordingTable = ({ recordings, participant, session_date, imported, callb
                         <th>Filename</th>
                         <th>Comment</th>
                         {/* <th>Config File</th> */}
+                        <th>Duration</th>
                         <th>Should Process</th>
                     </tr>
                 </thead>
                 <tbody>
-                    {recordings.map((recording, index) => (
+                    {recordings.map((recording, index) => {
+                        const comment = recording.metadata?.comment ?? '';
+                        return (
                         <tr key={recording.filename}>
                             <td>{stripPath(recording.filename)}</td>
 
 
-                            {/* If recording.comment == "calibration" add button for run calibration, otherwise show comment */}
-                            {recording.comment === "calibration" ? (
+                            {/* If the metadata comment is "calibration" add button for run calibration, otherwise show comment */}
+                            {comment === "calibration" ? (
                                 <td><Button variant="primary" onClick={() => calibrate(recording.filename, false)}>Checkerboard Calibration</Button></td>
-                            ) : recording.comment === "charuco" ? (
+                            ) : comment === "charuco" ? (
                                 <td><Button variant="primary" onClick={() => calibrate(recording.filename, true)}>Charuco Calibration</Button></td>
                             ) : (
-                                <td>{recording.comment}</td>
+                                <td>{comment}</td>
                             )}
+
+                            <td>{recording.duration != null ? recording.duration.toFixed(1) + ' s' : '—'}</td>
 
 
                             {/* <td>{recording.config_file}</td> */}
@@ -65,7 +70,8 @@ const RecordingTable = ({ recordings, participant, session_date, imported, callb
 
                             </td>
                         </tr>
-                    ))}
+                        );
+                    })}
                 </tbody>
             </Table>
             {/* Button that pushes a recording to DataJoint */}

--- a/frontend/acquisition/src/components/PriorRecordingsTable.js
+++ b/frontend/acquisition/src/components/PriorRecordingsTable.js
@@ -54,7 +54,7 @@ const PriorRecordingsTable = ({ api }) => {
                                         suppressContentEditableWarning
                                         // onBlur={(e) => hangeComment(recording.participant, recording.filename, e.target.textContent)}
                                         onKeyDown={(e) => handleKeyPress(e, recording.participant, recording.filename, e.target.textContent)}
-                                    >{recording.metadata?.comment ?? ''}</td>
+                                    >{(recording.metadata || {}).comment || ''}</td>
                                     {/* <td>{recording.config_file}</td> */}
                                     <td>{recording.duration != null ? recording.duration.toFixed(1) + ' s' : '—'}</td>
                                     {/* round recording.timestamp_spread to 2 decimal places */}

--- a/frontend/acquisition/src/components/PriorRecordingsTable.js
+++ b/frontend/acquisition/src/components/PriorRecordingsTable.js
@@ -38,6 +38,7 @@ const PriorRecordingsTable = ({ api }) => {
                                 <th>Timestamp</th>
                                 <th>Comment</th>
                                 {/* <th>Config</th> */}
+                                <th>Duration</th>
                                 <th>Timestamp Spread</th>
                                 <th>Process</th>
                             </tr>
@@ -53,8 +54,9 @@ const PriorRecordingsTable = ({ api }) => {
                                         suppressContentEditableWarning
                                         // onBlur={(e) => hangeComment(recording.participant, recording.filename, e.target.textContent)}
                                         onKeyDown={(e) => handleKeyPress(e, recording.participant, recording.filename, e.target.textContent)}
-                                    >{recording.comment}</td>
+                                    >{recording.metadata?.comment ?? ''}</td>
                                     {/* <td>{recording.config_file}</td> */}
+                                    <td>{recording.duration != null ? recording.duration.toFixed(1) + ' s' : '—'}</td>
                                     {/* round recording.timestamp_spread to 2 decimal places */}
                                     <td>{recording.timestamp_spread.toFixed(2)}</td>
                                     <td>

--- a/multi_camera/acquisition/flir_recording_api.py
+++ b/multi_camera/acquisition/flir_recording_api.py
@@ -808,6 +808,9 @@ def write_metadata_queue(
                     "filename": current_filename,
                     "timestamp_spread": max_timespread,
                     "recording_timestamp": local_times[0],
+                    # Wall-clock span of the synced frames in this file (#25); the
+                    # per-frame camera frame_rates arrays are not trustworthy here.
+                    "duration": (local_times[-1] - local_times[0]).total_seconds(),
                     "frame_skip_count": len(trial_skips),
                 }
             )
@@ -881,6 +884,7 @@ def write_metadata_queue(
             "filename": current_filename,
             "timestamp_spread": max_timespread,
             "recording_timestamp": local_times[0],
+            "duration": (local_times[-1] - local_times[0]).total_seconds(),
             "frame_skip_count": len(trial_skips),
         }
     )

--- a/multi_camera/backend/fastapi.py
+++ b/multi_camera/backend/fastapi.py
@@ -1098,7 +1098,7 @@ async def new_trial(data: NewTrialData, db: Session = Depends(db_dependency)):
                     config_file=config,
                     comment=comment,
                     timestamp_spread=record["timestamp_spread"],
-                    duration=record.get("duration"),
+                    duration=record["duration"],
                 )
             _broadcast_new_session_insights()
         except Exception as e:

--- a/multi_camera/backend/fastapi.py
+++ b/multi_camera/backend/fastapi.py
@@ -18,7 +18,7 @@ from starlette.concurrency import run_in_threadpool
 from uvicorn.main import Server
 from websockets.exceptions import ConnectionClosedOK
 from datetime import date
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from contextlib import asynccontextmanager
 from typing import List, Dict, Optional
 from dataclasses import dataclass, field
@@ -63,6 +63,7 @@ from multi_camera.backend.recording_db import (
     push_to_datajoint,
     ParticipantOut,
     SessionOut,
+    RecordingMetadata,
     RecordingOut,
 )
 
@@ -575,10 +576,13 @@ class PriorRecordings(BaseModel):
     participant: str
     filename: str
     recording_timestamp: datetime.datetime
-    comment: str
+    # Metadata container (#28): {"comment": str, "10mwt_time": float, ...}. Clients must
+    # round-trip unknown keys: fetch, mutate known elements, send the whole object back.
+    metadata: RecordingMetadata = Field(default_factory=RecordingMetadata)
     config_file: str
     should_process: bool
     timestamp_spread: float
+    duration: Optional[float] = None  # seconds; server-computed (#25), ignored on update
 
 
 class ImageUploadResponse(BaseModel):
@@ -1094,6 +1098,7 @@ async def new_trial(data: NewTrialData, db: Session = Depends(db_dependency)):
                     config_file=config,
                     comment=comment,
                     timestamp_spread=record["timestamp_spread"],
+                    duration=record.get("duration"),
                 )
             _broadcast_new_session_insights()
         except Exception as e:
@@ -1198,10 +1203,11 @@ async def get_prior_recordings(db=Depends(db_dependency)) -> List[PriorRecording
                         participant=participant.name,
                         filename=recording.filename,
                         recording_timestamp=recording.recording_timestamp,
-                        comment=recording.comment,
+                        metadata=recording.metadata,
                         config_file=recording.config_file,
                         should_process=recording.should_process,
                         timestamp_spread=recording.timestamp_spread,
+                        duration=recording.duration,
                     )
                 )
 
@@ -1215,16 +1221,21 @@ async def update_recording(recording: PriorRecordings, db=Depends(db_dependency)
     print("Updating recording: ", recording)
 
     participant = ParticipantOut(name=recording.participant, sessions=[])
+    # duration is deliberately not forwarded — it is server-computed (#25) and
+    # modify_recording_entry only persists the metadata container + should_process.
     recording = RecordingOut(
         filename=recording.filename,
         recording_timestamp=recording.recording_timestamp,
-        comment=recording.comment,
+        metadata=recording.metadata,
         config_file=recording.config_file,
         should_process=recording.should_process,
         timestamp_spread=recording.timestamp_spread,
     )
 
-    modify_recording_entry(db, participant, recording)
+    try:
+        modify_recording_entry(db, participant, recording)
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
 
     return {}
 

--- a/multi_camera/backend/recording_db.py
+++ b/multi_camera/backend/recording_db.py
@@ -1,9 +1,11 @@
+import json
 import os
+import re
 
-from sqlalchemy import create_engine, Boolean, Column, Float, Integer, String, Date, DateTime, ForeignKey
+from sqlalchemy import create_engine, Boolean, Column, Float, Integer, JSON, String, Date, DateTime, ForeignKey
 from sqlalchemy.orm import relationship, declarative_base, joinedload
 from typing import Union, Tuple, List, Optional
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field
 from datetime import date, datetime
 
 Base = declarative_base()
@@ -41,10 +43,15 @@ class Recording(Base):
     session_id = Column(Integer, ForeignKey("sessions.id"))
     filename = Column(String)
     recording_timestamp = Column(DateTime)  # Add recording_timestamp field
-    comment = Column(String, nullable=True)  # Add comment field
+    comment = Column(String, nullable=True)  # DEPRECATED (#28): moved into recording_metadata["comment"];
+    # kept read-only for one release to support rollback, migrated by _ensure_recording_metadata_columns.
     config_file = Column(String, nullable=True)  # Add config_file field
     should_process = Column(Boolean, default=True)  # Add should_process field with a default value of True
     timestamp_spread = Column(Integer, nullable=True)  # Add timestamp_spread field
+    # Per-recording metadata container (#28): {"comment": str, "10mwt_time": float, ...}.
+    # Writes must REASSIGN a whole new dict — SQLAlchemy's JSON type does not track nested mutation.
+    recording_metadata = Column(JSON, nullable=True)
+    duration = Column(Float, nullable=True)  # #25: seconds, computed at file finalization; historical rows NULL
 
     session = relationship("Session", back_populates="recordings")
 
@@ -159,6 +166,7 @@ def add_recording(
     comment: Optional[str] = None,
     should_process: Optional[bool] = True,
     timestamp_spread: Optional[int] = None,
+    duration: Optional[float] = None,
 ):
     print(
         "Adding recording to database: ",
@@ -171,6 +179,7 @@ def add_recording(
         config_file,
         should_process,
         timestamp_spread,
+        duration,
     )
 
     session = _get_or_create_session(db, participant_name, session_date, session_path)
@@ -179,10 +188,11 @@ def add_recording(
         session_id=session.id,
         filename=filename,
         recording_timestamp=recording_timestamp,
-        comment=comment,
+        recording_metadata={"comment": comment or ""},
         config_file=config_file,
         should_process=should_process,
         timestamp_spread=timestamp_spread,
+        duration=duration,
     )
     db.add(new_recording)
     db.commit()
@@ -222,13 +232,29 @@ def add_photo(
 ### Data access API with Pydantic models
 
 
+class RecordingMetadata(BaseModel):
+    """Per-recording metadata container (#28).
+
+    `extra="allow"` round-trips unknown keys so future elements (e.g. trial type,
+    stopwatch time from #26) survive clients that predate them. The wire key for
+    the walk-test time is "10mwt_time" (not a valid Python identifier, hence the
+    alias); FastAPI serializes response models by alias.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
+    comment: str = ""
+    ten_mwt_time: Optional[float] = Field(default=None, alias="10mwt_time")
+
+
 class RecordingOut(BaseModel):
     filename: str
     recording_timestamp: datetime
-    comment: Optional[str]
+    metadata: RecordingMetadata = Field(default_factory=RecordingMetadata)
     config_file: Optional[str]
     should_process: bool
     timestamp_spread: Optional[float]
+    duration: Optional[float] = None  # seconds; server-computed, None for historical rows
 
 
 class PhotoOut(BaseModel):
@@ -251,6 +277,19 @@ class SessionOut(BaseModel):
 class ParticipantOut(BaseModel):
     name: str
     sessions: List[SessionOut]
+
+
+def _recording_to_out(recording: Recording) -> RecordingOut:
+    """Map an ORM Recording row to RecordingOut.
+
+    Rows written by a pre-#28 binary after the column migration ran may have a
+    NULL container; fall back to wrapping the legacy comment column. The stale
+    top-level "comment" key left in `data` is ignored by pydantic.
+    """
+    data = {k: v for k, v in recording.__dict__.items() if k != "_sa_instance_state"}
+    raw = data.pop("recording_metadata", None)
+    data["metadata"] = raw if raw is not None else {"comment": data.get("comment") or ""}
+    return RecordingOut(**data)
 
 
 def get_recordings(
@@ -276,10 +315,7 @@ def get_recordings(
             if filter_by_session_date and session.session_date != filter_by_session_date:
                 continue
 
-            recording_out_list = [
-                RecordingOut(**{k: v for k, v in recording.__dict__.items() if k != "_sa_instance_state"})
-                for recording in session.recordings
-            ]
+            recording_out_list = [_recording_to_out(recording) for recording in session.recordings]
 
             photo_out_list = [
                 PhotoOut(**{k: v for k, v in photo.__dict__.items() if k != "_sa_instance_state"})
@@ -330,9 +366,15 @@ def modify_recording_entry(db: Session, participant: ParticipantOut, updated_rec
 
     # get the recording entry
     recording = query.first()
+    if recording is None:
+        raise ValueError(
+            f"Recording not found: participant={participant.name}, filename={updated_recording.filename}"
+        )
 
-    # now update the comment and should process fields
-    recording.comment = updated_recording.comment
+    # Replace the metadata container wholesale (clients round-trip unknown keys) and
+    # the should_process flag. duration/timestamp_spread are server-computed — never
+    # written here. Whole-dict reassignment is required for the JSON column to persist.
+    recording.recording_metadata = updated_recording.metadata.model_dump(by_alias=True)
     recording.should_process = updated_recording.should_process
 
     # commit the changes
@@ -616,15 +658,17 @@ def push_to_datajoint(db: Session, participant_id: str, session_date: date, vide
     # Split into trial recordings (push to DataJoint Recording chain) and calibration
     # recordings (push raw videos only; Calibration computation still happens in the
     # notebook via run_calibration_and_insert, which is idempotent on Video rows).
+    # Trial tuples carry the whole metadata container (#28) so DataJoint stores it
+    # whole-hog alongside the plain comment string.
     trial_recordings = [
-        (rec.filename, rec.comment)
+        (rec.filename, rec.metadata.comment, rec.metadata.model_dump(by_alias=True))
         for rec in recordings
-        if rec.should_process and not _is_calibration_comment(rec.comment)
+        if rec.should_process and not _is_calibration_comment(rec.metadata.comment)
     ]
     calibration_recordings = [
-        (rec.filename, rec.comment)
+        (rec.filename, rec.metadata.comment)
         for rec in recordings
-        if rec.should_process and _is_calibration_comment(rec.comment)
+        if rec.should_process and _is_calibration_comment(rec.metadata.comment)
     ]
 
     print("Processing trial recordings: ", trial_recordings)
@@ -685,6 +729,60 @@ def _ensure_session_fin_column(engine):
             """))
 
 
+_TEN_MWT_COMMENT_RE = re.compile(r"\s*10MWT:\s*([\d.]+)\s*s", re.IGNORECASE)
+
+
+def _wrap_legacy_comment(comment: Optional[str]) -> dict:
+    """Build a metadata container from a pre-#28 free-text comment.
+
+    The capture-app's 10MWT timer used to append exactly "10MWT: <n>s" to the
+    comment. Parse-&-strip (user-approved): the last match becomes the structured
+    "10mwt_time" element and all matches are removed from the comment text.
+    """
+    container = {"comment": comment or ""}
+    matches = _TEN_MWT_COMMENT_RE.findall(container["comment"])
+    if matches:
+        try:
+            container["10mwt_time"] = float(matches[-1])  # last match wins
+        except ValueError:
+            return container  # malformed number (e.g. "1.2.3") — leave text untouched
+        stripped = _TEN_MWT_COMMENT_RE.sub("", container["comment"])
+        container["comment"] = " ".join(stripped.split())  # collapse leftover whitespace
+    return container
+
+
+def _ensure_recording_metadata_columns(engine):
+    """Add `recordings.recording_metadata` (JSON) and `recordings.duration` (FLOAT) — #28/#25.
+
+    Same ALTER-on-startup idiom as _ensure_session_fin_column: create_all only
+    creates missing tables, not columns. Idempotent (cheap inspect + early return
+    per column). The one-time backfill wraps each legacy comment into the JSON
+    container via _wrap_legacy_comment; duration stays NULL for historical rows.
+    Backfill runs in Python (json.dumps) so the stored text is exactly what
+    SQLAlchemy's JSON deserializer expects.
+    """
+    from sqlalchemy import inspect, text
+
+    insp = inspect(engine)
+    if "recordings" not in insp.get_table_names():
+        return
+    cols = [c["name"] for c in insp.get_columns("recordings")]
+
+    if "duration" not in cols:
+        with engine.begin() as conn:
+            conn.execute(text("ALTER TABLE recordings ADD COLUMN duration FLOAT"))
+
+    if "recording_metadata" not in cols:
+        with engine.begin() as conn:
+            conn.execute(text("ALTER TABLE recordings ADD COLUMN recording_metadata JSON"))
+            rows = conn.execute(text("SELECT id, comment FROM recordings")).fetchall()
+            for row_id, comment in rows:
+                conn.execute(
+                    text("UPDATE recordings SET recording_metadata = :meta WHERE id = :id"),
+                    {"meta": json.dumps(_wrap_legacy_comment(comment)), "id": row_id},
+                )
+
+
 def get_db():
     from sqlalchemy.orm import Session, sessionmaker
 
@@ -693,6 +791,7 @@ def get_db():
     engine = create_engine(DATABASE_URL)
     Base.metadata.create_all(bind=engine)
     _ensure_session_fin_column(engine)
+    _ensure_recording_metadata_columns(engine)
 
     SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 

--- a/multi_camera/backend/templates/index.html
+++ b/multi_camera/backend/templates/index.html
@@ -224,7 +224,7 @@
                 const filenameCell = row.insertCell(0);
                 const commentCell = row.insertCell(1);
                 filenameCell.innerHTML = recording.filename;
-                commentCell.innerHTML = recording.comment;
+                commentCell.innerHTML = recording.metadata.comment;
             });
         }
 
@@ -264,7 +264,7 @@
                     const commentCell = row.insertCell(2);
                     participantCell.innerHTML = recording.participant;
                     filenameCell.innerHTML = recording.filename;
-                    commentCell.innerHTML = recording.comment;
+                    commentCell.innerHTML = recording.metadata.comment;
                 });
             });
 

--- a/multi_camera/backend/templates/index.html
+++ b/multi_camera/backend/templates/index.html
@@ -224,7 +224,7 @@
                 const filenameCell = row.insertCell(0);
                 const commentCell = row.insertCell(1);
                 filenameCell.innerHTML = recording.filename;
-                commentCell.innerHTML = recording.metadata.comment;
+                commentCell.innerHTML = (recording.metadata || {}).comment || '';
             });
         }
 
@@ -264,7 +264,7 @@
                     const commentCell = row.insertCell(2);
                     participantCell.innerHTML = recording.participant;
                     filenameCell.innerHTML = recording.filename;
-                    commentCell.innerHTML = recording.metadata.comment;
+                    commentCell.innerHTML = (recording.metadata || {}).comment || '';
                 });
             });
 

--- a/multi_camera/datajoint/sessions.py
+++ b/multi_camera/datajoint/sessions.py
@@ -79,6 +79,7 @@ class Recording(dj.Manual):
     -> MultiCameraRecording
     ---
     comment: varchar(255)
+    metadata=null: json   # opaque copy of the SQLite per-recording metadata container (#28); requires MySQL 8.0+
     """
 
 
@@ -100,7 +101,7 @@ def import_session(
     participant_id: str,
     session_date: date,
     video_project: str,
-    recordings: List[Tuple[str, str]],
+    recordings: List[Tuple[str, str, Optional[dict]]],
     fin: Optional[str] = None,
     photo: Optional[PhotoSpec] = None,
 ):
@@ -111,7 +112,9 @@ def import_session(
         participant_id (str): subject id
         session_date (date): session date
         video_project (str): video project
-        recordings (List[Tuple(str, str)]): list of recording tuples
+        recordings (List[Tuple(str, str, Optional[dict])]): list of
+            (video_base_path, comment, metadata_container) tuples; the container
+            is stored whole-hog in Recording.metadata (#28)
         fin (Optional[str]): hospital FIN for this session (pushed to subject_extended.Fin)
         photo (Optional[PhotoSpec]): most recent patient identification photo for this session
 
@@ -148,7 +151,7 @@ def import_session(
 
         for recording in recordings:
             print("processing recording", recording)
-            vid_base, comment = recording
+            vid_base, comment, metadata = recording
 
             vid_dir, vid_base = os.path.split(vid_base)
             print("vid_dir", vid_dir, "vid_base", vid_base)
@@ -158,6 +161,7 @@ def import_session(
             key = (MultiCameraRecording & key).fetch1("KEY")
             key.update(session_key)
             key["comment"] = comment
+            key["metadata"] = metadata
 
             Recording.insert1(key)
 

--- a/tests/acquisition/test_recording_api.py
+++ b/tests/acquisition/test_recording_api.py
@@ -1,0 +1,204 @@
+"""Tests for /api/v1/prior_recordings and /api/v1/update_recording (#28/#25).
+
+Greenfield coverage for the recordings API: metadata container shape on GET,
+whole-container round-trip (including unknown keys) on update, 404 on missing
+recordings, and /calibrate accepting the new body. Uses a tmp-SQLite session via
+app.dependency_overrides — no hardware, no DataJoint.
+"""
+
+from __future__ import annotations
+
+import datetime
+import sys
+import types
+
+import pytest
+
+
+def _install_pyspin_stubs() -> None:
+    for name in ("PySpin", "simple_pyspin"):
+        if name in sys.modules:
+            continue
+        stub = types.ModuleType(name)
+        if name == "simple_pyspin":
+
+            class _Camera:
+                def __init__(self, *args, **kwargs):
+                    raise RuntimeError("PySpin stub")
+
+            stub.Camera = _Camera  # type: ignore[attr-defined]
+            stub._SYSTEM = None  # type: ignore[attr-defined]
+            stub.list_cameras = lambda: []  # type: ignore[attr-defined]
+        sys.modules[name] = stub
+
+
+_install_pyspin_stubs()
+
+
+def _import_backend():
+    import os
+    import unittest.mock as _mock
+
+    real_listdir = os.listdir
+
+    def safe_listdir(path):
+        if str(path).startswith("/configs"):
+            return []
+        return real_listdir(path)
+
+    os.makedirs("data", exist_ok=True)
+    with _mock.patch("os.listdir", side_effect=safe_listdir):
+        from fastapi.testclient import TestClient as _TestClient
+        from multi_camera.backend import fastapi as _backend_fastapi
+    return _TestClient, _backend_fastapi
+
+
+try:
+    TestClient, backend_fastapi = _import_backend()
+except Exception as exc:  # pragma: no cover
+    pytest.skip(f"Backend not importable: {exc}", allow_module_level=True)
+
+
+from sqlalchemy import create_engine  # noqa: E402
+from sqlalchemy.orm import sessionmaker  # noqa: E402
+
+from multi_camera.backend.recording_db import Base, Recording, add_recording  # noqa: E402
+
+SESSION_DATE = datetime.date(2026, 7, 16)
+TIMESTAMP = datetime.datetime(2026, 7, 16, 14, 30, 52)
+FILENAME = "rec/P001_10mwt_20260716_143052"
+
+
+@pytest.fixture
+def db_session(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path}/recordings.db")
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(autocommit=False, autoflush=False, bind=engine)()
+
+    add_recording(
+        session,
+        participant_name="P001",
+        session_date=SESSION_DATE,
+        session_path="rec",
+        filename=FILENAME,
+        recording_timestamp=TIMESTAMP,
+        config_file="config.yaml",
+        comment="Baseline",
+        timestamp_spread=0.003,
+        duration=14.2,
+    )
+    yield session
+    session.close()
+
+
+@pytest.fixture
+def client(db_session, monkeypatch):
+    def override_db():
+        yield db_session
+
+    backend_fastapi.app.dependency_overrides[backend_fastapi.db_dependency] = override_db
+
+    # Same stubbing as test_session_summary: the lifespan constructs a FlirRecorder
+    # at startup and calls .close() at shutdown, which would touch the PySpin stub.
+    class StubRecorder:
+        def __init__(self):
+            self.camera_config = {"camera-info": {}}
+            self.cams = []
+
+        def close(self):
+            return None
+
+        async def get_camera_status(self):
+            return []
+
+    monkeypatch.setattr(backend_fastapi, "FlirRecorder", lambda *a, **kw: StubRecorder())
+    monkeypatch.setattr(backend_fastapi, "synchronize_to_datajoint", lambda *a, **kw: None)
+
+    state = backend_fastapi.get_global_state()
+    previous_session = state.current_session
+    state.current_session = backend_fastapi.Session(
+        participant_name="P001",
+        session_date=SESSION_DATE,
+        recording_path="rec",
+    )
+
+    with TestClient(backend_fastapi.app) as test_client:
+        yield test_client
+
+    state.current_session = previous_session
+    backend_fastapi.app.dependency_overrides.pop(backend_fastapi.db_dependency, None)
+
+
+def test_prior_recordings_returns_metadata_container_and_duration(client):
+    r = client.get("/api/v1/prior_recordings")
+    assert r.status_code == 200
+    (entry,) = r.json()
+
+    assert entry["filename"] == FILENAME
+    assert entry["metadata"]["comment"] == "Baseline"
+    assert entry["metadata"]["10mwt_time"] is None  # wire key is the alias
+    assert entry["duration"] == 14.2
+    assert "comment" not in entry  # flat field is gone from the wire shape
+
+
+def test_update_recording_round_trips_whole_container(client, db_session):
+    payload = {
+        "participant": "P001",
+        "filename": FILENAME,
+        "recording_timestamp": TIMESTAMP.isoformat(),
+        "metadata": {"comment": "Edited", "10mwt_time": 12.34, "custom": "kept"},
+        "config_file": "config.yaml",
+        "should_process": False,
+        "timestamp_spread": 0.003,
+    }
+    r = client.post("/api/v1/update_recording", json=payload)
+    assert r.status_code == 200
+
+    db_session.expire_all()
+    row = db_session.query(Recording).one()
+    assert row.recording_metadata == {
+        "comment": "Edited",
+        "10mwt_time": 12.34,
+        "custom": "kept",
+    }
+    assert row.should_process is False
+    assert row.duration == 14.2  # server-computed; update must not touch it
+
+    r = client.get("/api/v1/prior_recordings")
+    (entry,) = r.json()
+    assert entry["metadata"]["10mwt_time"] == 12.34
+    assert entry["metadata"]["custom"] == "kept"
+
+
+def test_update_recording_unknown_filename_returns_404(client):
+    payload = {
+        "participant": "P001",
+        "filename": "rec/does_not_exist",
+        "recording_timestamp": TIMESTAMP.isoformat(),
+        "metadata": {"comment": "x"},
+        "config_file": "",
+        "should_process": True,
+        "timestamp_spread": 0.0,
+    }
+    r = client.post("/api/v1/update_recording", json=payload)
+    assert r.status_code == 404
+
+
+def test_calibrate_accepts_container_body(client, monkeypatch):
+    calibrate_stub = types.ModuleType("multi_camera.datajoint.calibrate_cameras")
+    calibrate_stub.run_calibration = lambda **kwargs: None
+    monkeypatch.setitem(
+        sys.modules, "multi_camera.datajoint.calibrate_cameras", calibrate_stub
+    )
+
+    payload = {
+        "participant": "P001",
+        "filename": FILENAME,
+        "recording_timestamp": TIMESTAMP.isoformat(),
+        "metadata": {"comment": "charuco"},
+        "config_file": "config.yaml",
+        "should_process": True,
+        "timestamp_spread": 0.003,
+    }
+    r = client.post("/api/v1/calibrate", params={"charuco_flag": True}, json=payload)
+    assert r.status_code == 200

--- a/tests/acquisition/test_recording_duration.py
+++ b/tests/acquisition/test_recording_duration.py
@@ -1,0 +1,92 @@
+"""Tests that write_metadata_queue emits per-file duration (#25).
+
+Feeds synthetic frames through the metadata thread function synchronously and
+checks both records_queue emit sites: the mid-stream file rollover and the
+final flush. No hardware — PySpin is stubbed before import.
+"""
+
+from __future__ import annotations
+
+import datetime
+import sys
+import types
+from queue import Queue
+
+
+def _install_pyspin_stubs() -> None:
+    for name in ("PySpin", "simple_pyspin"):
+        if name in sys.modules:
+            continue
+        stub = types.ModuleType(name)
+        if name == "simple_pyspin":
+
+            class _Camera:
+                def __init__(self, *args, **kwargs):
+                    raise RuntimeError("PySpin stub")
+
+            stub.Camera = _Camera  # type: ignore[attr-defined]
+            stub._SYSTEM = None  # type: ignore[attr-defined]
+            stub.list_cameras = lambda: []  # type: ignore[attr-defined]
+        sys.modules[name] = stub
+
+
+_install_pyspin_stubs()
+
+from multi_camera.acquisition.flir_recording_api import write_metadata_queue  # noqa: E402
+
+SERIALS = ["CAM_A", "CAM_B"]
+BASE_NS = 1_000_000_000_000
+T0 = datetime.datetime(2026, 7, 16, 14, 30, 0)
+
+
+def _frame(base_filename: str, local_time: datetime.datetime, index: int) -> dict:
+    return {
+        "base_filename": base_filename,
+        "real_times": local_time.strftime("%Y-%m-%d %H:%M:%S.%f")[:-3],
+        "local_times": local_time,
+        "timestamps": [BASE_NS + index * 33_000_000] * len(SERIALS),
+        "frame_id": [1000 + index] * len(SERIALS),
+        "camera_serials": list(SERIALS),
+        "exposure_times": [15000] * len(SERIALS),
+        "frame_rates_requested": [30] * len(SERIALS),
+        "frame_rates_binning": [30] * len(SERIALS),
+    }
+
+
+def test_duration_emitted_at_rollover_and_final_flush(tmp_path):
+    file_a = str(tmp_path / "trial_a")
+    file_b = str(tmp_path / "trial_b")
+
+    json_queue: Queue = Queue()
+    records_queue: Queue = Queue()
+
+    # File A: two frames spanning 2.0 s; file B: three frames spanning 5.0 s.
+    # The first file-B frame triggers the rollover emit for file A.
+    json_queue.put(_frame(file_a, T0, 0))
+    json_queue.put(_frame(file_a, T0 + datetime.timedelta(seconds=2), 1))
+    json_queue.put(_frame(file_b, T0 + datetime.timedelta(seconds=10), 2))
+    json_queue.put(_frame(file_b, T0 + datetime.timedelta(seconds=12.5), 3))
+    json_queue.put(_frame(file_b, T0 + datetime.timedelta(seconds=15), 4))
+    json_queue.put(None)
+
+    config_metadata = {
+        "chunk_data": False,
+        "camera_config_hash": "deadbeef",
+        "camera_info": {},
+        "meta_info": {},
+        "system_info": {},
+    }
+
+    write_metadata_queue(json_queue, records_queue, file_a, config_metadata)
+
+    record_a = records_queue.get_nowait()  # rollover emit site
+    record_b = records_queue.get_nowait()  # final-flush emit site
+    assert records_queue.empty()
+
+    assert record_a["filename"] == file_a
+    assert record_a["recording_timestamp"] == T0
+    assert record_a["duration"] == 2.0
+
+    assert record_b["filename"] == file_b
+    assert record_b["recording_timestamp"] == T0 + datetime.timedelta(seconds=10)
+    assert record_b["duration"] == 5.0

--- a/tests/backend/test_recording_db.py
+++ b/tests/backend/test_recording_db.py
@@ -1,0 +1,164 @@
+"""Unit tests for the recordings SQLite layer (#28 metadata container, #25 duration).
+
+Pure sqlalchemy/pydantic — no camera hardware, no PySpin stubs, no DataJoint
+connection (the push test stubs the lazily-imported sessions module).
+"""
+
+from __future__ import annotations
+
+import datetime
+import sys
+import types
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from multi_camera.backend import recording_db
+from multi_camera.backend.recording_db import (
+    Base,
+    Recording,
+    RecordingMetadata,
+    RecordingOut,
+    ParticipantOut,
+    _recording_to_out,
+    add_recording,
+    get_recordings,
+    modify_recording_entry,
+    push_to_datajoint,
+)
+
+SESSION_DATE = datetime.date(2026, 7, 16)
+TIMESTAMP = datetime.datetime(2026, 7, 16, 14, 30, 52)
+
+
+@pytest.fixture
+def db(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path}/recordings.db")
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(autocommit=False, autoflush=False, bind=engine)()
+    yield session
+    session.close()
+
+
+def _seed(db, comment="hello", filename="rec/trial_01", duration=14.2):
+    return add_recording(
+        db,
+        participant_name="P001",
+        session_date=SESSION_DATE,
+        session_path="rec",
+        filename=filename,
+        recording_timestamp=TIMESTAMP,
+        config_file="config.yaml",
+        comment=comment,
+        timestamp_spread=0.003,
+        duration=duration,
+    )
+
+
+def test_add_recording_wraps_comment_and_stores_duration(db):
+    _seed(db)
+
+    row = db.query(Recording).one()
+    assert row.recording_metadata == {"comment": "hello"}
+    assert row.duration == 14.2
+    assert row.comment is None  # legacy column no longer written
+
+
+def test_get_recordings_exposes_metadata_and_duration(db):
+    _seed(db)
+
+    participants = get_recordings(db, participant_name="P001")
+    recording = participants[0].sessions[0].recordings[0]
+    assert recording.metadata.comment == "hello"
+    assert recording.metadata.ten_mwt_time is None
+    assert recording.duration == 14.2
+
+
+def test_recording_to_out_falls_back_to_legacy_comment():
+    # A row written by a pre-#28 binary after the column migration ran: the
+    # container is NULL but the legacy comment column is set.
+    row = Recording(
+        filename="rec/legacy",
+        recording_timestamp=TIMESTAMP,
+        comment="legacy text",
+        recording_metadata=None,
+        config_file=None,
+        should_process=True,
+        timestamp_spread=None,
+        duration=None,
+    )
+    out = _recording_to_out(row)
+    assert out.metadata.comment == "legacy text"
+    assert out.duration is None
+
+
+def test_modify_recording_entry_replaces_container_and_preserves_unknown_keys(db):
+    _seed(db)
+
+    updated = RecordingOut(
+        filename="rec/trial_01",
+        recording_timestamp=TIMESTAMP,
+        metadata=RecordingMetadata(
+            comment="edited", **{"10mwt_time": 12.34, "future_key": 1}
+        ),
+        config_file="config.yaml",
+        should_process=False,
+        timestamp_spread=0.003,
+    )
+    modify_recording_entry(db, ParticipantOut(name="P001", sessions=[]), updated)
+
+    row = db.query(Recording).one()
+    assert row.recording_metadata == {
+        "comment": "edited",
+        "10mwt_time": 12.34,
+        "future_key": 1,
+    }
+    assert row.should_process is False
+    assert row.duration == 14.2  # server-computed field untouched by updates
+
+
+def test_modify_recording_entry_raises_when_recording_missing(db):
+    updated = RecordingOut(
+        filename="rec/nope",
+        recording_timestamp=TIMESTAMP,
+        metadata=RecordingMetadata(comment="x"),
+        config_file="",
+        should_process=True,
+        timestamp_spread=0.0,
+    )
+    with pytest.raises(ValueError, match="Recording not found"):
+        modify_recording_entry(db, ParticipantOut(name="P001", sessions=[]), updated)
+
+
+def test_push_to_datajoint_tuple_shapes(db, tmp_path, monkeypatch):
+    _seed(db, comment="walk trial", filename="rec/trial_01")
+    _seed(db, comment="charuco", filename="rec/calibration_20260716_140000", duration=None)
+
+    captured = {}
+
+    def fake_import_session(participant_id, session_date, video_project, recordings, fin, photo):
+        captured["recordings"] = recordings
+
+    sessions_stub = types.ModuleType("multi_camera.datajoint.sessions")
+    sessions_stub.import_session = fake_import_session
+    sessions_stub.PhotoSpec = types.SimpleNamespace
+    monkeypatch.setitem(sys.modules, "multi_camera.datajoint.sessions", sessions_stub)
+
+    calibration_calls = []
+    monkeypatch.setattr(recording_db, "get_datajoint_external_path", lambda: str(tmp_path))
+    monkeypatch.setattr(recording_db, "check_datajoint_external_mounted", lambda p: None)
+    monkeypatch.setattr(recording_db, "synchronize_to_datajoint", lambda db: None)
+    monkeypatch.setattr(
+        recording_db,
+        "_push_calibration_videos",
+        lambda recs, trial_video_project: calibration_calls.append(recs),
+    )
+
+    push_to_datajoint(db, "P001", SESSION_DATE, video_project="test_project")
+
+    # Trial tuples carry (filename, comment, whole container); calibration stays 2-tuples.
+    assert captured["recordings"] == [
+        ("rec/trial_01", "walk trial", {"comment": "walk trial", "10mwt_time": None})
+    ]
+    assert calibration_calls == [[("rec/calibration_20260716_140000", "charuco")]]

--- a/tests/backend/test_recording_db_migration.py
+++ b/tests/backend/test_recording_db_migration.py
@@ -1,0 +1,108 @@
+"""Tests for the #28/#25 startup migration (_ensure_recording_metadata_columns).
+
+Builds a legacy-schema SQLite DB with raw DDL (no recording_metadata/duration
+columns) and verifies the ALTER + backfill, including the parse-&-strip of
+app-written "10MWT: <n>s" comment text, and idempotency on re-run.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from sqlalchemy import create_engine, inspect, text
+
+from multi_camera.backend.recording_db import (
+    _ensure_recording_metadata_columns,
+    _wrap_legacy_comment,
+)
+
+LEGACY_DDL = """
+CREATE TABLE recordings (
+    id INTEGER NOT NULL PRIMARY KEY,
+    session_id INTEGER,
+    filename VARCHAR,
+    recording_timestamp DATETIME,
+    comment VARCHAR,
+    config_file VARCHAR,
+    should_process BOOLEAN,
+    timestamp_spread INTEGER
+)
+"""
+
+
+@pytest.fixture
+def legacy_engine(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path}/legacy.db")
+    with engine.begin() as conn:
+        conn.execute(text(LEGACY_DDL))
+        for row_id, comment in [
+            (1, "baseline 10MWT: 12.34s"),
+            (2, None),
+            (3, "plain walking note"),
+            (4, "10MWT: 9.87s 10MWT: 12.34s"),
+            (5, "fast walk 10mwt: 5.50s"),  # case-insensitive
+        ]:
+            conn.execute(
+                text("INSERT INTO recordings (id, comment) VALUES (:id, :comment)"),
+                {"id": row_id, "comment": comment},
+            )
+    return engine
+
+
+def _containers(engine):
+    with engine.begin() as conn:
+        rows = conn.execute(
+            text("SELECT id, recording_metadata FROM recordings ORDER BY id")
+        ).fetchall()
+    return {row_id: json.loads(meta) for row_id, meta in rows}
+
+
+def test_migration_adds_columns_and_backfills(legacy_engine):
+    _ensure_recording_metadata_columns(legacy_engine)
+
+    cols = [c["name"] for c in inspect(legacy_engine).get_columns("recordings")]
+    assert "recording_metadata" in cols
+    assert "duration" in cols
+
+    containers = _containers(legacy_engine)
+    assert containers[1] == {"comment": "baseline", "10mwt_time": 12.34}
+    assert containers[2] == {"comment": ""}
+    assert containers[3] == {"comment": "plain walking note"}
+    # Multiple matches: last one wins, all stripped
+    assert containers[4] == {"comment": "", "10mwt_time": 12.34}
+    assert containers[5] == {"comment": "fast walk", "10mwt_time": 5.5}
+
+    with legacy_engine.begin() as conn:
+        durations = conn.execute(text("SELECT DISTINCT duration FROM recordings")).fetchall()
+    assert durations == [(None,)]  # historical rows stay NULL (no backfill)
+
+
+def test_migration_is_idempotent(legacy_engine):
+    _ensure_recording_metadata_columns(legacy_engine)
+    before = _containers(legacy_engine)
+
+    _ensure_recording_metadata_columns(legacy_engine)  # second run: early-returns
+    assert _containers(legacy_engine) == before  # no double-wrap
+
+
+def test_migration_noop_without_recordings_table(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path}/empty.db")
+    _ensure_recording_metadata_columns(engine)  # must not raise
+    assert "recordings" not in inspect(engine).get_table_names()
+
+
+@pytest.mark.parametrize(
+    "comment,expected",
+    [
+        (None, {"comment": ""}),
+        ("", {"comment": ""}),
+        ("note", {"comment": "note"}),
+        ("10MWT: 12.34s", {"comment": "", "10mwt_time": 12.34}),
+        ("a 10MWT: 12.34s b", {"comment": "a b", "10mwt_time": 12.34}),
+        # Malformed number: leave the text untouched rather than guessing
+        ("10MWT: 1.2.3s", {"comment": "10MWT: 1.2.3s"}),
+    ],
+)
+def test_wrap_legacy_comment(comment, expected):
+    assert _wrap_legacy_comment(comment) == expected


### PR DESCRIPTION
## What & why

Implements roadmap **#28** (structured per-recording metadata) and **#25** (per-trial duration), which share the recordings API surface so they ship together.

- **#28:** the free-text `comment` moves into a per-recording JSON metadata container; `10mwt_time` becomes a structured element instead of text jammed into the comment (where the capture-app could overwrite it). The container is the extension point for future per-recording metadata.
- **#25:** each trial's duration is computed at file finalization and exposed in the API so the app can show trial times.

This is a **breaking API change**. The acquisition React frontend is updated in lockstep in this PR; the Flutter capture-app updates on its own branch (`capture-app: feature/25-28-trial-times-metadata`) and mobile devices must be updated together with this deploy.

## Changes

- **`recording_db.py`:** new `recording_metadata` (JSON) + `duration` (Float) columns; `RecordingMetadata` model (`extra="allow"` so unknown keys round-trip; `10mwt_time` aliased). `add_recording`/`get_recordings`/`modify_recording_entry`/`RecordingOut` move to the container. `modify_recording_entry` replaces the whole container + `should_process` only, and now raises `ValueError` (→ 404) instead of `AttributeError` when no row matches. `_ensure_recording_metadata_columns` migrates on startup (idempotent): wraps each legacy comment and parse-&-strips app-written `10MWT: <n>s` text into `10mwt_time`.
- **`fastapi.py`:** `PriorRecordings` carries `metadata` + `duration`; `/prior_recordings` and `/update_recording` use the container; `/update_recording` returns 404 on no match; `task_done_callback` stores the computed duration. `/new_trial` stays flat.
- **`flir_recording_api.py`:** `write_metadata_queue` emits per-file `duration` at both records-queue sites.
- **`sessions.py` (DataJoint):** `Recording` gains a nullable `metadata: json` secondary attribute holding the container whole-hog; the plain `comment` varchar and calibration/aruco/SkippedRecording paths are unchanged.
- **`frontend/acquisition`:** container-aware render/edit, calibration equality-check fix, duration column.
- **`templates/index.html`:** legacy fallback UI reads `recording.metadata.comment`.

## Tests (hardware-free)

`tests/backend/` (recording_db CRUD + container round-trip incl. unknown keys; migration parse-&-strip + idempotency) and `tests/acquisition/` (API round-trip via TestClient; per-file duration emit). Ran green locally under Python 3.14 / pydantic 2.13; full hardware-free acquisition suite unaffected. Also smoke-tested end-to-end against a throwaway SQLite via uvicorn (migration on a legacy DB, GET/POST round-trip incl. unknown-key preservation, 404 path, `recording_db` shape).

## ⚠️ Deploy steps (in order)

1. **MySQL 8.0+ required** for the DataJoint `json` attribute type. Confirm the production DataJoint MySQL version before deploying; if it's older, switch `Recording.metadata` to `varchar` (JSON string) first.
2. Deploy backend + React together (breaking cutover). Update the capture-app tablets in lockstep.
3. **Before the first post-deploy session push**, run once against the live schema to add the new attribute:
   ```
   python -c "from multi_camera.datajoint.sessions import Recording; Recording.alter()"
   ```
   Until this runs, `push_to_datajoint` will fail inserting the `metadata` field. (Rehearsed on the local test DataJoint.)

## Validation — ✅ complete (end-to-end against test DataJoint)

Exercised on a Linux server (`jc-tower01`) with the `mocap-test-dj` + `datajoint-test` containers and inspected in MySQL Workbench:

- Recorded trials from **both** clients — the React acquisition app and the Flutter capture-app (the latter running the in-session 10MWT timer). Trial duration and 10MWT time render as expected in each client's recordings list.
- Pushed the session to the test DataJoint via the React Analyze screen.
- In Workbench, `mocap_sessions.recording` shows the container landing whole-hog as **readable, queryable JSON**:
  - Timer trial: `metadata = {"comment": "", "10mwt_time": 5.329}`, and `JSON_EXTRACT(metadata, '$."10mwt_time"')` returns `5.329`.
  - Non-timer trial: `{"comment": "", "10mwt_time": null}` → extracts `null`.
  - The plain `comment` varchar is populated consistently (unchanged calibration/aruco/downstream behavior); `duration` is correctly absent from DataJoint (SQLite/API-only by design).

This confirms the `json` attribute type (vs `longblob`) gives Workbench-readable, `JSON_EXTRACT`-queryable storage, and that the 10MWT time round-trips from the capture-app timer all the way to DataJoint.

## Follow-on fixes made during validation (in this branch)

Test-rig / environment issues surfaced and fixed while validating; none change the feature contract:

- **`fix(acquisition-frontend): drop optional chaining / nullish coalescing (CRA 2.1)`** — the React frontend builds on `react-scripts@2.1.8`, which can't compile `?.`/`??`; rewrote the #28 container reads with `||`/ternaries/`Object.assign`.
- **`fix(acquisition-frontend): derive API host from window.location`** — the bundle hard-defaulted its API/WS host to `localhost`, so the GUI was blank from any remote browser. Now uses the served host, so `:3000` works from any machine with no build-time base URL (root cause of the "config dropdown empty" symptom).
- **`fix(make): load .env in run-mocap-test[-dj]`** — the test targets bypassed `start_acquisition.sh`'s `.env` export, so the container ran with compose defaults instead of the operator's config; they now source `.env` like `make run` does.
- **`fix(index.html): guard metadata access`** — defensive null-guard on the legacy Jinja page's container read.

## Deploy (unchanged from above)

MySQL 8.0+ for the `json` attribute; deploy backend + React together; run `Recording.alter()` on the live schema before the first post-deploy push. Rehearsed against the test DJ during validation.
