### PR TITLE
aruco: record when a detection row was copied from another calibration

### DIFF
--- a/multi_camera/datajoint/aruco.py
+++ b/multi_camera/datajoint/aruco.py
@@ -36,6 +36,7 @@ class CalibrationArucoDetection(dj.Computed):
     frame_step                 : int         # frames sampled (every Nth)
     marker_position_spread_mm  : longblob    # dict[marker_id -> median absolute deviation (mm) of triangulated positions across frames]
     marker_n_frames_detected   : longblob    # dict[marker_id -> int] frames each marker was triangulatable in (>= min_cameras visible)
+    copied_from_cal_timestamp=NULL  : timestamp    # copied from Calibration.cal_timestamp. 
     """
 
     @property


### PR DESCRIPTION
Calibrations recorded without the ArUco codes on the floor never get a CalibrationArucoDetection row, so their trials can never reach TenMeterWalkTest. The recovery is to copy the pixel detections from another calibration of the same camera setup and re-triangulate them with this calibration's parameters.

copied_from_cal_timestamp records that this happened. NULL means the markers were detected in this calibration's own videos.