### PR TITLE
Feat/cli register calibration videos

### DIFF
--- a/multi_camera/analysis/calibration.py
+++ b/multi_camera/analysis/calibration.py
@@ -114,12 +114,6 @@ def run_calibration_and_insert(
     import datajoint as dj
 
     from multi_camera.datajoint.calibrate_cameras import Calibration
-    from multi_camera.datajoint.multi_camera_dj import (
-        CalibrationVideos,
-        MultiCameraCalibration,
-        calibration_video_project,
-    )
-    from pose_pipeline import Video
 
     entry, board = run_calibration_APL(vid_base, **calibration_kwargs)
 
@@ -135,6 +129,56 @@ def run_calibration_and_insert(
         "cal_timestamp": entry["cal_timestamp"],
         "camera_config_hash": entry["camera_config_hash"],
     }
+
+    with dj.conn().transaction:
+        Calibration.insert1(entry)
+        insert_calibration_videos(
+            cal_key,
+            vid_base,
+            camera_names=entry["camera_names"],
+            trial_video_project=trial_video_project,
+            comment=comment,
+        )
+
+    return cal_key
+
+
+def insert_calibration_videos(
+    cal_key,
+    vid_base,
+    *,
+    camera_names,
+    trial_video_project=None,
+    comment=None,
+):
+    """Register a calibration's videos against an existing ``Calibration`` row.
+
+    Inserts ``Video``, ``MultiCameraCalibration`` and ``CalibrationVideos``. The
+    ``Calibration`` row itself must already exist, or be inserted by the caller
+    inside the same transaction.
+
+    Split out of ``run_calibration_and_insert`` so it can also be used to
+    backfill calibrations that were computed without their videos being
+    registered — those never enter ``CalibrationArucoDetection.key_source``,
+    so their trials can never reach ``TenMeterWalkTest``.
+
+    Args:
+        cal_key: ``{cal_timestamp, camera_config_hash}``.
+        vid_base: full path to the video set, without the ``.{serial}.mp4`` suffix.
+        camera_names: serials the calibration was computed from. The discovered
+            videos must match exactly.
+        trial_video_project: trial-side ``video_project``. Only needed when no
+            ``MultiCameraCalibration`` row exists yet.
+        comment: comment for the ``MultiCameraCalibration`` row when this
+            function inserts it. ArUco detection is gated on this containing
+            ``"aruco"`` — see ``CalibrationArucoDetection.key_source``.
+    """
+    from multi_camera.datajoint.multi_camera_dj import (
+        CalibrationVideos,
+        MultiCameraCalibration,
+        calibration_video_project,
+    )
+    from pose_pipeline import Video
 
     # Resolve calibration video_project from the MultiCameraCalibration row that
     # push_to_datajoint inserted. If absent (legacy / no prior push), derive from
@@ -169,7 +213,7 @@ def run_calibration_and_insert(
                 "video_project": cal_video_project,
                 "filename": filename_no_ext,
                 "video": v,
-                "start_time": entry["cal_timestamp"],
+                "start_time": cal_key["cal_timestamp"],
             }
         )
         cal_video_rows.append(
@@ -181,10 +225,10 @@ def run_calibration_and_insert(
         )
 
     # Consistency check between videos discovered here and what calibration used
-    if set(discovered_serials) != set(entry["camera_names"]):
+    if set(discovered_serials) != set(camera_names):
         raise RuntimeError(
             f"Camera mismatch: videos discovered {sorted(discovered_serials)} but "
-            f"calibration used {sorted(entry['camera_names'])}. "
+            f"calibration used {sorted(camera_names)}. "
             "Refusing to insert inconsistent state."
         )
 
@@ -198,13 +242,9 @@ def run_calibration_and_insert(
         "comment": comment or "",
     }
 
-    with dj.conn().transaction:
-        Calibration.insert1(entry)
-        Video.insert(video_rows, skip_duplicates=True)
-        MultiCameraCalibration.insert1(capture_row, skip_duplicates=True)
-        CalibrationVideos.insert(cal_video_rows, skip_duplicates=True)
-
-    return cal_key
+    Video.insert(video_rows, skip_duplicates=True)
+    MultiCameraCalibration.insert1(capture_row, skip_duplicates=True)
+    CalibrationVideos.insert(cal_video_rows, skip_duplicates=True)
 
 
 def relevel_calibration(

--- a/multi_camera/datajoint/aruco.py
+++ b/multi_camera/datajoint/aruco.py
@@ -8,6 +8,8 @@ any calibration whose recording comment contains the substring ``"aruco"``
 ``MultiCameraCalibration.comment``).
 """
 
+import tempfile
+
 import cv2
 import datajoint as dj
 from pose_pipeline.dj_schema import TimestampedSchema
@@ -58,32 +60,38 @@ class CalibrationArucoDetection(dj.Computed):
         dictionary_id = DEFAULT_DICTIONARY_ID
         dictionary_name = aruco_dictionary_name(dictionary_id)
 
-        # Fetch per-camera video paths via CalibrationVideos → Video
         video_query = (Video & (CalibrationVideos & key)).proj("video", "filename")
-        video_rows = video_query.fetch(as_dict=True)
-        if not video_rows:
+        if not video_query:
             raise FileNotFoundError(
                 f"No CalibrationVideos rows linked to {key} — push calibration videos first."
             )
 
-        video_paths: dict[str, str] = {}
-        for row in video_rows:
-            # Filename is "{recording_base}.{camera_serial}" — last dot-segment is the serial
-            cam_serial = row["filename"].rsplit(".", 1)[-1]
-            video_paths[cam_serial] = row["video"]
-
         cal_entry = (Calibration & key).fetch1()
         cgroup = recreate_cgroup_from_entry(cal_entry)
 
-        print(f"[CalibrationArucoDetection] Detecting ArUco markers for {key}")
-        print(f"  {len(video_paths)} cameras, dictionary={dictionary_name}, frame_step={frame_step}")
+        # fetch() copies attachments to download_path, which defaults to the
+        # current working directory — running this from a notebook leaves half
+        # a gigabyte of .mp4 per calibration wherever the kernel was started.
+        # Detection reads each video once, so stage them somewhere temporary
+        # and let them go afterwards.
+        with tempfile.TemporaryDirectory(prefix="aruco_detect_") as staging:
+            video_rows = video_query.fetch(as_dict=True, download_path=staging)
 
-        pixel_detections = detect_markers_multi_camera(
-            video_paths,
-            expected_ids=None,  # generic: keep every marker the detector finds
-            dictionary_id=dictionary_id,
-            frame_step=frame_step,
-        )
+            video_paths: dict[str, str] = {}
+            for row in video_rows:
+                # Filename is "{recording_base}.{camera_serial}" — last dot-segment is the serial
+                cam_serial = row["filename"].rsplit(".", 1)[-1]
+                video_paths[cam_serial] = row["video"]
+
+            print(f"[CalibrationArucoDetection] Detecting ArUco markers for {key}")
+            print(f"  {len(video_paths)} cameras, dictionary={dictionary_name}, frame_step={frame_step}")
+
+            pixel_detections = detect_markers_multi_camera(
+                video_paths,
+                expected_ids=None,  # generic: keep every marker the detector finds
+                dictionary_id=dictionary_id,
+                frame_step=frame_step,
+            )
 
         # Triangulate every detected marker, recording per-marker spatial spread.
         # Stable markers (physically fixed) have low spread; transient markers

--- a/multi_camera/datajoint/calibrate_cameras.py
+++ b/multi_camera/datajoint/calibrate_cameras.py
@@ -30,10 +30,20 @@ class Calibration(dj.Manual):
 if __name__ == "__main__":
     import argparse
     import os
-    from ..analysis.calibration import run_calibration_APL
+
+    import datajoint as dj
+
+    from ..analysis.calibration import insert_calibration_videos, run_calibration_APL
 
     parser = argparse.ArgumentParser(description="Run camera calibration and releveling pipeline.")
     parser.add_argument('--vid_base', type=str, required=True, help='Base path to calibration video set (without .cam.mp4)')
+    parser.add_argument('--trial_video_project', type=str, default=None,
+                        help='Trial-side video_project for this session, e.g. CLINIC_GAIT. Only '
+                             'needed when the session has not been pushed to DataJoint yet; the '
+                             'calibration videos are filed under "{project}_CALIBRATION".')
+    parser.add_argument('--comment', type=str, default=None,
+                        help='Comment for the MultiCameraCalibration row. ArUco detection only '
+                             'runs on calibrations whose comment contains "aruco".')
     parser.add_argument('--charuco', type=str, default='charuco', help='Use charuco or checkerboard')
     parser.add_argument('--checkerboard_size', type=int, default=109, help='Checkerboard square size in mm')
     parser.add_argument('--checkerboard_dim', type=int, nargs=2, default=[5,7], help='Checkerboard dimensions (rows cols)')
@@ -94,5 +104,16 @@ if __name__ == "__main__":
         print("Cancelling")
     else:
         print("Storing calibration in database...")
-        Calibration.insert1(entry)
+        # Register the videos alongside the calibration. Without them the
+        # calibration never enters CalibrationArucoDetection.key_source, so its
+        # trials can never reach TenMeterWalkTest.
+        with dj.conn().transaction:
+            Calibration.insert1(entry)
+            insert_calibration_videos(
+                {k: entry[k] for k in ("cal_timestamp", "camera_config_hash")},
+                args.vid_base,
+                camera_names=entry["camera_names"],
+                trial_video_project=args.trial_video_project,
+                comment=args.comment,
+            )
         print("Calibration complete.")


### PR DESCRIPTION
Updating the calibration code to also insert videos when the CLI version of the script is used. Previously, it was just when pushed from the GUI that calibration videos would automatically be inserted. 

Also updating the aruco detection code to fetch the videos to a temp location so the working directory does not fill up with calibration videos that are only used for detection.